### PR TITLE
feat: Added logging via Stencila Logga

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -757,6 +757,11 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
     },
+    "@stencila/logga": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@stencila/logga/-/logga-1.0.0.tgz",
+      "integrity": "sha512-4PgOMsywK357E9ASht1SCpnygJi9k+B/DAYma44QeIlgmntZFj78Zs8WV6Z/wfTDWgWnWUYKXcyJYNklB6FzOA=="
+    },
     "@stencila/schema": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@stencila/schema/-/schema-0.12.0.tgz",
@@ -4663,8 +4668,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4682,13 +4686,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4701,18 +4703,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4815,8 +4814,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4826,7 +4824,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4839,20 +4836,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4869,7 +4863,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4942,8 +4935,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4953,7 +4945,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5029,8 +5020,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5060,7 +5050,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5078,7 +5067,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5117,13 +5105,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "url": "https://github.com/stencila/encoda/issues"
   },
   "dependencies": {
+    "@stencila/logga": "^1.0.0",
     "@stencila/schema": "^0.12.0",
     "ajv": "^6.10.0",
     "axios": "^0.18.0",

--- a/src/devserve.ts
+++ b/src/devserve.ts
@@ -1,8 +1,11 @@
+import { getLogger } from '@stencila/logga'
 import browserSync from 'browser-sync'
 import chokidar from 'chokidar'
 import path from 'path'
 import { write } from '.'
 import process from './process'
+
+const logger = getLogger('encoda')
 
 /**
  * Serve a directory, watching for file changes,
@@ -37,7 +40,7 @@ export function devserve(
     const { dir, name, ext } = path.parse(filePath)
     if (ext !== '.html') {
       // TODO: prettier logging of file being processed
-      console.error(filePath)
+      logger.error(filePath)
       const htmlPath = path.join(dir, name + '.html')
       try {
         const doc = await process(filePath)
@@ -45,7 +48,7 @@ export function devserve(
         browser.reload(htmlPath)
       } catch (error) {
         // TODO: prettier logging of errors
-        console.error(error)
+        logger.error(error)
         browser.notify(
           `<span style="color: #f83939;">${error.message}</span>`,
           60 * 60 * 1000

--- a/src/gdoc.ts
+++ b/src/gdoc.ts
@@ -22,6 +22,7 @@
  *    to walk Stencila JSON and build up the GDoc by calling methods such as `Body.appendParagraph` etc.
  */
 
+import { getLogger } from '@stencila/logga'
 import * as stencila from '@stencila/schema'
 import { InlineContent } from '@stencila/schema'
 import axios from 'axios'
@@ -30,6 +31,8 @@ import fs from 'fs'
 import { docs_v1 as GDoc } from 'googleapis'
 import { validate } from './util'
 import { dump, load, VFile } from './vfile'
+
+const logger = getLogger('encoda')
 
 export const mediaTypes = ['application/vnd.google-apps.document']
 
@@ -103,7 +106,7 @@ class FetchToFile {
         response.data.pipe(fs.createWriteStream(filePath))
       })
       .catch(error => {
-        console.error(`Error when fetching ${url}: ${error.message}`)
+        logger.error(`Error when fetching ${url}: ${error.message}`)
       })
     this.requests.push(request)
     return filePath

--- a/src/pandoc.ts
+++ b/src/pandoc.ts
@@ -1,3 +1,4 @@
+import { getLogger } from '@stencila/logga'
 import * as stencila from '@stencila/schema'
 import childProcess from 'child_process'
 import { pandocDataDir, pandocPath } from './boot'
@@ -6,6 +7,8 @@ import * as rpng from './rpng'
 import { create, load, VFile, write } from './vfile'
 
 export { InputFormat, OutputFormat } from './pandoc-types'
+
+const logger = getLogger('encoda')
 
 // Although this codec is usually used as a base for others (e.g `docx`),
 // the following definitions allow Pandoc JSON to be decoded or encoded
@@ -97,9 +100,7 @@ let encodePromises: Promise<any>[] = []
  */
 function run(input: string | Buffer, args: string[]): Promise<string> {
   args.push(`--data-dir=${pandocDataDir}`)
-  if (process.env.DEBUG) {
-    console.log(`Running ${pandocPath} with args:\n  ${args.join('\n  ')}`)
-  }
+  logger.debug(`Running ${pandocPath} with args:\n  ${args.join('\n  ')}`)
   return new Promise((resolve, reject) => {
     const child = childProcess.spawn(pandocPath, args)
 

--- a/src/tdp.ts
+++ b/src/tdp.ts
@@ -14,11 +14,14 @@
  * - a CSV file
  */
 
+import { getLogger } from '@stencila/logga'
 import * as stencila from '@stencila/schema'
 // @ts-ignore
 import datapackage from 'datapackage'
 import * as csv from './csv'
 import { create, dump, load, VFile } from './vfile'
+
+const logger = getLogger('encoda')
 
 export const mediaTypes = [
   // As registered at https://www.iana.org/assignments/media-types/media-types.xhtml
@@ -154,7 +157,7 @@ async function decodeResource(
     data = await resource.read()
   } catch (error) {
     if (error.multiple) {
-      for (const err of error.errors) console.log(err)
+      for (const err of error.errors) logger.error(err)
     }
     throw error
   }


### PR DESCRIPTION
^ As per title. The other uses of console.log / console.error that haven't been replaced are because they were used to send to STDOUT used in scripts that would only be called from the command line.