### PR TITLE
Add codec to create Demo Magic scripts.

### DIFF
--- a/src/demo-magic.ts
+++ b/src/demo-magic.ts
@@ -1,0 +1,114 @@
+/**
+ * Codec for [Demo Magic](https://github.com/paxtonhare/demo-magic) script.
+ *
+ * > `demo-magic.sh` is a handy shell script that enables you to script
+ * > repeatable demos in a bash environment so you don't have to type as
+ * > you present. Rather than trying to type commands when presenting you
+ * > simply script them and let `demo-magic.sh` run them for you.
+ *
+ * This codec encodes a Stencila `Node` (usually an `Article` authored using
+ * Markdown) as a Bash script that uses the `demo-magic.sh` functions to
+ * provide an interactive demo with simulated typing and other features.
+ * It's very useful for recording screencasts for command line applications.
+ *
+ * It supports `Heading`, `Paragraph` and `CodeBlock` nodes with `bash` or
+ * `sh` as the `language`.
+ *
+ * You can run the generated script using options. Use `-h` for help.
+ */
+
+import stencila from '@stencila/schema'
+import fs from 'fs-extra'
+import path from 'path'
+import * as md from './md'
+import { type } from './util'
+import { dump, load, VFile } from './vfile'
+
+/**
+ * The media types that this codec can decode/encode.
+ */
+export const mediaTypes = ['application/x-demo-magic']
+
+/**
+ * The file name extensions to register for the codec.
+ * Used to be able to explicitly refer to this codec.
+ */
+export const extNames = ['demo-magic']
+
+/**
+ * Decode a `VFile` with `demo-magic.sh` content to a Stencila `Node`.
+ *
+ * @param file The `VFile` to decode
+ * @returns A promise that resolves to a Stencila `Node`
+ */
+export async function decode(file: VFile): Promise<stencila.Node> {
+  throw new Error('Decoding of Demo Magic scripts is not supported.')
+}
+
+/**
+ * Encode a Stencila `Node` to a `VFile` with `demo-magic.sh` content.
+ *
+ * @param thing The Stencila `Node` to encode
+ * @returns A promise that resolves to a `VFile`
+ */
+export async function encode(
+  node: stencila.Node,
+  filePath?: string,
+  options: any = { embed: true }
+): Promise<VFile> {
+  let bash = await encodeNode(node)
+  if (options.embed) {
+    if (!demoMagicSh) {
+      demoMagicSh = await fs.readFile(
+        path.join(__dirname, 'templates', 'demo-magic.sh'),
+        'utf8'
+      )
+    }
+    bash = demoMagicSh + bash
+  }
+  return load(bash)
+}
+
+// The content of the Bash Script. Lazily loaded.
+let demoMagicSh: string | undefined
+
+/**
+ * Encode a Stencila `Node` as a Demo Magic Bash string.
+ */
+async function encodeNode(node: stencila.Node): Promise<string> {
+  if (node === null || typeof node !== 'object') return ''
+
+  switch (type(node)) {
+    case 'Heading':
+      const heading = node as stencila.Heading
+      return `h ${heading.depth} "${await escapedMd(heading)}"\n\n`
+
+    case 'Paragraph':
+      return `p "# ${await escapedMd(node)}"\n\n`
+
+    case 'CodeBlock':
+      const block = node as stencila.CodeBlock
+      if (
+        block.language &&
+        !(block.language == 'bash' || block.language == 'sh')
+      )
+        return ''
+      let bash = `pe "${block.value}"\n`
+      if (block.meta) {
+        if (block.meta.pause) bash += `z ${block.meta.pause}\n`
+      }
+      return bash + '\n'
+  }
+
+  // For all other node types, recurse over their children
+  const strings = await Promise.all(Object.values(node).map(encodeNode))
+  return strings.join('')
+}
+
+/**
+ * Generate escaped Markdown suitable for inserting into Bash
+ */
+async function escapedMd(node: stencila.Node): Promise<string> {
+  const markdown = await dump(await md.encode(node))
+  return markdown.replace(/`/g, '\\`')
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import stencila from '@stencila/schema'
 import mime from 'mime'
 import path from 'path'
 import * as csv from './csv'
+import * as demoMagic from './demo-magic'
 import * as docx from './docx'
 import * as gdoc from './gdoc'
 import * as html from './html'
@@ -44,6 +45,9 @@ export const codecList: Array<Codec> = [
   md,
   odt,
   pdf,
+
+  // Scripts
+  demoMagic,
 
   // Images
   rpng,

--- a/src/templates/demo-magic.sh
+++ b/src/templates/demo-magic.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+
+# This Bash file includes the demo-magic.sh Bash script (from https://raw.githubusercontent.com/paxtonhare/demo-magic/a336b3c3afd48830adb3f83975dbea1b43e3cc6d/demo-magic.sh)
+# plus some customisations and extensions (at the end of this file) for use with Encoda.
+
+###############################################################################
+# The MIT License (MIT)
+# 
+# Copyright (c) 2015 Paxton Hare
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+##############################################################################
+
+###############################################################################
+#
+# demo-magic.sh
+#
+# Copyright (c) 2015 Paxton Hare
+#
+# This script lets you script demos in bash. It runs through your demo script when you press
+# ENTER. It simulates typing and runs commands.
+#
+###############################################################################
+
+# the speed to "type" the text
+TYPE_SPEED=20
+
+# no wait after "p" or "pe"
+NO_WAIT=false
+
+# if > 0, will pause for this amount of seconds before automatically proceeding with any p or pe
+PROMPT_TIMEOUT=0
+
+# don't show command number unless user specifies it
+SHOW_CMD_NUMS=false
+
+
+# handy color vars for pretty prompts
+BLACK="\033[0;30m"
+BLUE="\033[0;34m"
+GREEN="\033[0;32m"
+GREY="\033[0;90m"
+CYAN="\033[0;36m"
+RED="\033[0;31m"
+PURPLE="\033[0;35m"
+BROWN="\033[0;33m"
+WHITE="\033[1;37m"
+COLOR_RESET="\033[0m"
+
+C_NUM=0
+
+# prompt and command color which can be overriden
+DEMO_PROMPT="$ "
+DEMO_CMD_COLOR=$WHITE
+DEMO_COMMENT_COLOR=$GREY
+
+##
+# prints the script usage
+##
+function usage() {
+  echo -e ""
+  echo -e "Usage: $0 [options]"
+  echo -e ""
+  echo -e "\tWhere options is one or more of:"
+  echo -e "\t-h\tPrints Help text"
+  echo -e "\t-d\tDebug mode. Disables simulated typing"
+  echo -e "\t-n\tNo wait"
+  echo -e "\t-w\tWaits max the given amount of seconds before proceeding with demo (e.g. '-w5')"
+  echo -e ""
+}
+
+##
+# wait for user to press ENTER
+# if $PROMPT_TIMEOUT > 0 this will be used as the max time for proceeding automatically
+##
+function wait() {
+  if [[ "$PROMPT_TIMEOUT" == "0" ]]; then
+    read -rs
+  else
+    read -rst "$PROMPT_TIMEOUT"
+  fi
+}
+
+##
+# print command only. Useful for when you want to pretend to run a command
+#
+# takes 1 param - the string command to print
+#
+# usage: p "ls -l"
+#
+##
+function p() {
+  if [[ ${1:0:1} == "#" ]]; then
+    cmd=$DEMO_COMMENT_COLOR$1$COLOR_RESET
+  else
+    cmd=$DEMO_CMD_COLOR$1$COLOR_RESET
+  fi
+
+  # render the prompt
+  x=$(PS1="$DEMO_PROMPT" "$BASH" --norc -i </dev/null 2>&1 | sed -n '${s/^\(.*\)exit$/\1/p;}')
+  
+  # show command number is selected
+  if $SHOW_CMD_NUMS; then
+   printf "[$((++C_NUM))] $x"
+  else
+   printf "$x"
+  fi
+
+  # wait for the user to press a key before typing the command
+  if !($NO_WAIT); then
+    wait
+  fi
+
+  if [[ -z $TYPE_SPEED ]]; then
+    echo -en "$cmd"
+  else
+    echo -en "$cmd" | pv -qL $[$TYPE_SPEED+(-2 + RANDOM%5)];
+  fi
+
+  # wait for the user to press a key before moving on
+  if !($NO_WAIT); then
+    wait
+  fi
+  echo ""
+}
+
+##
+# Prints and executes a command
+#
+# takes 1 parameter - the string command to run
+#
+# usage: pe "ls -l"
+#
+##
+function pe() {
+  # print the command
+  p "$@"
+
+  # execute the command
+  eval "$@"
+}
+
+##
+# Enters script into interactive mode
+#
+# and allows newly typed commands to be executed within the script
+#
+# usage : cmd
+#
+##
+function cmd() {
+  # render the prompt
+  x=$(PS1="$DEMO_PROMPT" "$BASH" --norc -i </dev/null 2>&1 | sed -n '${s/^\(.*\)exit$/\1/p;}')
+  printf "$x\033[0m"
+  read command
+  eval "${command}"
+}
+
+
+function check_pv() {
+  command -v pv >/dev/null 2>&1 || {
+
+    echo ""
+    echo -e "${RED}##############################################################"
+    echo "# HOLD IT!! I require pv but it's not installed.  Aborting." >&2;
+    echo -e "${RED}##############################################################"
+    echo ""
+    echo -e "${COLOR_RESET}Installing pv:"
+    echo ""
+    echo -e "${BLUE}Mac:${COLOR_RESET} $ brew install pv"
+    echo ""
+    echo -e "${BLUE}Other:${COLOR_RESET} http://www.ivarch.com/programs/pv.shtml"
+    echo -e "${COLOR_RESET}"
+    exit 1;
+  }
+}
+
+check_pv
+#
+# handle some default params
+# -h for help
+# -d for disabling simulated typing
+#
+while getopts ":dhncw:" opt; do
+  case $opt in
+    h)
+      usage
+      exit 1
+      ;;
+    d)
+      unset TYPE_SPEED
+      ;;
+    n)
+      NO_WAIT=true
+      ;;
+    c)
+      SHOW_CMD_NUMS=true
+      ;;
+    w)
+      PROMPT_TIMEOUT=$OPTARG
+      ;;
+  esac
+done
+
+
+###############################################################################
+# The following are customisations and extensions for use with Encoda
+
+DEMO_PROMPT=$BLUE"$ "
+DEMO_CMD_COLOR=$GREEN
+
+BOLD=$(tput bold)
+NORMAL=$(tput sgr0)
+
+# Print headings
+function h {
+  p "$BOLD$WHITE$2$COLOR_RESET$NORMAL"
+}
+
+# Function to `sleep` when in non interactive mode i.e. `-n`
+# and to continue when in interactive mode. This allows for pauses when
+# recording a screencast but for them not to be there in interactive tutorials
+function z {
+  if $NO_WAIT; then sleep $1; fi
+}
+
+clear
+

--- a/tests/demo-magic.test.ts
+++ b/tests/demo-magic.test.ts
@@ -1,0 +1,86 @@
+import * as stencila from '@stencila/schema'
+import { decode, encode } from '../src/demo-magic'
+import { create, dump } from '../src/vfile'
+
+test('decode', async () => {
+  await expect(decode(create())).rejects.toThrow(
+    /Decoding of Demo Magic scripts is not supported/
+  )
+})
+
+test('encode', async () => {
+  expect(await dump(await encode(node, undefined, { embed: false }))).toEqual(
+    bash
+  )
+  expect(await encode(node)).toBeTruthy()
+})
+
+const node: stencila.Article = {
+  type: 'Article',
+  authors: [],
+  content: [
+    {
+      type: 'Heading',
+      depth: 1,
+      content: ['Heading one']
+    },
+    {
+      type: 'Heading',
+      depth: 2,
+      content: ['Heading two']
+    },
+    {
+      type: 'Paragraph',
+      content: [
+        'A paragraph with ',
+        {
+          type: 'Strong',
+          content: ['strong']
+        },
+        ' and ',
+        {
+          type: 'Code',
+          value: 'code'
+        }
+      ]
+    },
+    {
+      type: 'CodeBlock',
+      language: 'bash',
+      value: 'date'
+    },
+    {
+      type: 'CodeBlock',
+      language: 'bash',
+      value: 'date --utc',
+      meta: {
+        pause: 2
+      }
+    },
+    {
+      type: 'CodeBlock',
+      language: 'sh',
+      value: 'date -u'
+    },
+    {
+      type: 'CodeBlock',
+      language: 'foo',
+      value: 'ignored'
+    }
+  ]
+}
+
+const bash = `h 1 "# Heading one"
+
+h 2 "## Heading two"
+
+p "# A paragraph with **strong** and \\\`code\\\`"
+
+pe "date"
+
+pe "date --utc"
+z 2
+
+pe "date -u"
+
+`


### PR DESCRIPTION
Codec for [Demo Magic](https://github.com/paxtonhare/demo-magic) script.

> `demo-magic.sh` is a handy shell script that enables you to script
> repeatable demos in a bash environment so you don't have to type as
> you present. Rather than trying to type commands when presenting you
> simply script them and let `demo-magic.sh` run them for you.

This codec encodes a Stencila `Node` (usually an `Article` authored using
Markdown) as a Bash script that uses the `demo-magic.sh` functions to
provide an interactive demo with simulated typing and other features.
It's very useful for recording screencasts for command line applications.

It supports `Heading`, `Paragraph` and `CodeBlock` nodes with `bash` or
`sh` as the `language`.

You can run the generated script using options. Use `-h` for help.

Adding this now for easier generation of demos and tutorials for the `stencila` CLI.
More :dog2: :meat_on_bone: !
