### PR TITLE
Rename to Encoda

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,5 +1,5 @@
 {
-  "projectName": "convert",
+  "projectName": "encoda",
   "projectOwner": "stencila",
   "repoType": "github",
   "repoHost": "https://github.com",

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 *token.json
 /.sandbox
 /bin
-/convert-deps.tgz
 /encoda-deps.tgz
 /coverage
 /dist

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /.sandbox
 /bin
 /convert-deps.tgz
+/encoda-deps.tgz
 /coverage
 /dist
 /docs/api

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # Build from local source
-#   docker build --tag stencila/convert .
+#   docker build --tag stencila/encoda .
 # Run tests
-#   docker run stencila/convert
+#   docker run stencila/encoda
 # Or to test out interactively at the terminal
-#   docker run -it stencila/convert bash
+#   docker run -it stencila/encoda bash
 
 FROM node
 
-RUN mkdir -p /opt/stecila-convert
-WORKDIR /opt/stecila-convert
+RUN mkdir -p /opt/encoda
+WORKDIR /opt/encoda
 
 # Separate copy and Docker layer for `package.json` to prevent
 # unecessary reinstall of `node_modules` when `src` changes
@@ -20,7 +20,7 @@ COPY . .
 
 # Run as guest user
 RUN useradd --create-home --home-dir /home/guest guest
-RUN chown -R guest /opt/stecila-convert
+RUN chown -R guest /opt/encoda
 USER guest
 
 CMD npm test

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Convert: a format converter for reproducible documents
+# Encoda
 
-[![Build status](https://travis-ci.org/stencila/convert.svg?branch=master)](https://travis-ci.org/stencila/convert)
-[![Build status](https://ci.appveyor.com/api/projects/status/f1hx694pxm0fyqni?svg=true)](https://ci.appveyor.com/project/nokome/convert)
-[![Code coverage](https://codecov.io/gh/stencila/convert/branch/master/graph/badge.svg)](https://codecov.io/gh/stencila/convert)
-[![NPM](https://img.shields.io/npm/v/stencila-convert.svg?style=flat)](https://www.npmjs.com/package/stencila-convert)
+[![Build status](https://travis-ci.org/stencila/encoda.svg?branch=master)](https://travis-ci.org/stencila/encoda)
+[![Build status](https://ci.appveyor.com/api/projects/status/f1hx694pxm0fyqni?svg=true)](https://ci.appveyor.com/project/nokome/encoda)
+[![Code coverage](https://codecov.io/gh/stencila/encoda/branch/master/graph/badge.svg)](https://codecov.io/gh/stencila/encoda)
+[![NPM](https://img.shields.io/npm/v/@stencila/encoda.svg?style=flat)](https://www.npmjs.com/package/@stencila/encoda)
 [![Contributors](https://img.shields.io/badge/contributors-6-orange.svg)](#contribute)
-[![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://stencila.github.io/convert/)
+[![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://stencila.github.io/encoda/)
 [![Chat](https://badges.gitter.im/stencila/stencila.svg)](https://gitter.im/stencila/stencila)
 
-Stencila Converters allow you to convert between a range of formats commonly used for "executable documents" (those containing some type of source code or calculation).
+Encoda allows you to convert between a range of formats commonly used for "executable documents" (those containing some type of source code or calculation).
 
 <!-- Automatically generated TOC. Don't edit, `make docs` instead>
 
@@ -40,8 +40,8 @@ Stencila Converters allow you to convert between a range of formats commonly use
 ## Status
 
 The following tables list the status of converters that have been developed, are in development, or are being considered for development.
-We'll be developing converters based on demand from users. So if you'd like to see a converter for your favorite format, look at the [listed issues](https://github.com/stencila/convert/issues) and comment under the relevant one. If there is no
-issue regarding the converter you need, [create one](https://github.com/stencila/convert/issues/new).
+We'll be developing converters based on demand from users. So if you'd like to see a converter for your favorite format, look at the [listed issues](https://github.com/stencila/encoda/issues) and comment under the relevant one. If there is no
+issue regarding the converter you need, [create one](https://github.com/stencila/encoda/issues/new).
 
 When the converters have been better tested, the plan is to integrate them into [Stencila Desktop](https://github.com/stencila/desktop) as a menu item e.g. `Save as... > Jupyter Notebook`
 
@@ -64,16 +64,16 @@ and [Stencila Gitter channel](https://gitter.im/stencila/stencila).
 | Format                                                                          |                           Status                            |
 | ------------------------------------------------------------------------------- | :---------------------------------------------------------: |
 | CSV                                                                             | ![alpha](https://img.shields.io/badge/status-alpha-red.svg) |
-| Yaml front matter for CSV [CSVY](http://csvy.org/)                              |    [#25](https://github.com/stencila/convert/issues/25)     |
+| Yaml front matter for CSV [CSVY](http://csvy.org/)                              |     [#25](https://github.com/stencila/encoda/issues/25)     |
 | Excel (.xlsx)                                                                   | ![alpha](https://img.shields.io/badge/status-alpha-red.svg) |
 | OpenDocument Spreadsheet                                                        | ![alpha](https://img.shields.io/badge/status-alpha-red.svg) |
 | [Tabular Data Package](https://frictionlessdata.io/specs/tabular-data-package/) | ![alpha](https://img.shields.io/badge/status-alpha-red.svg) |
 
 #### Other formats
 
-| Format                                                                                 |                           Status                            |
-| -------------------------------------------------------------------------------------- | :---------------------------------------------------------: |
-| Reproducible PNG ([rPNG](https://github.com/stencila/convert/blob/master/src/rpng.ts)) | ![alpha](https://img.shields.io/badge/status-alpha-red.svg) |
+| Format                                                                                |                           Status                            |
+| ------------------------------------------------------------------------------------- | :---------------------------------------------------------: |
+| Reproducible PNG ([rPNG](https://github.com/stencila/encoda/blob/master/src/rpng.ts)) | ![alpha](https://img.shields.io/badge/status-alpha-red.svg) |
 
 ## Demo
 
@@ -81,62 +81,62 @@ and [Stencila Gitter channel](https://gitter.im/stencila/stencila).
 
 ## Install
 
-Convert is available as a pre-compiled, standalone command line tool ([CLI](#cli)), or as a Node.js [package](#package).
+Encoda is available as a pre-compiled, standalone command line tool ([CLI](#cli)), or as a Node.js [package](#package).
 
 ### CLI
 
 #### Windows
 
-To install the latest release of the `convert` command line tool, download `convert-win-x64.zip` for the [latest release](https://github.com/stencila/convert/releases/) and place it somewhere on your `PATH`.
+To install the latest release of the `encoda` command line tool, download `encoda-win-x64.zip` for the [latest release](https://github.com/stencila/encoda/releases/) and place it somewhere on your `PATH`.
 
 #### MacOS
 
-To install the latest release of the `convert` command line tool to `/usr/local/bin` just use,
+To install the latest release of the `encoda` command line tool to `/usr/local/bin` just use,
 
 ```bash
-curl -L https://raw.githubusercontent.com/stencila/convert/master/install.sh | bash
+curl -L https://raw.githubusercontent.com/stencila/encoda/master/install.sh | bash
 ```
 
 To install a specific version, append `-s vX.X.X` e.g.
 
 ```bash
-curl -L https://raw.githubusercontent.com/stencila/convert/master/install.sh | bash -s v0.33.0
+curl -L https://raw.githubusercontent.com/stencila/encoda/master/install.sh | bash -s v0.33.0
 ```
 
-Or, if you'd prefer to do things manually, download `convert-macos-x64.tar.gz` for the [latest release](https://github.com/stencila/convert/releases/) and then,
+Or, if you'd prefer to do things manually, download `encoda-macos-x64.tar.gz` for the [latest release](https://github.com/stencila/encoda/releases/) and then,
 
 ```bash
-tar xvf convert-macos-x64.tar.gz
-sudo mv -f stencila-convert /usr/local/bin # or wherever you like
+tar xvf encoda-macos-x64.tar.gz
+sudo mv -f encoda /usr/local/bin # or wherever you like
 ```
 
 #### Linux
 
-To install the latest release of the `convert` command line tool to `~/.local/bin/` just use,
+To install the latest release of the `encoda` command line tool to `~/.local/bin/` just use,
 
 ```bash
-curl -L https://raw.githubusercontent.com/stencila/convert/master/install.sh | bash
+curl -L https://raw.githubusercontent.com/stencila/encoda/master/install.sh | bash
 ```
 
 To install a specific version, append `-s vX.X.X` e.g.
 
 ```bash
-curl -L https://raw.githubusercontent.com/stencila/convert/master/install.sh | bash -s v0.33.0
+curl -L https://raw.githubusercontent.com/stencila/encoda/master/install.sh | bash -s v0.33.0
 ```
 
-Or, if you'd prefer to do things manually, or place Convert elsewhere, download `convert-linux-x64.tar.gz` for the [latest release](https://github.com/stencila/convert/releases/) and then,
+Or, if you'd prefer to do things manually, or place encoda elsewhere, download `encoda-linux-x64.tar.gz` for the [latest release](https://github.com/stencila/encoda/releases/) and then,
 
 ```bash
-tar xvf convert-linux-x64.tar.gz
-mv -f stencila-convert ~/.local/bin/ # or wherever you like
+tar xvf encoda-linux-x64.tar.gz
+mv -f encoda ~/.local/bin/ # or wherever you like
 ```
 
 ### Package
 
-If you want to integrate Convert into another application or package, it is also available as a Node.js package :
+If you want to integrate Encoda into another application or package, it is also available as a Node.js package :
 
 ```bash
-npm install stencila-convert
+npm install @stencila/encoda
 ```
 
 ## Use
@@ -144,7 +144,7 @@ npm install stencila-convert
 ### Example
 
 ```bash
-stencila-convert document.md document.jats.xml
+encoda document.md document.jats.xml
 ```
 
 You can use the `--from` and `--to` flag options to explicitly specify formats. For example,
@@ -159,20 +159,20 @@ You can use the `--from` and `--to` flag options to explicitly specify formats. 
 To get an overview of the commands available use the `--help` option i.e.
 
 ```bash
-stencila-convert --help
+encoda --help
 ```
 
-API documentation is available at https://stencila.github.io/convert.
+API documentation is available at https://stencila.github.io/encoda.
 
 ## Develop
 
-Check how to [contribute back to the project](https://github.com/stencila/convert/blob/master/CONTRIBUTING.md). All PRs are most welcome! Thank you!
+Check how to [contribute back to the project](https://github.com/stencila/encoda/blob/master/CONTRIBUTING.md). All PRs are most welcome! Thank you!
 
 Clone the repository and install a development environment:
 
 ```bash
-git clone https://github.com/stencila/convert.git
-cd convert
+git clone https://github.com/stencila/encoda.git
+cd encoda
 npm install
 ```
 
@@ -216,8 +216,8 @@ make lint cover check
 You can also test using the Docker image for a self-contained, host-independent test environment:
 
 ```bash
-docker build --tag stencila/convert .
-docker run stencila/convert
+docker build --tag stencila/encoda .
+docker run stencila/encoda
 ```
 
 ## Roadmap
@@ -232,7 +232,7 @@ We recognize [all contributors](https://allcontributors.org/) - including those 
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore -->
-<table><tr><td align="center"><a href="http://stenci.la"><img src="https://avatars2.githubusercontent.com/u/2358535?v=4" width="50px;" alt="Aleksandra Pawlik"/><br /><sub><b>Aleksandra Pawlik</b></sub></a><br /><a href="https://github.com/stencila/convert/commits?author=apawlik" title="Code">💻</a> <a href="https://github.com/stencila/convert/commits?author=apawlik" title="Documentation">📖</a> <a href="https://github.com/stencila/convert/issues?q=author%3Aapawlik" title="Bug reports">🐛</a></td><td align="center"><a href="https://github.com/nokome"><img src="https://avatars0.githubusercontent.com/u/1152336?v=4" width="50px;" alt="Nokome Bentley"/><br /><sub><b>Nokome Bentley</b></sub></a><br /><a href="https://github.com/stencila/convert/commits?author=nokome" title="Code">💻</a> <a href="https://github.com/stencila/convert/commits?author=nokome" title="Documentation">📖</a> <a href="https://github.com/stencila/convert/issues?q=author%3Anokome" title="Bug reports">🐛</a></td><td align="center"><a href="http://toki.io"><img src="https://avatars1.githubusercontent.com/u/10161095?v=4" width="50px;" alt="Jacqueline"/><br /><sub><b>Jacqueline</b></sub></a><br /><a href="https://github.com/stencila/convert/commits?author=jwijay" title="Documentation">📖</a> <a href="#design-jwijay" title="Design">🎨</a></td><td align="center"><a href="https://github.com/hamishmack"><img src="https://avatars2.githubusercontent.com/u/620450?v=4" width="50px;" alt="Hamish Mackenzie"/><br /><sub><b>Hamish Mackenzie</b></sub></a><br /><a href="https://github.com/stencila/convert/commits?author=hamishmack" title="Code">💻</a> <a href="https://github.com/stencila/convert/commits?author=hamishmack" title="Documentation">📖</a></td><td align="center"><a href="http://ketch.me"><img src="https://avatars2.githubusercontent.com/u/1646307?v=4" width="50px;" alt="Alex Ketch"/><br /><sub><b>Alex Ketch</b></sub></a><br /><a href="https://github.com/stencila/convert/commits?author=alex-ketch" title="Code">💻</a> <a href="https://github.com/stencila/convert/commits?author=alex-ketch" title="Documentation">📖</a> <a href="#design-alex-ketch" title="Design">🎨</a></td><td align="center"><a href="https://github.com/beneboy"><img src="https://avatars1.githubusercontent.com/u/292725?v=4" width="50px;" alt="Ben Shaw"/><br /><sub><b>Ben Shaw</b></sub></a><br /><a href="https://github.com/stencila/convert/commits?author=beneboy" title="Code">💻</a> <a href="https://github.com/stencila/convert/issues?q=author%3Abeneboy" title="Bug reports">🐛</a></td></tr></table>
+<table><tr><td align="center"><a href="http://stenci.la"><img src="https://avatars2.githubusercontent.com/u/2358535?v=4" width="50px;" alt="Aleksandra Pawlik"/><br /><sub><b>Aleksandra Pawlik</b></sub></a><br /><a href="https://github.com/stencila/encoda/commits?author=apawlik" title="Code">💻</a> <a href="https://github.com/stencila/encoda/commits?author=apawlik" title="Documentation">📖</a> <a href="https://github.com/stencila/encoda/issues?q=author%3Aapawlik" title="Bug reports">🐛</a></td><td align="center"><a href="https://github.com/nokome"><img src="https://avatars0.githubusercontent.com/u/1152336?v=4" width="50px;" alt="Nokome Bentley"/><br /><sub><b>Nokome Bentley</b></sub></a><br /><a href="https://github.com/stencila/encoda/commits?author=nokome" title="Code">💻</a> <a href="https://github.com/stencila/encoda/commits?author=nokome" title="Documentation">📖</a> <a href="https://github.com/stencila/encoda/issues?q=author%3Anokome" title="Bug reports">🐛</a></td><td align="center"><a href="http://toki.io"><img src="https://avatars1.githubusercontent.com/u/10161095?v=4" width="50px;" alt="Jacqueline"/><br /><sub><b>Jacqueline</b></sub></a><br /><a href="https://github.com/stencila/encoda/commits?author=jwijay" title="Documentation">📖</a> <a href="#design-jwijay" title="Design">🎨</a></td><td align="center"><a href="https://github.com/hamishmack"><img src="https://avatars2.githubusercontent.com/u/620450?v=4" width="50px;" alt="Hamish Mackenzie"/><br /><sub><b>Hamish Mackenzie</b></sub></a><br /><a href="https://github.com/stencila/encoda/commits?author=hamishmack" title="Code">💻</a> <a href="https://github.com/stencila/encoda/commits?author=hamishmack" title="Documentation">📖</a></td><td align="center"><a href="http://ketch.me"><img src="https://avatars2.githubusercontent.com/u/1646307?v=4" width="50px;" alt="Alex Ketch"/><br /><sub><b>Alex Ketch</b></sub></a><br /><a href="https://github.com/stencila/encoda/commits?author=alex-ketch" title="Code">💻</a> <a href="https://github.com/stencila/encoda/commits?author=alex-ketch" title="Documentation">📖</a> <a href="#design-alex-ketch" title="Design">🎨</a></td><td align="center"><a href="https://github.com/beneboy"><img src="https://avatars1.githubusercontent.com/u/292725?v=4" width="50px;" alt="Ben Shaw"/><br /><sub><b>Ben Shaw</b></sub></a><br /><a href="https://github.com/stencila/encoda/commits?author=beneboy" title="Code">💻</a> <a href="https://github.com/stencila/encoda/issues?q=author%3Abeneboy" title="Bug reports">🐛</a></td></tr></table>
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
@@ -246,16 +246,16 @@ We recognize [all contributors](https://allcontributors.org/) - including those 
 
 ## Acknowledgments
 
-Convert relies on many awesome opens source tools (see `package.json` for the complete list). We are grateful ❤ to their developers and contributors for all their time and energy. In particular, these tools do a lot of the heavy lifting 💪 under the hood.
+Encoda relies on many awesome opens source tools (see `package.json` for the complete list). We are grateful ❤ to their developers and contributors for all their time and energy. In particular, these tools do a lot of the heavy lifting 💪 under the hood.
 
-|                                                                                                                    |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ![Ajv](https://ajv.js.org/images/ajv_logo.png)                                                                     | [Ajv](https://ajv.js.org/) is "the fastest JSON Schema validator for Node.js and browser". Ajv is not only fast, it also has an impressive breadth of functionality. We use Ajv for the `validate()` and `coerce()` functions to ensure that ingested data is valid against the Stencila [schema](https://github.com/stencila/schema).                                                                                                                                                                                                                                                                         |
-| ![Frictionless Data](https://avatars0.githubusercontent.com/u/5912125?s=200&v=4)                                   | [`datapackage-js`](https://github.com/frictionlessdata/datapackage-js) from the team at [Frictionless Data](https://frictionlessdata.io/) is a Javascript library for working with [Data Packages](https://frictionlessdata.io/specs/data-package/). It does a lot of the work in converting between Tabular Data Packages and Stencila Datatables.                                                                                                                                                                                                                                                            |
-| **Pandoc**                                                                                                         | [Pandoc](https://pandoc.org/) is a "universal document converter". It's able to convert between an impressive number of formats for textual documents. Our [Typescript definitions for Pandoc's AST](https://github.com/stencila/convert/blob/c400d798e6b54ea9f88972b038489df79e38895b/src/pandoc-types.ts) allow us to leverage this functionality from within Node.js while maintaining type safety. Pandoc powers our converters for Word, JATS and Latex. We have contributed to Pandoc, including developing it [JATS reader](https://github.com/jgm/pandoc/blob/master/src/Text/Pandoc/Readers/JATS.hs). |
-| ![Puppeteer](https://user-images.githubusercontent.com/10379601/29446482-04f7036a-841f-11e7-9872-91d1fc2ea683.png) | [Puppeteer](https://pptr.dev/) is a Node library which provides a high-level API to control Chrome. We use it to take screenshots of HTML snippets as part of generating rPNGs and we plan to use it for [generating PDFs](https://github.com/stencila/convert/issues/53).                                                                                                                                                                                                                                                                                                                                     |
-| ![Remark](https://avatars2.githubusercontent.com/u/16309564?s=200&v=4)                                             | [`Remark`](https://remark.js.org/) is an ecosystem of plugins for processing Markdown. It's part of the [unified](https://unifiedjs.github.io/) framework for processing text with syntax trees - a similar approach to Pandoc but in Javascript. We use Remark as our Markdown parser because of it's extensibility.                                                                                                                                                                                                                                                                                          |
-| ![SheetJs](https://sheetjs.com/sketch128.png)                                                                      | [SheetJs](https://sheetjs.com) is a Javascript library for parsing and writing various spreadhseet formats. We use their [community edition](https://github.com/sheetjs/js-xlsx) to power converters for CSV, Excel, and Open Document Spreadsheet formats. They also have a [pro version](https://sheetjs.com/pro) if you need extra support and functionality.                                                                                                                                                                                                                                               |
+|                                                                                                                    |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ![Ajv](https://ajv.js.org/images/ajv_logo.png)                                                                     | [Ajv](https://ajv.js.org/) is "the fastest JSON Schema validator for Node.js and browser". Ajv is not only fast, it also has an impressive breadth of functionality. We use Ajv for the `validate()` and `coerce()` functions to ensure that ingested data is valid against the Stencila [schema](https://github.com/stencila/schema).                                                                                                                                                                                                                                                                        |
+| ![Frictionless Data](https://avatars0.githubusercontent.com/u/5912125?s=200&v=4)                                   | [`datapackage-js`](https://github.com/frictionlessdata/datapackage-js) from the team at [Frictionless Data](https://frictionlessdata.io/) is a Javascript library for working with [Data Packages](https://frictionlessdata.io/specs/data-package/). It does a lot of the work in converting between Tabular Data Packages and Stencila Datatables.                                                                                                                                                                                                                                                           |
+| **Pandoc**                                                                                                         | [Pandoc](https://pandoc.org/) is a "universal document converter". It's able to convert between an impressive number of formats for textual documents. Our [Typescript definitions for Pandoc's AST](https://github.com/stencila/encoda/blob/c400d798e6b54ea9f88972b038489df79e38895b/src/pandoc-types.ts) allow us to leverage this functionality from within Node.js while maintaining type safety. Pandoc powers our converters for Word, JATS and Latex. We have contributed to Pandoc, including developing it [JATS reader](https://github.com/jgm/pandoc/blob/master/src/Text/Pandoc/Readers/JATS.hs). |
+| ![Puppeteer](https://user-images.githubusercontent.com/10379601/29446482-04f7036a-841f-11e7-9872-91d1fc2ea683.png) | [Puppeteer](https://pptr.dev/) is a Node library which provides a high-level API to control Chrome. We use it to take screenshots of HTML snippets as part of generating rPNGs and we plan to use it for [generating PDFs](https://github.com/stencila/encoda/issues/53).                                                                                                                                                                                                                                                                                                                                     |
+| ![Remark](https://avatars2.githubusercontent.com/u/16309564?s=200&v=4)                                             | [`Remark`](https://remark.js.org/) is an ecosystem of plugins for processing Markdown. It's part of the [unified](https://unifiedjs.github.io/) framework for processing text with syntax trees - a similar approach to Pandoc but in Javascript. We use Remark as our Markdown parser because of it's extensibility.                                                                                                                                                                                                                                                                                         |
+| ![SheetJs](https://sheetjs.com/sketch128.png)                                                                      | [SheetJs](https://sheetjs.com) is a Javascript library for parsing and writing various spreadhseet formats. We use their [community edition](https://github.com/sheetjs/js-xlsx) to power converters for CSV, Excel, and Open Document Spreadsheet formats. They also have a [pro version](https://sheetjs.com/pro) if you need extra support and functionality.                                                                                                                                                                                                                                              |
 
 Many thanks ❤ to the [Alfred P. Sloan Foundation](https://sloan.org) and [eLife](https://elifesciences.org) for funding development of this tool.
 

--- a/bundle-win.sh
+++ b/bundle-win.sh
@@ -8,10 +8,10 @@
 osslsigncode sign \
   -pkcs12 "win-cert.p12" \
   -pass "$WIN_CERT_PASSWORD" \
-  -n "Convert" \
+  -n "Encoda" \
   -i "https://stenci.la" \
   -t "http://timestamp.comodoca.com/authenticode" \
-  -in "bin/stencila-convert.exe" \
-  -out "bin/stencila-convert.exe"
+  -in "bin/encoda.exe" \
+  -out "bin/encoda.exe"
 
-zip -j bin/convert-win-x64.zip bin/stencila-convert.exe
+zip -j bin/encoda-win-x64.zip bin/encoda.exe

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ if [[ "$OS" == "Linux" || "$OS" == "Darwin" ]]; then
         'Linux')
             PLATFORM="linux-x64"
             if [ -z "$1" ]; then
-                VERSION=$(curl --silent "https://api.github.com/repos/stencila/convert/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')
+                VERSION=$(curl --silent "https://api.github.com/repos/stencila/encoda/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')
             else
                 VERSION=$1
             fi
@@ -17,7 +17,7 @@ if [[ "$OS" == "Linux" || "$OS" == "Darwin" ]]; then
         'Darwin')
             PLATFORM="macos-x64"
             if [ -z "$1" ]; then
-                VERSION=$(curl --silent "https://api.github.com/repos/stencila/convert/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+                VERSION=$(curl --silent "https://api.github.com/repos/stencila/encoda/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
             else
                 VERSION=$1
             fi
@@ -25,19 +25,19 @@ if [[ "$OS" == "Linux" || "$OS" == "Darwin" ]]; then
             ;;
     esac
     
-    echo "Downloading stencila-convert $VERSION"
-    curl -Lo /tmp/convert.tar.gz https://github.com/stencila/convert/releases/download/$VERSION/convert-$PLATFORM.tar.gz
-    tar xvf /tmp/convert.tar.gz
-    rm -f /tmp/convert.tar.gz
+    echo "Downloading encoda $VERSION"
+    curl -Lo /tmp/encoda.tar.gz https://github.com/stencila/encoda/releases/download/$VERSION/encoda-$PLATFORM.tar.gz
+    tar xvf /tmp/encoda.tar.gz
+    rm -f /tmp/encoda.tar.gz
     
-    echo "Installing stencila-convert to $INSTALL_PATH/stencila-convert-$VERSION"
-    mkdir -p $INSTALL_PATH/stencila-convert-$VERSION
-    mv -f stencila-convert $INSTALL_PATH/stencila-convert-$VERSION
-    # Unpack `node_modules` etc into the $INSTALL_PATH/convert-$VERSION
-    $INSTALL_PATH/stencila-convert-$VERSION/stencila-convert --version
+    echo "Installing encoda to $INSTALL_PATH/encoda-$VERSION"
+    mkdir -p $INSTALL_PATH/encoda-$VERSION
+    mv -f encoda $INSTALL_PATH/encoda-$VERSION
+    # Unpack `node_modules` etc into the $INSTALL_PATH/encoda-$VERSION
+    $INSTALL_PATH/encoda-$VERSION/encoda --version
     
-    echo "Pointing stencila-convert to $INSTALL_PATH/stencila-convert-$VERSION/stencila-convert"
-    ln -sf stencila-convert-$VERSION/stencila-convert $INSTALL_PATH/stencila-convert
+    echo "Pointing encoda to $INSTALL_PATH/encoda-$VERSION/encoda"
+    ln -sf encoda-$VERSION/encoda $INSTALL_PATH/encoda
 else
-    echo "Sorry, I don't know how to install on this OS, please see https://github.com/stencila/convert#install"
+    echo "Sorry, I don't know how to install on this OS, please see https://github.com/stencila/encoda#install"
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "stencila-convert",
+  "name": "@stencila/encoda",
   "version": "0.37.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "stencila-convert",
+  "name": "@stencila/encoda",
   "version": "0.37.0",
-  "description": "Convert between Stencila document trees and other formats",
+  "description": "Codecs for executable document formats",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "convert": "./dist/cli.js"
+    "encoda": "./dist/cli.js"
   },
   "scripts": {
     "install": "node install.js",
@@ -17,10 +17,10 @@
     "check:deps-unused": "dependency-check --unused --no-dev .",
     "build": "npm run build:dist && npm run build:tgz && npm run build:bin",
     "build:dist": "tsc && cp src/*.js dist/",
-    "build:tgz": "tar czf convert-deps.tgz src vendor node_modules/puppeteer/.local-chromium",
-    "build:bin": "pkg --target=host -o=bin/stencila-convert .",
-    "bundle:linux": "tar -czvf bin/convert-linux-x64.tar.gz -C bin stencila-convert",
-    "bundle:osx": "tar -czvf bin/convert-macos-x64.tar.gz -C bin stencila-convert",
+    "build:tgz": "tar czf encoda-deps.tgz src vendor node_modules/puppeteer/.local-chromium",
+    "build:bin": "pkg --target=node10 -o=bin/encoda .",
+    "bundle:linux": "tar -czvf bin/encoda-linux-x64.tar.gz -C bin encoda",
+    "bundle:osx": "tar -czvf bin/encoda-macos-x64.tar.gz -C bin encoda",
     "bundle:windows": "./bundle-win.sh",
     "docs": "markdown-toc -i --maxdepth=4 README.md && typedoc --options typedoc.js ./src",
     "docs:dev": "ts-node --files src/cli devserve docs",
@@ -32,19 +32,19 @@
   "pkg": {
     "scripts": "./dist/**/*.js",
     "assets": [
-      "./convert-deps.tgz",
+      "./encoda-deps.tgz",
       "./dist/**/*.json",
       "./node_modules/@stencila/schema/dist/**/*.json"
     ]
   },
   "license": "Apache-2.0",
-  "homepage": "https://github.com/stencila/convert#readme",
+  "homepage": "https://github.com/stencila/encoda#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stencila/convert.git"
+    "url": "git+https://github.com/stencila/encoda.git"
   },
   "bugs": {
-    "url": "https://github.com/stencila/convert/issues"
+    "url": "https://github.com/stencila/encoda/issues"
   },
   "dependencies": {
     "@stencila/schema": "^0.12.0",

--- a/src/boot.ts
+++ b/src/boot.ts
@@ -1,15 +1,15 @@
 /**
- * Module for installing Convert native modules and executables
+ * Module for installing Encoda native modules and executables
  *
  * The [`pkg`](https://github.com/zeit/pkg) Node.js packager does not
  * package native modules.  i.e `*.node` files. There are various ways to handle this but
  * we found the easiest/safest was to simply copy the directories for the
  * packages with native modules, from the host system, into directory where the
- * binary is installed. This script does that via `convert-deps.tar.gz` which is
+ * binary is installed. This script does that via `encoda-deps.tar.gz` which is
  * packaged in the binary snapshot as an `asset`.
  *
  * See:
- *   - https://github.com/stencila/convert/pull/47#issuecomment-489912132
+ *   - https://github.com/stencila/encoda/pull/47#issuecomment-489912132
  *   - https://github.com/zeit/pkg/issues/329
  *   - https://github.com/JoshuaWise/better-sqlite3/issues/173
  *   - `package.json`
@@ -41,7 +41,7 @@ export const home = packaged
 if (packaged && !fs.existsSync(path.join(home, 'node_modules'))) {
   tar.x({
     sync: true,
-    file: path.join('/', 'snapshot', 'convert', 'convert-deps.tgz'),
+    file: path.join('/', 'snapshot', 'encoda', 'encoda-deps.tgz'),
     C: home
   })
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ import { convert } from './index'
 const VERSION = require('../package').version
 
 yargs
-  .scriptName('stencila-convert')
+  .scriptName('encoda')
 
   // @ts-ignore
   .command(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -80,4 +80,4 @@ yargs
   .alias('version', 'v')
   .describe('version', 'Show version')
 
-  .decode()
+  .parse()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -80,4 +80,4 @@ yargs
   .alias('version', 'v')
   .describe('version', 'Show version')
 
-  .parse()
+  .decode()

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -1,5 +1,5 @@
 /**
- * Compiler for comma separated values (CSV)
+ * Codec for comma separated values (CSV)
  */
 
 import stencila from '@stencila/schema'
@@ -8,10 +8,10 @@ import * as xlsx from './xlsx'
 
 export const mediaTypes = ['text/csv']
 
-export async function parse(file: VFile): Promise<stencila.Node> {
-  return xlsx.parse(file)
+export async function decode(file: VFile): Promise<stencila.Node> {
+  return xlsx.decode(file)
 }
 
-export async function unparse(node: stencila.Node): Promise<VFile> {
-  return xlsx.unparse(node, undefined, 'csv')
+export async function encode(node: stencila.Node): Promise<VFile> {
+  return xlsx.encode(node, undefined, 'csv')
 }

--- a/src/devserve.ts
+++ b/src/devserve.ts
@@ -34,7 +34,7 @@ export function devserve(
 
   const glob = path.join(dir, include)
   chokidar.watch(glob, { ignored: ignore }).on('change', async filePath => {
-    const { dir, name, ext } = path.decode(filePath)
+    const { dir, name, ext } = path.parse(filePath)
     if (ext !== '.html') {
       // TODO: prettier logging of file being processed
       console.error(filePath)

--- a/src/devserve.ts
+++ b/src/devserve.ts
@@ -34,7 +34,7 @@ export function devserve(
 
   const glob = path.join(dir, include)
   chokidar.watch(glob, { ignored: ignore }).on('change', async filePath => {
-    const { dir, name, ext } = path.parse(filePath)
+    const { dir, name, ext } = path.decode(filePath)
     if (ext !== '.html') {
       // TODO: prettier logging of file being processed
       console.error(filePath)

--- a/src/docx.ts
+++ b/src/docx.ts
@@ -1,5 +1,5 @@
 /**
- * Compiler for Microsoft Word
+ * Codec for Microsoft Word
  */
 
 import stencila from '@stencila/schema'
@@ -12,8 +12,8 @@ export const mediaTypes = [
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
 ]
 
-export async function parse(file: VFile): Promise<stencila.Node> {
-  return pandoc.parse(
+export async function decode(file: VFile): Promise<stencila.Node> {
+  return pandoc.decode(
     file,
     pandoc.InputFormat.docx,
     [`--extract-media=${file.path}.media`],
@@ -29,12 +29,12 @@ const defaultDocxTemplatePath = path.join(
   'stencila-template.docx'
 )
 
-export async function unparse(
+export async function encode(
   node: stencila.Node,
   filePath?: string,
   templatePath: string = defaultDocxTemplatePath
 ): Promise<VFile> {
-  return pandoc.unparse(
+  return pandoc.encode(
     node,
     filePath,
     pandoc.OutputFormat.docx,

--- a/src/jats.ts
+++ b/src/jats.ts
@@ -1,7 +1,7 @@
 /**
- * JATS compiler
+ * JATS codec
  *
- * Compiler for [Journal Article Tag Suite (JATS)](https://en.wikipedia.org/wiki/Journal_Article_Tag_Suite).
+ * Codec for [Journal Article Tag Suite (JATS)](https://en.wikipedia.org/wiki/Journal_Article_Tag_Suite).
  */
 
 import stencila from '@stencila/schema'
@@ -29,15 +29,15 @@ export const extNames = ['jats']
 // TODO: add a `sniff` function that check is a XML files
 // and uses regex (for speed) for look for  JATs declaration
 
-export async function parse(file: VFile): Promise<stencila.Node> {
-  return pandoc.parse(file, pandoc.InputFormat.jats)
+export async function decode(file: VFile): Promise<stencila.Node> {
+  return pandoc.decode(file, pandoc.InputFormat.jats)
 }
 
-export async function unparse(
+export async function encode(
   node: stencila.Node,
   filePath?: string
 ): Promise<VFile> {
-  return pandoc.unparse(node, filePath, pandoc.OutputFormat.jats, [
+  return pandoc.encode(node, filePath, pandoc.OutputFormat.jats, [
     `--template=jats-template.xml`
   ])
 }

--- a/src/json.ts
+++ b/src/json.ts
@@ -1,17 +1,17 @@
 /**
- * Compiler for JSON
+ * Codec for JSON
  */
 
-import * as stencila from '@stencila/schema';
-import { coerce } from './util';
-import { dump, load, VFile } from './vfile';
+import * as stencila from '@stencila/schema'
+import { coerce } from './util'
+import { dump, load, VFile } from './vfile'
 
 export const mediaTypes = ['application/json']
 
-export async function parse(file: VFile): Promise<stencila.Node> {
+export async function decode(file: VFile): Promise<stencila.Node> {
   return coerce(JSON.parse(await dump(file)))
 }
 
-export async function unparse(node: stencila.Node): Promise<VFile> {
+export async function encode(node: stencila.Node): Promise<VFile> {
   return load(JSON.stringify(node, null, '  '))
 }

--- a/src/json5.ts
+++ b/src/json5.ts
@@ -1,5 +1,5 @@
 /**
- * # JSON5 compiler
+ * # JSON5 codec
  *
  * [JSON5](https://json5.org/) is "JSON for Humans":
  *
@@ -7,10 +7,10 @@
  * > to alleviate some of the limitations of JSON by expanding its syntax to
  * > include some productions from ECMAScript 5.1.
  *
- * This compiler is primarily targeted at developers.
+ * This codec is primarily targeted at developers.
  * Given that it is more forgiving and it has less typing overhead,
  * JSON5 can be a little more convenient than JSON for quickly testing
- * unparsing of Stencila nodes e.g
+ * encoding of Stencila nodes e.g
  *
  * ```bash
  * stencila convert "{type:'ImageObject', contentUrl: 'https://example.org', text: 'alt', title: 'title'}" --from json5 --to html
@@ -29,13 +29,13 @@
  * See https://github.com/christopherthielen/typedoc-plugin-external-module-name/issues/300
  */
 
-import stencila from '@stencila/schema';
-import json5 from 'json5';
-import { coerce } from './util';
-import { dump, load, VFile } from './vfile';
+import stencila from '@stencila/schema'
+import json5 from 'json5'
+import { coerce } from './util'
+import { dump, load, VFile } from './vfile'
 
 /**
- * The media types that this compiler can parse/unparse.
+ * The media types that this codec can decode/encode.
  */
 export const mediaTypes = ['application/json5']
 
@@ -43,21 +43,21 @@ export const mediaTypes = ['application/json5']
 // so there is no need to specify `extNames`
 
 /**
- * Parse a `VFile` with JSON5 content to a Stencila `Node`.
+ * Decode a `VFile` with JSON5 content to a Stencila `Node`.
  *
- * @param file The `VFile` to parse
+ * @param file The `VFile` to decode
  * @returns A promise that resolves to a Stencila `Node`
  */
-export async function parse(file: VFile): Promise<stencila.Node> {
+export async function decode(file: VFile): Promise<stencila.Node> {
   return coerce(json5.parse(await dump(file)))
 }
 
 /**
- * Unparse a Stencila `Node` to a `VFile` with JSON5 content.
+ * Encode a Stencila `Node` to a `VFile` with JSON5 content.
  *
- * @param thing The Stencila `Node` to unparse
+ * @param thing The Stencila `Node` to encode
  * @returns A promise that resolves to a `VFile`
  */
-export async function unparse(node: stencila.Node): Promise<VFile> {
+export async function encode(node: stencila.Node): Promise<VFile> {
   return load(json5.stringify(node, null, '  '))
 }

--- a/src/latex.ts
+++ b/src/latex.ts
@@ -1,5 +1,5 @@
 /**
- * Compiler for LaTeX
+ * Codec for LaTeX
  */
 
 import stencila from '@stencila/schema'
@@ -10,13 +10,13 @@ export const mediaTypes = ['application/x-latex']
 
 export const extNames = ['latex', 'tex']
 
-export async function parse(file: VFile): Promise<stencila.Node> {
-  return pandoc.parse(file, pandoc.InputFormat.latex)
+export async function decode(file: VFile): Promise<stencila.Node> {
+  return pandoc.decode(file, pandoc.InputFormat.latex)
 }
 
-export async function unparse(
+export async function encode(
   node: stencila.Node,
   filePath?: string
 ): Promise<VFile> {
-  return pandoc.unparse(node, filePath, pandoc.OutputFormat.latex)
+  return pandoc.encode(node, filePath, pandoc.OutputFormat.latex)
 }

--- a/src/md.ts
+++ b/src/md.ts
@@ -1,5 +1,5 @@
 /**
- * # Markdown compiler
+ * # Markdown codec
  *
  * These functions transform nodes from a [Markdown Abstract Syntax Tree](https://github.com/syntax-tree/mdast) to
  * nodes in a [Stencila Document Tree](https://github.com/stencila/schema).
@@ -68,15 +68,15 @@ const GENERIC_EXTENSIONS = [
 ]
 
 /**
- * Parse a `VFile` with Markdown contents to a `stencila.Node`.
+ * Decode a `VFile` with Markdown contents to a `stencila.Node`.
  *
- * @param file The `VFile` to parse
+ * @param file The `VFile` to decode
  * @returns A promise that resolves to a `stencila.Node`
  */
-export async function parse(file: VFile): Promise<stencila.Node> {
+export async function decode(file: VFile): Promise<stencila.Node> {
   const extensionHandlers: { [key: string]: any } = {}
   for (let ext of GENERIC_EXTENSIONS) {
-    extensionHandlers[ext] = { replace: parseExtension }
+    extensionHandlers[ext] = { replace: decodeExtension }
   }
   const mdast = unified()
     .use(parser, {
@@ -87,18 +87,18 @@ export async function parse(file: VFile): Promise<stencila.Node> {
     .use(genericExtensions, { elements: extensionHandlers })
     .parse(file)
   compact(mdast, true)
-  return parseNode(mdast)
+  return decodeNode(mdast)
 }
 
 /**
- * Unparse a `stencila.Node` to a `VFile` with Markdown contents.
+ * Encode a `stencila.Node` to a `VFile` with Markdown contents.
  *
- * @param thing The `stencila.Node` to unparse
+ * @param thing The `stencila.Node` to encode
  * @returns A promise that resolves to a `VFile`
  */
-export async function unparse(node: stencila.Node): Promise<VFile> {
+export async function encode(node: stencila.Node): Promise<VFile> {
   let mdast = filter(
-    unparseNode(node),
+    encodeNode(node),
     (node: UNIST.Node | undefined) => typeof node !== 'undefined'
   ) as UNIST.Node
 
@@ -112,59 +112,59 @@ export async function unparse(node: stencila.Node): Promise<VFile> {
   return load(md)
 }
 
-function parseNode(node: UNIST.Node): stencila.Node {
+function decodeNode(node: UNIST.Node): stencila.Node {
   const type = node.type
   switch (type) {
     case 'root':
-      return parseRoot(node as MDAST.Root)
+      return decodeRoot(node as MDAST.Root)
 
     case 'heading':
-      return parseHeading(node as MDAST.Heading)
+      return decodeHeading(node as MDAST.Heading)
     case 'paragraph':
-      return parseParagraph(node as MDAST.Paragraph)
+      return decodeParagraph(node as MDAST.Paragraph)
     case 'blockquote':
-      return parseBlockquote(node as MDAST.Blockquote)
+      return decodeBlockquote(node as MDAST.Blockquote)
     case 'code':
-      return parseCodeblock(node as MDAST.Code)
+      return decodeCodeblock(node as MDAST.Code)
     case 'list':
-      return parseList(node as MDAST.List)
+      return decodeList(node as MDAST.List)
     case 'table':
-      return parseTable(node as MDAST.Table)
+      return decodeTable(node as MDAST.Table)
     case 'thematicBreak':
-      return parseThematicBreak(node as MDAST.ThematicBreak)
+      return decodeThematicBreak(node as MDAST.ThematicBreak)
 
     case 'link':
-      return parseLink(node as MDAST.Link)
+      return decodeLink(node as MDAST.Link)
     case 'emphasis':
-      return parseEmphasis(node as MDAST.Emphasis)
+      return decodeEmphasis(node as MDAST.Emphasis)
     case 'strong':
-      return parseStrong(node as MDAST.Strong)
+      return decodeStrong(node as MDAST.Strong)
     case 'delete':
-      return parseDelete(node as MDAST.Delete)
+      return decodeDelete(node as MDAST.Delete)
     case 'inlineCode':
-      return parseInlineCode(node as MDAST.InlineCode)
+      return decodeInlineCode(node as MDAST.InlineCode)
     case 'image':
-      return parseImage(node as MDAST.Image)
+      return decodeImage(node as MDAST.Image)
     case 'text':
-      return parseText(node as MDAST.Text)
+      return decodeText(node as MDAST.Text)
     case 'inline-extension':
       const ext = (node as unknown) as Extension
       switch (ext.name) {
         case 'quote':
-          return parseQuote(ext)
+          return decodeQuote(ext)
 
         case 'null':
-          return parseNull(ext)
+          return decodeNull(ext)
         case 'boolean':
         case 'true':
         case 'false':
-          return parseBoolean(ext)
+          return decodeBoolean(ext)
         case 'number':
-          return parseNumber(ext)
+          return decodeNumber(ext)
         case 'array':
-          return parseArray(ext)
+          return decodeArray(ext)
         case 'object':
-          return parseObject(ext)
+          return decodeObject(ext)
 
         default:
           if (ext.name) {
@@ -177,98 +177,98 @@ function parseNode(node: UNIST.Node): stencila.Node {
       }
 
     default:
-      throw new Error(`No Markdown parser for MDAST node type "${type}"`)
+      throw new Error(`No Markdown decoder for MDAST node type "${type}"`)
   }
 }
 
-function unparseNode(node: stencila.Node): UNIST.Node | undefined {
+function encodeNode(node: stencila.Node): UNIST.Node | undefined {
   const type = stencila.type(node)
   switch (type) {
     case 'Article':
-      return unparseArticle(node as stencila.Article)
+      return encodeArticle(node as stencila.Article)
 
     case 'Heading':
-      return unparseHeading(node as stencila.Heading)
+      return encodeHeading(node as stencila.Heading)
     case 'Paragraph':
-      return unparseParagraph(node as stencila.Paragraph)
+      return encodeParagraph(node as stencila.Paragraph)
     case 'QuoteBlock':
-      return unparseQuoteBlock(node as stencila.QuoteBlock)
+      return encodeQuoteBlock(node as stencila.QuoteBlock)
     case 'CodeBlock':
-      return unparseCodeBlock(node as stencila.CodeBlock)
+      return encodeCodeBlock(node as stencila.CodeBlock)
     case 'List':
-      return unparseList(node as stencila.List)
+      return encodeList(node as stencila.List)
     case 'Table':
-      return unparseTable(node as stencila.Table)
+      return encodeTable(node as stencila.Table)
     case 'ThematicBreak':
-      return unparseThematicBreak(node as stencila.ThematicBreak)
+      return encodeThematicBreak(node as stencila.ThematicBreak)
 
     case 'Link':
-      return unparseLink(node as stencila.Link)
+      return encodeLink(node as stencila.Link)
     case 'Emphasis':
-      return unparseEmphasis(node as stencila.Emphasis)
+      return encodeEmphasis(node as stencila.Emphasis)
     case 'Strong':
-      return unparseStrong(node as stencila.Strong)
+      return encodeStrong(node as stencila.Strong)
     case 'Delete':
-      return unparseDelete(node as stencila.Delete)
+      return encodeDelete(node as stencila.Delete)
     case 'Quote':
-      return unparseQuote(node as stencila.Quote)
+      return encodeQuote(node as stencila.Quote)
     case 'Code':
-      return unparseCode(node as stencila.Code)
+      return encodeCode(node as stencila.Code)
     case 'ImageObject':
-      return unparseImageObject(node as stencila.ImageObject)
+      return encodeImageObject(node as stencila.ImageObject)
 
     case 'string':
-      return unparseString(node as string)
+      return encodeString(node as string)
     case 'null':
-      return unparseNull(node as null)
+      return encodeNull(node as null)
     case 'boolean':
-      return unparseBoolean(node as boolean)
+      return encodeBoolean(node as boolean)
     case 'number':
-      return unparseNumber(node as number)
+      return encodeNumber(node as number)
     case 'array':
-      return unparseArray(node as Array<any>)
+      return encodeArray(node as Array<any>)
     case 'object':
-      return unparseObject(node as object)
+      return encodeObject(node as object)
 
     default:
-      throw new Error(`No Markdown unparser for Stencila node type "${type}"`)
+      throw new Error(`No Markdown encoder for Stencila node type "${type}"`)
   }
 }
 
-function unparseContent(node: stencila.Node): MDAST.Content {
-  return unparseNode(node) as MDAST.Content
+function encodeContent(node: stencila.Node): MDAST.Content {
+  return encodeNode(node) as MDAST.Content
 }
 
-function parsePhrasingContent(
+function decodePhrasingContent(
   node: MDAST.PhrasingContent
 ): stencila.InlineContent {
-  return parseNode(node) as stencila.InlineContent
+  return decodeNode(node) as stencila.InlineContent
 }
 
-function unparseInlineContent(
+function encodeInlineContent(
   node: stencila.InlineContent
 ): MDAST.PhrasingContent {
-  return unparseNode(node) as MDAST.PhrasingContent
+  return encodeNode(node) as MDAST.PhrasingContent
 }
 
-function parseBlockContent(node: MDAST.BlockContent): stencila.BlockContent {
-  return parseNode(node) as stencila.BlockContent
+function decodeBlockContent(node: MDAST.BlockContent): stencila.BlockContent {
+  return decodeNode(node) as stencila.BlockContent
 }
 
-function unparseBlockContent(node: stencila.BlockContent): MDAST.BlockContent {
-  return unparseNode(node) as MDAST.BlockContent
+function encodeBlockContent(node: stencila.BlockContent): MDAST.BlockContent {
+  return encodeNode(node) as MDAST.BlockContent
 }
 
 /**
- * Parse a `MDAST.root` node to a `stencila.Article`
+ * Decode a `MDAST.root` node to a `stencila.Article`
  *
  * If the root has a front matter node (defined using YAML), that
  * meta data is added to the top level of the document. Other
  * child nodes are added to the article's `content` property.
  *
- * @param root The MDAST root to parse
+ * @param root The MDAST root to decode
  */
-function parseRoot(root: MDAST.Root): stencila.Article {
+function decodeRoot(root: MDAST.Root): stencila.Article {
   const article = stencila.create(
     'Article',
     {
@@ -293,7 +293,7 @@ function parseRoot(root: MDAST.Root): stencila.Article {
         article[key] = value
       }
     } else {
-      body.push(parseNode(child))
+      body.push(decodeNode(child))
     }
   }
   article.content = body
@@ -304,23 +304,23 @@ function parseRoot(root: MDAST.Root): stencila.Article {
 }
 
 /**
- * Unparse a `stencila.Article` to a `MDAST.Root`
+ * Encode a `stencila.Article` to a `MDAST.Root`
  *
  * The article's `content` property becomes the root's `children`
  * and any other properties are serialized as YAML
  * front matter and prepended to the children.
  *
- * @param node The Stencila article to unparse
+ * @param node The Stencila article to encode
  */
-function unparseArticle(article: stencila.Article): MDAST.Root {
+function encodeArticle(article: stencila.Article): MDAST.Root {
   const root: MDAST.Root = {
     type: 'root',
     children: []
   }
 
-  // Unparse the article body
+  // Encode the article body
   if (article.content) {
-    root.children = article.content.map(unparseContent)
+    root.children = article.content.map(encodeContent)
   }
 
   // Add other properties as frontmatter
@@ -342,44 +342,44 @@ function unparseArticle(article: stencila.Article): MDAST.Root {
 }
 
 /**
- * Parse a `MDAST.Heading` to a `stencila.Heading`
+ * Decode a `MDAST.Heading` to a `stencila.Heading`
  */
-function parseHeading(heading: MDAST.Heading): stencila.Heading {
+function decodeHeading(heading: MDAST.Heading): stencila.Heading {
   return {
     type: 'Heading',
     depth: heading.depth,
-    content: heading.children.map(parsePhrasingContent)
+    content: heading.children.map(decodePhrasingContent)
   }
 }
 
 /**
- * Unparse a `stencila.Heading` to a `MDAST.Heading`
+ * Encode a `stencila.Heading` to a `MDAST.Heading`
  */
-function unparseHeading(heading: stencila.Heading): MDAST.Heading {
+function encodeHeading(heading: stencila.Heading): MDAST.Heading {
   return {
     type: 'heading',
     depth: heading.depth as (1 | 2 | 3 | 4 | 5 | 6),
-    children: heading.content.map(unparseInlineContent)
+    children: heading.content.map(encodeInlineContent)
   }
 }
 
 /**
- * Parse a `MDAST.Paragraph` to a `stencila.Paragraph`
+ * Decode a `MDAST.Paragraph` to a `stencila.Paragraph`
  */
-function parseParagraph(paragraph: MDAST.Paragraph): stencila.Paragraph {
+function decodeParagraph(paragraph: MDAST.Paragraph): stencila.Paragraph {
   return {
     type: 'Paragraph',
-    content: paragraph.children.map(parsePhrasingContent)
+    content: paragraph.children.map(decodePhrasingContent)
   }
 }
 
 /**
- * Unparse a `stencila.Paragraph` to a `MDAST.Paragraph`
+ * Encode a `stencila.Paragraph` to a `MDAST.Paragraph`
  *
  * Returns `undefined` (i.e skip this node) if the paragraph
  * is empty (not content, or only whitespace)
  */
-function unparseParagraph(
+function encodeParagraph(
   paragraph: stencila.Paragraph
 ): MDAST.Paragraph | undefined {
   const content = paragraph.content
@@ -393,47 +393,47 @@ function unparseParagraph(
   } else {
     return {
       type: 'paragraph',
-      children: content.map(unparseInlineContent)
+      children: content.map(encodeInlineContent)
     }
   }
 }
 
 /**
- * Parse a `MDAST.Blockquote` to a `stencila.QuoteBlock`
+ * Decode a `MDAST.Blockquote` to a `stencila.QuoteBlock`
  */
-function parseBlockquote(block: MDAST.Blockquote): stencila.QuoteBlock {
+function decodeBlockquote(block: MDAST.Blockquote): stencila.QuoteBlock {
   return {
     type: 'QuoteBlock',
-    content: block.children.map(parseBlockContent)
+    content: block.children.map(decodeBlockContent)
   }
 }
 
 /**
- * Unparse a `stencila.QuoteBlock` to a `MDAST.Blockquote`
+ * Encode a `stencila.QuoteBlock` to a `MDAST.Blockquote`
  */
-function unparseQuoteBlock(block: stencila.QuoteBlock): MDAST.Blockquote {
+function encodeQuoteBlock(block: stencila.QuoteBlock): MDAST.Blockquote {
   return {
     type: 'blockquote',
-    children: block.content.map(unparseBlockContent)
+    children: block.content.map(encodeBlockContent)
   }
 }
 
 /**
- * Parse a `MDAST.Code` to a `stencila.CodeBlock`
+ * Decode a `MDAST.Code` to a `stencila.CodeBlock`
  *
  * The ["info string"](https://spec.commonmark.org/0.29/#info-string)
- * is parsed to the `meta` dictionary on the `CodeBlock`. For example,
+ * is decoded to the `meta` dictionary on the `CodeBlock`. For example,
  * the code block starting with,
  *
  * ~~~markdown
  * ```python python meta1 meta2=foo meta3="bar baz"
  * ~~~
  *
- * is parsed to a `CodeBlock` with `language` `"python"` and `meta`
+ * is decoded to a `CodeBlock` with `language` `"python"` and `meta`
  * `{meta1:"", meta2:"foo", meta3:"bar baz" }`
  */
-function parseCodeblock(block: MDAST.Code): stencila.CodeBlock {
-  // The `remark-attrs` plugin parses the "info string" to `data.hProperties`
+function decodeCodeblock(block: MDAST.Code): stencila.CodeBlock {
+  // The `remark-attrs` plugin decodes the "info string" to `data.hProperties`
   const meta = block.data && block.data.hProperties
   return {
     type: 'CodeBlock',
@@ -444,9 +444,9 @@ function parseCodeblock(block: MDAST.Code): stencila.CodeBlock {
 }
 
 /**
- * Unparse a `stencila.CodeBlock` to a `MDAST.Code`
+ * Encode a `stencila.CodeBlock` to a `MDAST.Code`
  */
-function unparseCodeBlock(block: stencila.CodeBlock): MDAST.Code {
+function encodeCodeBlock(block: stencila.CodeBlock): MDAST.Code {
   const meta = block.meta ? stringifyMeta(block.meta) : ''
   return {
     type: 'code',
@@ -457,13 +457,13 @@ function unparseCodeBlock(block: stencila.CodeBlock): MDAST.Code {
 }
 
 /**
- * Parse a `MDAST.List` to a `stencila.List`
+ * Decode a `MDAST.List` to a `stencila.List`
  */
-function parseList(list: MDAST.List): stencila.List {
+function decodeList(list: MDAST.List): stencila.List {
   const items = []
   for (let item of list.children) {
     // TODO: when there are more than one child then create a stencila.Block
-    let node = parseNode(item.children[0])
+    let node = decodeNode(item.children[0])
 
     // If the item has a check box then insert that as a boolean as the first
     // child of the first child
@@ -482,16 +482,16 @@ function parseList(list: MDAST.List): stencila.List {
 }
 
 /**
- * Unparse a `stencila.List` to a `MDAST.List`
+ * Encode a `stencila.List` to a `MDAST.List`
  */
-function unparseList(list: stencila.List): MDAST.List {
+function encodeList(list: stencila.List): MDAST.List {
   return {
     type: 'list',
     ordered: list.order === 'ascending',
     children: list.items.map(
       (item: stencila.Node): MDAST.ListItem => {
         // TODO: wrap anything that is not inline content into a block e.g. para
-        const first = unparseNode(item) as MDAST.BlockContent
+        const first = encodeNode(item) as MDAST.BlockContent
         const children = [first]
 
         // Is this a checked item (ie. a paragraph starting with a boolean)?
@@ -519,9 +519,9 @@ function unparseList(list: stencila.List): MDAST.List {
 }
 
 /**
- * Parse a `MDAST.Table` to a `stencila.Table`
+ * Decode a `MDAST.Table` to a `stencila.Table`
  */
-function parseTable(table: MDAST.Table): stencila.Table {
+function decodeTable(table: MDAST.Table): stencila.Table {
   return {
     type: 'Table',
     rows: table.children.map(
@@ -532,7 +532,7 @@ function parseTable(table: MDAST.Table): stencila.Table {
             (cell: MDAST.TableCell): stencila.TableCell => {
               return {
                 type: 'TableCell',
-                content: cell.children.map(parsePhrasingContent)
+                content: cell.children.map(decodePhrasingContent)
               }
             }
           )
@@ -543,9 +543,9 @@ function parseTable(table: MDAST.Table): stencila.Table {
 }
 
 /**
- * Unparse a `stencila.Table` to a `MDAST.Table`
+ * Encode a `stencila.Table` to a `MDAST.Table`
  */
-function unparseTable(table: stencila.Table): MDAST.Table {
+function encodeTable(table: stencila.Table): MDAST.Table {
   return {
     type: 'table',
     children: table.rows.map(
@@ -556,7 +556,7 @@ function unparseTable(table: stencila.Table): MDAST.Table {
             (cell: stencila.TableCell): MDAST.TableCell => {
               return {
                 type: 'tableCell',
-                children: cell.content.map(unparseInlineContent)
+                children: cell.content.map(encodeInlineContent)
               }
             }
           )
@@ -567,9 +567,9 @@ function unparseTable(table: stencila.Table): MDAST.Table {
 }
 
 /**
- * Parse a `MDAST.ThematicBreak` to a `stencila.ThematicBreak`
+ * Decode a `MDAST.ThematicBreak` to a `stencila.ThematicBreak`
  */
-function parseThematicBreak(
+function decodeThematicBreak(
   tbreak: MDAST.ThematicBreak
 ): stencila.ThematicBreak {
   return {
@@ -578,9 +578,9 @@ function parseThematicBreak(
 }
 
 /**
- * Unparse a `stencila.ThematicBreak` to a `MDAST.ThematicBreak`
+ * Encode a `stencila.ThematicBreak` to a `MDAST.ThematicBreak`
  */
-function unparseThematicBreak(
+function encodeThematicBreak(
   tbreak: stencila.ThematicBreak
 ): MDAST.ThematicBreak {
   return {
@@ -589,17 +589,17 @@ function unparseThematicBreak(
 }
 
 /**
- * Parse a `MDAST.Link` to a `stencila.Link`
+ * Decode a `MDAST.Link` to a `stencila.Link`
  */
-function parseLink(link: MDAST.Link): stencila.Link {
-  // The `remark-attrs` plugin parses curly brace attributes to `data.hProperties`
+function decodeLink(link: MDAST.Link): stencila.Link {
+  // The `remark-attrs` plugin decodes curly brace attributes to `data.hProperties`
   const meta = (link.data && link.data.hProperties) as {
     [key: string]: string
   }
   return {
     type: 'Link',
     target: link.url,
-    content: link.children.map(parsePhrasingContent),
+    content: link.children.map(decodePhrasingContent),
     // TODO: remove ts-ignore, when add meta as property to link
     // @ts-ignore
     meta
@@ -607,9 +607,9 @@ function parseLink(link: MDAST.Link): stencila.Link {
 }
 
 /**
- * Unparse a `stencila.Link` to a `MDAST.Link`
+ * Encode a `stencila.Link` to a `MDAST.Link`
  */
-function unparseLink(link: stencila.Link): MDAST.Link {
+function encodeLink(link: stencila.Link): MDAST.Link {
   // TODO: remove ts-ignore, when add meta as property to link
   // @ts-ignore
   const data = { hProperties: link.meta }
@@ -617,84 +617,84 @@ function unparseLink(link: stencila.Link): MDAST.Link {
     type: 'link',
     url: link.target,
     children: link.content.map(
-      node => unparseInlineContent(node) as MDAST.StaticPhrasingContent
+      node => encodeInlineContent(node) as MDAST.StaticPhrasingContent
     ),
     data
   }
 }
 
 /**
- * Parse a `MDAST.Emphasis` to a `stencila.Emphasis`
+ * Decode a `MDAST.Emphasis` to a `stencila.Emphasis`
  */
-function parseEmphasis(emphasis: MDAST.Emphasis): stencila.Emphasis {
+function decodeEmphasis(emphasis: MDAST.Emphasis): stencila.Emphasis {
   return {
     type: 'Emphasis',
-    content: emphasis.children.map(parsePhrasingContent)
+    content: emphasis.children.map(decodePhrasingContent)
   }
 }
 
 /**
- * Unparse a `stencila.Emphasis` to a `MDAST.Emphasis`
+ * Encode a `stencila.Emphasis` to a `MDAST.Emphasis`
  */
-function unparseEmphasis(emphasis: stencila.Emphasis): MDAST.Emphasis {
+function encodeEmphasis(emphasis: stencila.Emphasis): MDAST.Emphasis {
   return {
     type: 'emphasis',
-    children: emphasis.content.map(unparseInlineContent)
+    children: emphasis.content.map(encodeInlineContent)
   }
 }
 
 /**
- * Parse a `MDAST.Strong` to a `stencila.Strong`
+ * Decode a `MDAST.Strong` to a `stencila.Strong`
  */
-function parseStrong(strong: MDAST.Strong): stencila.Strong {
+function decodeStrong(strong: MDAST.Strong): stencila.Strong {
   return {
     type: 'Strong',
-    content: strong.children.map(parsePhrasingContent)
+    content: strong.children.map(decodePhrasingContent)
   }
 }
 
 /**
- * Unparse a `stencila.Strong` to a `MDAST.Strong`
+ * Encode a `stencila.Strong` to a `MDAST.Strong`
  */
-function unparseStrong(strong: stencila.Strong): MDAST.Strong {
+function encodeStrong(strong: stencila.Strong): MDAST.Strong {
   return {
     type: 'strong',
-    children: strong.content.map(unparseInlineContent)
+    children: strong.content.map(encodeInlineContent)
   }
 }
 
 /**
- * Parse a `MDAST.Delete` to a `stencila.Delete`
+ * Decode a `MDAST.Delete` to a `stencila.Delete`
  */
-function parseDelete(delet: MDAST.Delete): stencila.Delete {
+function decodeDelete(delet: MDAST.Delete): stencila.Delete {
   return {
     type: 'Delete',
-    content: delet.children.map(parsePhrasingContent)
+    content: delet.children.map(decodePhrasingContent)
   }
 }
 
 /**
- * Unparse a `stencila.Delete` to a `MDAST.Delete`
+ * Encode a `stencila.Delete` to a `MDAST.Delete`
  */
-function unparseDelete(delet: stencila.Delete): MDAST.Delete {
+function encodeDelete(delet: stencila.Delete): MDAST.Delete {
   return {
     type: 'delete',
-    children: delet.content.map(unparseInlineContent)
+    children: delet.content.map(encodeInlineContent)
   }
 }
 
 /**
- * Parse a `!quote` inline extension to a `Quote`.
+ * Decode a `!quote` inline extension to a `Quote`.
  *
  * Valid quotes include:
  *
  *   - `!quote[Quoted content]`
  *   - `!quote[Quoted content with _emphasis_](https://example.org)`
  */
-function parseQuote(ext: Extension): stencila.Quote {
+function decodeQuote(ext: Extension): stencila.Quote {
   const quote: stencila.Quote = {
     type: 'Quote',
-    // TODO: possibly parse the ext.content as Markdown?
+    // TODO: possibly decode the ext.content as Markdown?
     content: ext.content ? [ext.content] : []
   }
   const cite = ext.argument
@@ -703,9 +703,9 @@ function parseQuote(ext: Extension): stencila.Quote {
 }
 
 /**
- * Unparse a `stencila.Quote` to a `!quote` inline extension
+ * Encode a `stencila.Quote` to a `!quote` inline extension
  */
-function unparseQuote(quote: stencila.Quote): Extension {
+function encodeQuote(quote: stencila.Quote): Extension {
   return {
     type: 'inline-extension',
     name: 'quote',
@@ -716,9 +716,9 @@ function unparseQuote(quote: stencila.Quote): Extension {
 }
 
 /**
- * Parse a `MDAST.InlineCode` to a `stencila.Code`
+ * Decode a `MDAST.InlineCode` to a `stencila.Code`
  */
-function parseInlineCode(inlineCode: MDAST.InlineCode): stencila.Code {
+function decodeInlineCode(inlineCode: MDAST.InlineCode): stencila.Code {
   const code: stencila.Code = {
     type: 'Code',
     value: inlineCode.value
@@ -737,9 +737,9 @@ function parseInlineCode(inlineCode: MDAST.InlineCode): stencila.Code {
 }
 
 /**
- * Unparse a `stencila.Code` to a `MDAST.InlineCode`
+ * Encode a `stencila.Code` to a `MDAST.InlineCode`
  */
-function unparseCode(code: stencila.Code): MDAST.InlineCode {
+function encodeCode(code: stencila.Code): MDAST.InlineCode {
   let attrs
   if (code.language) attrs = { language: code.language }
   // TODO: remove ts-ignore
@@ -753,16 +753,16 @@ function unparseCode(code: stencila.Code): MDAST.InlineCode {
 }
 
 /**
- * Parse a `MDAST.Image` to a `stencila.ImageObject`
+ * Decode a `MDAST.Image` to a `stencila.ImageObject`
  */
-function parseImage(image: MDAST.Image): stencila.ImageObject {
+function decodeImage(image: MDAST.Image): stencila.ImageObject {
   const imageObject: stencila.ImageObject = {
     type: 'ImageObject',
     contentUrl: image.url
   }
   if (image.title) imageObject.title = image.title
   if (image.alt) imageObject.text = image.alt
-  // The `remark-attrs` plugin parses curly brace attributes to `data.hProperties`
+  // The `remark-attrs` plugin decodes curly brace attributes to `data.hProperties`
   const meta = image.data && image.data.hProperties
   // TODO: remove ts-ignore
   // @ts-ignore
@@ -771,9 +771,9 @@ function parseImage(image: MDAST.Image): stencila.ImageObject {
 }
 
 /**
- * Unparse a `stencila.ImageObject` to a `MDAST.Image`
+ * Encode a `stencila.ImageObject` to a `MDAST.Image`
  */
-function unparseImageObject(imageObject: stencila.ImageObject): MDAST.Image {
+function encodeImageObject(imageObject: stencila.ImageObject): MDAST.Image {
   const image: MDAST.Image = {
     type: 'image',
     url: imageObject.contentUrl || ''
@@ -787,35 +787,35 @@ function unparseImageObject(imageObject: stencila.ImageObject): MDAST.Image {
 }
 
 /**
- * Parse a `MDAST.Text` to a `string`
+ * Decode a `MDAST.Text` to a `string`
  */
-function parseText(text: MDAST.Text): string {
+function decodeText(text: MDAST.Text): string {
   return text.value
 }
 
 /**
- * Unparse a `string` to a `MDAST.Text`
+ * Encode a `string` to a `MDAST.Text`
  */
-function unparseString(value: string): MDAST.Text {
+function encodeString(value: string): MDAST.Text {
   return { type: 'text', value }
 }
 
 /**
- * Parse a `!null` inline extension to `null`
+ * Decode a `!null` inline extension to `null`
  */
-function parseNull(ext: Extension): null {
+function decodeNull(ext: Extension): null {
   return null
 }
 
 /**
- * Unparse `null` to a `!null` inline extension
+ * Encode `null` to a `!null` inline extension
  */
-function unparseNull(value: null): Extension {
+function encodeNull(value: null): Extension {
   return { type: 'inline-extension', name: 'null' }
 }
 
 /**
- * Parse a `!true`, `!false`, `!boolean` inline extension to a `boolean`
+ * Decode a `!true`, `!false`, `!boolean` inline extension to a `boolean`
  *
  * Valid booleans include (the first two are the preferred and the default,
  * the last should be avoided):
@@ -823,10 +823,10 @@ function unparseNull(value: null): Extension {
  *   - `!true` or `!false`
  *   - `!boolean(true)` and `!boolean(1)`
  *   - `!boolean(false)` and `!boolean(0)`
- *   - `!boolean` (parsed to `true`)
+ *   - `!boolean` (decoded to `true`)
  *   - `!boolean[true]` and `!boolean[1]` etc
  */
-function parseBoolean(ext: Extension): boolean {
+function decodeBoolean(ext: Extension): boolean {
   switch (ext.name) {
     case 'true':
       return true
@@ -839,30 +839,30 @@ function parseBoolean(ext: Extension): boolean {
 }
 
 /**
- * Unparse a `boolean` to a `!true` or `!false`.
+ * Encode a `boolean` to a `!true` or `!false`.
  */
-function unparseBoolean(value: boolean): Extension {
+function encodeBoolean(value: boolean): Extension {
   return { type: 'inline-extension', name: value ? 'true' : 'false' }
 }
 
 /**
- * Parse a `!number` inline extension to a `number`.
+ * Decode a `!number` inline extension to a `number`.
  *
  * Valid numbers include (the first is the preferred and the default,
  * the last should be avoided):
  *
  *   - `!number(3.14)`
- *   - `!number` (parsed to `0`)
+ *   - `!number` (decoded to `0`)
  *   - `!number[3.14]`
  */
-function parseNumber(ext: Extension): number {
+function decodeNumber(ext: Extension): number {
   return parseFloat(ext.argument || ext.content || '0')
 }
 
 /**
- * Unparse a `number` to a `!number` inline extension
+ * Encode a `number` to a `!number` inline extension
  */
-function unparseNumber(value: number): Extension {
+function encodeNumber(value: number): Extension {
   return {
     type: 'inline-extension',
     name: 'number',
@@ -871,41 +871,41 @@ function unparseNumber(value: number): Extension {
 }
 
 /**
- * Parse an `!array` inline extension to an `Array`.
+ * Decode an `!array` inline extension to an `Array`.
  *
  * Valid arrays include (the first is the preferred and the default,
  * the last should be avoided):
  *
  *   - `!array(1, 2)`
- *   - `!array` (parsed to `[]`)
+ *   - `!array` (decoded to `[]`)
  *   - `!array[1, 2]`
  */
-function parseArray(ext: Extension): Array<any> {
+function decodeArray(ext: Extension): Array<any> {
   const items = ext.argument || ext.content || ''
   const array = JSON5.parse(`[${items}]`)
   return array
 }
 
 /**
- * Unparse an `array` to a `!array` inline extension
+ * Encode an `array` to a `!array` inline extension
  */
-function unparseArray(value: Array<any>): Extension {
+function encodeArray(value: Array<any>): Extension {
   const argument = JSON5.stringify(value).slice(1, -1)
   return { type: 'inline-extension', name: 'array', argument }
 }
 
 /**
- * Parse an `!object` inline extension to an `Object`.
+ * Decode an `!object` inline extension to an `Object`.
  *
  * Valid objects include (the first is the preferred and the default,
  * the last should be avoided):
  *
  *   - `!object("key":value, ...)` (comma separated pairs, values can be any JSON primitives)
  *   - `!object{key=string ...}` (space separated pairs; values can only be strings)
- *   - `!object` (parsed to `{}`)
+ *   - `!object` (decoded to `{}`)
  *   - `!object["key":"value", ...]`
  */
-function parseObject(ext: Extension): object {
+function decodeObject(ext: Extension): object {
   if (ext.properties) {
     // Extension properties always contain `className` and `id`, which may
     // be undefined, so drop them.
@@ -920,15 +920,15 @@ function parseObject(ext: Extension): object {
 }
 
 /**
- * Unparse an `object` to a `!object` inline extension
+ * Encode an `object` to a `!object` inline extension
  */
-function unparseObject(value: object): Extension {
+function encodeObject(value: object): Extension {
   const argument = JSON5.stringify(value).slice(1, -1)
   return { type: 'inline-extension', name: 'object', argument }
 }
 
 /**
- * Interface for generic extension nodes parsed by
+ * Interface for generic extension nodes decoded by
  * [`remark-generic-extensions`](https://github.com/medfreeman/remark-generic-extensions)
  *
  * Inline extensions have the syntax:
@@ -959,7 +959,7 @@ interface Extension extends UNIST.Node {
   name: string
 
   /**
-   * Content (for inline extensions this is always text [but could be parsed as Markdown])
+   * Content (for inline extensions this is always text [but could be decoded as Markdown])
    */
   content?: string
 
@@ -975,9 +975,9 @@ interface Extension extends UNIST.Node {
 }
 
 /**
- * Parse a generic extension into an MDAST node.
+ * Decode a generic extension into an MDAST node.
  */
-function parseExtension(
+function decodeExtension(
   type: 'inline-extension' | 'block-extension',
   element: Extension
 ) {
@@ -989,12 +989,12 @@ function parseExtension(
 // to HAST i.e. HTML and not serialization back to Markdown).
 // They transform nodes to a `MDAST.HTML` node
 // so that no escaping of the value is done.
-// There is a more 'official' way to do this using a `unified.Compiler`
-// but the docs for that are not as good as for `Parser` and after
+// There is a more 'official' way to do this using a `unified.Codec`
+// but the docs for that are not as good as for `Decoder` and after
 // several attempts, this seemed like a more expedient, short term approach.
 
 /**
- * Unparse a generic extension node into a `MDAST.HTML` node.
+ * Encode a generic extension node into a `MDAST.HTML` node.
  *
  * The `remark-generic-extensions` plugin does not do this stringifying for us.
  */
@@ -1023,15 +1023,15 @@ function stringifyExtensions(tree: UNIST.Node) {
 }
 
 /**
- * Unparse a `link` node with `data.hProperties` into a `MDAST.HTML` node
+ * Encode a `link` node with `data.hProperties` into a `MDAST.HTML` node
  * with attributes in curly braces `{}`.
  *
  * The `remark-attr` plugin does not do this stringifying for us
  * (it only works with `rehype`).
  */
 function stringifyAttrs(tree: UNIST.Node) {
-  const compiler = unified().use(stringifier)
-  const md = (node: UNIST.Node) => compiler.stringify(node)
+  const codec = unified().use(stringifier)
+  const md = (node: UNIST.Node) => codec.stringify(node)
   return map(tree, (node: UNIST.Node) => {
     if (
       ['link', 'inlineCode'].includes(node.type) &&

--- a/src/ods.ts
+++ b/src/ods.ts
@@ -1,5 +1,5 @@
 /**
- * Compiler for Open Document Spreadsheet (ODS)
+ * Codec for Open Document Spreadsheet (ODS)
  */
 
 import stencila from '@stencila/schema'
@@ -12,10 +12,10 @@ export const mediaTypes = [
   // spell-checker: enable
 ]
 
-export async function parse(file: VFile): Promise<stencila.Node> {
-  return xlsx.parse(file)
+export async function decode(file: VFile): Promise<stencila.Node> {
+  return xlsx.decode(file)
 }
 
-export async function unparse(node: stencila.Node): Promise<VFile> {
-  return xlsx.unparse(node, undefined, 'ods')
+export async function encode(node: stencila.Node): Promise<VFile> {
+  return xlsx.encode(node, undefined, 'ods')
 }

--- a/src/odt.ts
+++ b/src/odt.ts
@@ -1,5 +1,5 @@
 /**
- * Compiler for Open Document Text (ODT)
+ * Codec for Open Document Text (ODT)
  */
 
 import stencila from '@stencila/schema'
@@ -8,15 +8,15 @@ import { VFile } from './vfile'
 
 export const mediaTypes = ['application/vnd.oasis.opendocument.text']
 
-export async function parse(file: VFile): Promise<stencila.Node> {
-  return pandoc.parse(file, pandoc.InputFormat.odt, [
+export async function decode(file: VFile): Promise<stencila.Node> {
+  return pandoc.decode(file, pandoc.InputFormat.odt, [
     `--extract-media=${file.path}.media`
   ])
 }
 
-export async function unparse(
+export async function encode(
   node: stencila.Node,
   filePath?: string
 ): Promise<VFile> {
-  return pandoc.unparse(node, filePath, pandoc.OutputFormat.odt, [], true)
+  return pandoc.encode(node, filePath, pandoc.OutputFormat.odt, [], true)
 }

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -1,5 +1,5 @@
 /**
- * # PDF unparser
+ * # PDF encoder
  *
  * @module pdf
  */
@@ -14,7 +14,7 @@ import * as puppeteer from './puppeteer'
 import { load, VFile } from './vfile'
 
 /**
- * The media types that this compiler can parse/unparse.
+ * The media types that this codec can decode/encode.
  */
 export const mediaTypes = ['application/pdf']
 
@@ -25,7 +25,7 @@ export const mediaTypes = ['application/pdf']
  * This function is required (currently) but is (and probably never will be)
  * implemented.
  */
-export async function parse(file: VFile): Promise<stencila.Node> {
+export async function decode(file: VFile): Promise<stencila.Node> {
   throw new Error(`Parsing of PDF files is not supported.`)
 }
 
@@ -33,13 +33,13 @@ export async function parse(file: VFile): Promise<stencila.Node> {
 export const browser = puppeteer.page()
 
 /**
- * Unparse a Stencila `Node` to a `VFile` with PDF content.
+ * Encode a Stencila `Node` to a `VFile` with PDF content.
  *
- * @param node The Stencila `Node` to unparse
+ * @param node The Stencila `Node` to encode
  * @param filePath The file system path to write the PDF to
  * @returns A promise that resolves to a `VFile`
  */
-export async function unparse(
+export async function encode(
   node: stencila.Node,
   filePath?: string
 ): Promise<VFile> {

--- a/src/person.ts
+++ b/src/person.ts
@@ -5,11 +5,11 @@ import parseAuthor from 'parse-author'
 import { parseFullName } from 'parse-full-name'
 
 /**
- * Parse string data into a `Person`.
+ * Decode string data into a `Person`.
  *
- * @param data Data to parse
+ * @param data Data to decode
  */
-export function parse(data: string): Person {
+export function decode(data: string): Person {
   const { name, email, url } = parseAuthor(data)
   const { title, first, middle, last, suffix } = parseFullName(name)
   const person: Person = { type: 'Person' }
@@ -19,7 +19,7 @@ export function parse(data: string): Person {
     if (middle) person.givenNames.push(middle)
   }
   if (last) person.familyNames = [last]
-  else throw new Error(`Unable to parse string "${data}" as a person`)
+  else throw new Error(`Unable to decode string "${data}" as a person`)
   if (suffix) person.honorificSuffix = suffix
   if (email) person.emails = [email]
   if (url) person.url = url

--- a/src/process.ts
+++ b/src/process.ts
@@ -1,8 +1,8 @@
 import * as stencila from '@stencila/schema'
 import assert from 'assert'
 import path from 'path'
-import { dump, load, read, write } from '../src'
-import { type, validate } from '../src/util'
+import { dump, load, read, write } from '.'
+import { type, validate } from './util'
 
 /**
  * Process a document

--- a/src/rpng.ts
+++ b/src/rpng.ts
@@ -1,7 +1,7 @@
 /**
- * A compiler for Reproducible PNGs (rPNG) files.
+ * A codec for Reproducible PNGs (rPNG) files.
  *
- * This compiler parses from, and unparses to, a rPNG which embeds the Stencila node
+ * This codec decodes from, and encodes to, a rPNG which embeds the Stencila node
  * into the `tEXt` chunk of the PNG.
  *
  * This has been implemented here to make use of the HTML converter to
@@ -132,26 +132,26 @@ export function sniffSync(content: string): boolean {
 }
 
 /**
- * Parse a rPNG to a Stencila node.
+ * Decode a rPNG to a Stencila node.
  *
  * This is done by extracting the JSON
  * from the `tEXt` chunk and parsing it.
  *
- * @param file The `VFile` to parse
+ * @param file The `VFile` to decode
  * @returns The Stencila node
  */
-export async function parse(file: VFile): Promise<stencila.Node> {
-  return parseSync(file)
+export async function decode(file: VFile): Promise<stencila.Node> {
+  return decodeSync(file)
 }
 
 /**
- * Synchronous version of `parse()`.
+ * Synchronous version of `decode()`.
  *
- * @see parse
+ * @see decode
  *
  * @param content The content to sniff (a file path).
  */
-export function parseSync(file: VFile): stencila.Node {
+export function decodeSync(file: VFile): stencila.Node {
   if (Buffer.isBuffer(file.contents)) {
     const json = extract(KEYWORD, file.contents)
     return JSON.parse(json)
@@ -160,14 +160,14 @@ export function parseSync(file: VFile): stencila.Node {
 }
 
 /**
- * Sniff and parse a file if it is a rPNG.
+ * Sniff and decode a file if it is a rPNG.
  *
- * This function is like combining `sniffSync()` and `parseSync()`
+ * This function is like combining `sniffSync()` and `decodeSync()`
  * but is faster because it only reads the file contents once.
  *
  * @param filePath The file path to sniff.
  */
-export function sniffParseSync(filePath: string): stencila.Node | undefined {
+export function sniffDecodeSync(filePath: string): stencila.Node | undefined {
   if (path.extname(filePath) === '.png') {
     if (fs.existsSync(filePath)) {
       const image = fs.readFileSync(filePath)
@@ -179,16 +179,16 @@ export function sniffParseSync(filePath: string): stencila.Node | undefined {
 }
 
 /**
- * Unparse a Stencila node to a rPNG.
+ * Encode a Stencila node to a rPNG.
  *
  * This is done by dumping the node to HTML,
  * "screen-shotting" the HTML to a PNG and then inserting the
  * node's JSON into the image's `tEXt` chunk.
  *
- * @param node The Stencila node to unparse
+ * @param node The Stencila node to encode
  * @param filePath The file system path to write to
  */
-export async function unparse(
+export async function encode(
   node: stencila.Node,
   filePath?: string
 ): Promise<VFile> {

--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -1,18 +1,18 @@
 /**
- * Compiler for YAML
+ * Codec for YAML
  */
 
-import * as stencila from '@stencila/schema';
-import yaml from 'js-yaml';
-import { coerce } from './util';
-import { dump, load, VFile } from './vfile';
+import * as stencila from '@stencila/schema'
+import yaml from 'js-yaml'
+import { coerce } from './util'
+import { dump, load, VFile } from './vfile'
 
 export const mediaTypes = ['text/yaml']
 
-export async function parse(file: VFile): Promise<stencila.Node> {
+export async function decode(file: VFile): Promise<stencila.Node> {
   return coerce(yaml.safeLoad(await dump(file)))
 }
 
-export async function unparse(node: stencila.Node): Promise<VFile> {
+export async function encode(node: stencila.Node): Promise<VFile> {
   return load(yaml.safeDump(node))
 }

--- a/tests/csv.test.ts
+++ b/tests/csv.test.ts
@@ -1,4 +1,4 @@
-import { parse, unparse } from '../src/csv'
+import { decode, encode } from '../src/csv'
 import { dump, load } from '../src/vfile'
 
 const simple = {
@@ -92,14 +92,14 @@ const formulas = {
   }
 }
 
-test('parse', async () => {
-  expect(await parse(load(simple.content))).toEqual(simple.node)
-  expect(await parse(load(named.content))).toEqual(named.node)
-  expect(await parse(load(formulas.content))).toEqual(formulas.node)
+test('decode', async () => {
+  expect(await decode(load(simple.content))).toEqual(simple.node)
+  expect(await decode(load(named.content))).toEqual(named.node)
+  expect(await decode(load(formulas.content))).toEqual(formulas.node)
 })
 
-test('unparse', async () => {
-  expect(await dump(await unparse(simple.node))).toEqual(simple.content)
-  expect(await dump(await unparse(named.node))).toEqual(named.content)
-  expect(await dump(await unparse(formulas.node))).toEqual(formulas.content)
+test('encode', async () => {
+  expect(await dump(await encode(simple.node))).toEqual(simple.content)
+  expect(await dump(await encode(named.node))).toEqual(named.content)
+  expect(await dump(await encode(formulas.node))).toEqual(formulas.content)
 })

--- a/tests/gdoc.test.ts
+++ b/tests/gdoc.test.ts
@@ -1,21 +1,21 @@
-import { parse, unparse } from '../src/gdoc'
+import { decode, encode } from '../src/gdoc'
 import { dump, load } from '../src/vfile'
 
-test('parse', async () => {
-  const p = async (gdoc: any) => await parse(load(JSON.stringify(gdoc)), false)
+test('decode', async () => {
+  const p = async (gdoc: any) => await decode(load(JSON.stringify(gdoc)), false)
   expect(await p(kitchenSink.gdoc)).toEqual(kitchenSink.node)
 })
 
-test('unparse', async () => {
-  const u = async (node: any) => JSON.parse(await dump(await unparse(node)))
+test('encode', async () => {
+  const u = async (node: any) => JSON.parse(await dump(await encode(node)))
   expect(await u(kitchenSink.node)).toEqual(kitchenSink.gdoc)
 })
 
-// An example intended for testing progressively added parser/unparser pairs
+// An example intended for testing progressively added decoder/encoder pairs
 const kitchenSink = {
   // Note that this object is missing many styling related properties that
   // are normally in a GDoc. To keep it a manageable size, throughout the
-  // object tree, we've only included the properties that the compiler uses.
+  // object tree, we've only included the properties that the codec uses.
   // A good way to generate content nodes is to author in GDocs and then
   // fetch using the `gapis.js` script (see there for more details).
   gdoc: {

--- a/tests/html.test.ts
+++ b/tests/html.test.ts
@@ -1,18 +1,18 @@
-import { parse, unparse } from '../src/html';
-import { stencilaCSS } from '../src/templates/stencila-css-template';
-import { dump, load } from '../src/vfile';
+import { decode, encode } from '../src/html'
+import { stencilaCSS } from '../src/templates/stencila-css-template'
+import { dump, load } from '../src/vfile'
 
-test('parse', async () => {
-  expect(await parse(load(kitchenSink.html))).toEqual(kitchenSink.node)
-  expect(await parse(await load(attrs.html))).toEqual(attrs.node)
+test('decode', async () => {
+  expect(await decode(load(kitchenSink.html))).toEqual(kitchenSink.node)
+  expect(await decode(await load(attrs.html))).toEqual(attrs.node)
 })
 
-test('unparse', async () => {
-  expect(await dump(await unparse(kitchenSink.node))).toEqual(kitchenSink.html)
-  expect(await dump(await unparse(attrs.node))).toEqual(attrs.html)
+test('encode', async () => {
+  expect(await dump(await encode(kitchenSink.node))).toEqual(kitchenSink.html)
+  expect(await dump(await encode(attrs.node))).toEqual(attrs.html)
 })
 
-// An example intended for testing progressively added parser/unparser pairs
+// An example intended for testing progressively added decoder/encoder pairs
 const kitchenSink = {
   html: `<html>
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -5,7 +5,7 @@ import fs from 'fs-extra'
 import path from 'path'
 import tempy from 'tempy'
 import {
-  compilerList,
+  codecList,
   convert,
   dump,
   handled,
@@ -22,7 +22,7 @@ import { fixture } from './helpers'
 fs.ensureDirSync(path.join(__dirname, 'output'))
 
 describe('match', () => {
-  // A dummy compiler for testing matching
+  // A dummy codec for testing matching
   const ssf = {
     fileNames: ['super-special-file'],
     extNames: ['ssf'],
@@ -30,10 +30,10 @@ describe('match', () => {
     sniff: async (content: string) => /^SSF:/.test(content),
 
     // Required, but don't do anything
-    parse: async (file: VFile) => null,
-    unparse: async (node: stencila.Node, filePath?: string) => create()
+    decode: async (file: VFile) => null,
+    encode: async (node: stencila.Node, filePath?: string) => create()
   }
-  compilerList.push(ssf)
+  codecList.push(ssf)
 
   it('works with file paths', async () => {
     expect(await match('./file.json')).toEqual(json)
@@ -70,15 +70,15 @@ describe('match', () => {
     expect(await match('SSF: woot!')).toEqual(ssf)
   })
 
-  it('throws when unable to find a matching compiler', async () => {
+  it('throws when unable to find a matching codec', async () => {
     await expect(match('./foo.bar')).rejects.toThrow(
-      'No compiler could be found for content "./foo.bar".'
+      'No codec could be found for content "./foo.bar".'
     )
     await expect(match('foo')).rejects.toThrow(
-      'No compiler could be found for content "foo".'
+      'No codec could be found for content "foo".'
     )
     await expect(match(undefined, 'foo')).rejects.toThrow(
-      'No compiler could be found for format "foo".'
+      'No codec could be found for format "foo".'
     )
   })
 })

--- a/tests/issues/58-list-unordered.test.ts
+++ b/tests/issues/58-list-unordered.test.ts
@@ -6,7 +6,7 @@ import { dump, read } from '../../src'
 describe('issue 58', () => {
   const file = path.join(__dirname, '58-list-unordered.gdoc')
 
-  test('goc unordered list is parsed correctly', async () => {
+  test('goc unordered list is decoded correctly', async () => {
     const gdoc = fs.readJSONSync(file)
     expect(
       gdoc.lists['kix.list.1'].listProperties.nestingLevels[0].glyphType

--- a/tests/matchers.ts
+++ b/tests/matchers.ts
@@ -7,30 +7,30 @@ import path from 'path'
 fs.ensureDirSync(path.join(__dirname, 'output'))
 
 /**
- * Add a Jest matcher for testing that a compiler is able
- * to invert a node (ie. unparse and then parse)
+ * Add a Jest matcher for testing that a codec is able
+ * to invert a node (ie. encode and then decode)
  * and produce useful error messages if it did not.
  *
- * @param compiler The compiler (passed by expect)
+ * @param codec The codec (passed by expect)
  * @param node The node to attempt to invert
  * @param name: The file name for any output files
  */
 expect.extend({
-  async toInvert(compiler, node, fileName?: string) {
+  async toInvert(codec, node, fileName?: string) {
     if (!fileName) {
       const type = stencila.type(node).toLowerCase()
       const num = Math.floor(Math.random() * Math.floor(1000))
       fileName = `${type}-${num}`
       const ext =
-        (compiler.extNames && compiler.extNames[0]) ||
-        (compiler.mediaTypes && mime.getExtension(compiler.mediaTypes[0]))
+        (codec.extNames && codec.extNames[0]) ||
+        (codec.mediaTypes && mime.getExtension(codec.mediaTypes[0]))
       if (ext) fileName += '.' + ext
     }
     const outPath = path.join(__dirname, 'output', fileName)
-    const file = await compiler.unparse(node, outPath)
-    const nodeParsed = await compiler.parse(file)
+    const file = await codec.encode(node, outPath)
+    const nodeDecoded = await codec.decode(file)
     try {
-      expect(nodeParsed).toEqual(node)
+      expect(nodeDecoded).toEqual(node)
     } catch (error) {
       return {
         message: () => {

--- a/tests/md.test.ts
+++ b/tests/md.test.ts
@@ -1,23 +1,23 @@
-import { parse, unparse } from '../src/md'
+import { decode, encode } from '../src/md'
 import { dump, load } from '../src/vfile'
 
-test('parse', async () => {
-  expect(await parse(await load(kitchenSink.md))).toEqual(kitchenSink.node)
-  expect(await parse(await load(attrs.md))).toEqual(attrs.node)
+test('decode', async () => {
+  expect(await decode(await load(kitchenSink.md))).toEqual(kitchenSink.node)
+  expect(await decode(await load(attrs.md))).toEqual(attrs.node)
 
-  expect(await parse(await load(shortYaml.from))).toEqual(shortYaml.node)
+  expect(await decode(await load(shortYaml.from))).toEqual(shortYaml.node)
 })
 
-test('unparse', async () => {
-  expect(await dump(await unparse(kitchenSink.node))).toEqual(kitchenSink.md)
-  expect(await dump(await unparse(attrs.node))).toEqual(attrs.md)
+test('encode', async () => {
+  expect(await dump(await encode(kitchenSink.node))).toEqual(kitchenSink.md)
+  expect(await dump(await encode(attrs.node))).toEqual(attrs.md)
 
-  expect(await dump(await unparse(shortYaml.node))).toEqual(shortYaml.to)
+  expect(await dump(await encode(shortYaml.node))).toEqual(shortYaml.to)
 
-  expect(await dump(await unparse(emptyParas.node))).toEqual(emptyParas.to)
+  expect(await dump(await encode(emptyParas.node))).toEqual(emptyParas.to)
 })
 
-// An example intended for testing progressively added parser/unparser pairs
+// An example intended for testing progressively added decoder/encoder pairs
 const kitchenSink = {
   // Note: for bidi conversion, we're using expanded YAML frontmatter,
   // but most authors are likely to prefer using shorter variants e.g.

--- a/tests/pdf.test.ts
+++ b/tests/pdf.test.ts
@@ -3,15 +3,15 @@ import * as pdf from '../src/pdf'
 import { create } from '../src/vfile'
 import articleSimple from './fixtures/article-simple'
 
-test('parse', async () => {
-  await expect(pdf.parse(create())).rejects.toThrow(
+test('decode', async () => {
+  await expect(pdf.decode(create())).rejects.toThrow(
     /Parsing of PDF files is not supported/
   )
 })
 
-test('unparse', async () => {
-  const output = path.join(__dirname, 'output', 'pdf-unparse.pdf')
-  const doc = await pdf.unparse(articleSimple, output)
+test('encode', async () => {
+  const output = path.join(__dirname, 'output', 'pdf-encode.pdf')
+  const doc = await pdf.encode(articleSimple, output)
 
   expect(Buffer.isBuffer(doc.contents)).toBe(true)
   expect(doc.contents.slice(0, 5).toString()).toBe('%PDF-')

--- a/tests/person.test.ts
+++ b/tests/person.test.ts
@@ -1,4 +1,4 @@
-import { parse } from '../src/person'
+import { decode } from '../src/person'
 import { coerce, create, validate } from '../src/util'
 
 describe('validate', () => {
@@ -15,37 +15,39 @@ describe('validate', () => {
   })
 })
 
-describe('parse', () => {
+describe('decode', () => {
   it('works', () => {
     let person = create('Person')
 
     person.familyNames = ['Jones']
-    expect(parse('Jones')).toEqual(person)
+    expect(decode('Jones')).toEqual(person)
 
     person.givenNames = ['Jane', 'Jill']
-    expect(parse('Jane Jill Jones')).toEqual(person)
+    expect(decode('Jane Jill Jones')).toEqual(person)
 
     person.honorificPrefix = 'Dr'
-    expect(parse('Dr Jane Jill Jones')).toEqual(person)
+    expect(decode('Dr Jane Jill Jones')).toEqual(person)
 
     person.honorificSuffix = 'PhD'
-    expect(parse('Dr Jane Jill Jones PhD')).toEqual(person)
+    expect(decode('Dr Jane Jill Jones PhD')).toEqual(person)
 
     person.emails = ['jane@example.com']
-    expect(parse('Dr Jane Jill Jones PhD <jane@example.com>')).toEqual(person)
+    expect(decode('Dr Jane Jill Jones PhD <jane@example.com>')).toEqual(person)
 
     person.url = 'http://example.com/jane'
     expect(
-      parse(
+      decode(
         'Dr Jane Jill Jones PhD <jane@example.com> (http://example.com/jane)'
       )
     ).toEqual(person)
   })
 
   it('throws', () => {
-    expect(() => parse('')).toThrow(/^Unable to parse string \"\" as a person$/)
-    expect(() => parse('#@&%')).toThrow(
-      /^Unable to parse string \"#@&%\" as a person$/s
+    expect(() => decode('')).toThrow(
+      /^Unable to decode string \"\" as a person$/
+    )
+    expect(() => decode('#@&%')).toThrow(
+      /^Unable to decode string \"#@&%\" as a person$/s
     )
   })
 })
@@ -153,7 +155,7 @@ describe('coerce', () => {
     expect(() =>
       coerce({ authors: ['John Smith', '#@&%', 'Jones, Jane'] }, 'CreativeWork')
     ).toThrow(
-      '/authors/1: parser error when parsing using "person": Unable to parse string "#@&%" as a person'
+      '/authors/1: parser error when decoding using "person": Unable to decode string "#@&%" as a person'
     )
   })
 })

--- a/tests/rpng.test.ts
+++ b/tests/rpng.test.ts
@@ -1,14 +1,14 @@
 import fs from 'fs'
 import path from 'path'
 import {
+  decode,
+  decodeSync,
+  encode,
   extract,
   has,
   insert,
-  parse,
-  parseSync,
   sniff,
-  sniffSync,
-  unparse
+  sniffSync
 } from '../src/rpng'
 import { read } from '../src/vfile'
 import vfile = require('vfile')
@@ -43,17 +43,17 @@ test('sniff', async () => {
   expect(sniffSync('/some/file.zip')).toBe(false)
 })
 
-test('parse', async () => {
+test('decode', async () => {
   const file = await read(rpngPath)
-  expect(await parse(file)).toEqual(node)
-  expect(parseSync(file)).toEqual(node)
+  expect(await decode(file)).toEqual(node)
+  expect(decodeSync(file)).toEqual(node)
 })
 
-test('unparse', async () => {
+test('encode', async () => {
   jest.setTimeout(30 * 1000) // Extending timeout due to failing test on AppVeyor
-  const file = await unparse(node)
+  const file = await encode(node)
   expect(file).toBeInstanceOf(vfile)
-  expect(await parse(file)).toEqual(node)
+  expect(await decode(file)).toEqual(node)
 })
 
 test('insert, has, extract', () => {

--- a/tests/tdp.test.ts
+++ b/tests/tdp.test.ts
@@ -1,4 +1,4 @@
-import { parse, unparse } from '../src/tdp'
+import { decode, encode } from '../src/tdp'
 import { dump, read } from '../src/vfile'
 
 const periodic = {
@@ -132,13 +132,13 @@ const periodic = {
   }
 }
 
-test('parse', async () => {
-  expect(await parse(await read(periodic.file))).toEqual(periodic.node)
+test('decode', async () => {
+  expect(await decode(await read(periodic.file))).toEqual(periodic.node)
 })
 
-test('unparse', async () => {
-  const actual = JSON.parse(await dump(await unparse(periodic.node)))
-  // Pretend that we unparsed to a a filePath i.e. that
+test('encode', async () => {
+  const actual = JSON.parse(await dump(await encode(periodic.node)))
+  // Pretend that we encoded to a a filePath i.e. that
   // the data was written to disk.
   delete actual.resources[0].data
   actual.resources[0].path = 'periodic-table.csv'

--- a/tests/xlsx.test.ts
+++ b/tests/xlsx.test.ts
@@ -2,8 +2,8 @@ import { read } from '../src/vfile'
 import {
   columnIndexToName,
   columnNameToIndex,
-  parse,
-  unparse
+  decode,
+  encode
 } from '../src/xlsx'
 
 test('columnNameToIndex, columnIndexToName', async () => {
@@ -119,14 +119,14 @@ const collection = {
   }
 }
 
-test('parse', async () => {
-  expect(await parse(await read(simple.file))).toEqual(simple.node)
-  expect(await parse(await read(collection.file))).toEqual(collection.node)
+test('decode', async () => {
+  expect(await decode(await read(simple.file))).toEqual(simple.node)
+  expect(await decode(await read(collection.file))).toEqual(collection.node)
 })
 
-test('unparse', async () => {
+test('encode', async () => {
   // Use round trip since meta data in the binary file (e.g. last save time)
   // makes comparison of those files difficult
-  expect(await parse(await unparse(simple.node))).toEqual(simple.node)
-  expect(await parse(await unparse(collection.node))).toEqual(collection.node)
+  expect(await decode(await encode(simple.node))).toEqual(simple.node)
+  expect(await decode(await encode(collection.node))).toEqual(collection.node)
 })


### PR DESCRIPTION
This renames `stencila/convert` (NPM package `stencila-convert`) to `stencila/encoda` (NPM package `@stencila/encoda`). 

This is in line with a general renaming (towards consistently using the `stencila/*a` convention), refactoring (towards a single, or at least main, downloadable) and rationalisation of our repos  (e.g. deprecating superseded ones).