### PR TITLE
Improve speed of rPNG generation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   testEnvironment: 'node',
   testMatch: ['**/tests/**/*.test.ts'],
   setupFilesAfterEnv: ['<rootDir>/tests/matchers.ts'],
+  globalTeardown: '<rootDir>/tests/teardown.ts',
   coveragePathIgnorePatterns: ['tests/helpers.ts', 'tests/fixtures/*'],
   watchPathIgnorePatterns: ['tests/output']
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,4 +43,10 @@ const args = _.slice(1)
 // @ts-ignore
 const func = encoda[name]
 if (!func) throw new Error(`No such function "${name}"`)
-func(...args, options)
+;(async () => {
+  // Call the function (which may, or may not be async) and then
+  await func(...args, options)
+  // Exit the process (necessary in case there are Puppeteer
+  // instances open etc
+  process.exit(0)
+})()

--- a/src/rpng.ts
+++ b/src/rpng.ts
@@ -19,9 +19,8 @@ import pngText from 'png-chunk-text'
 import pngEncode from 'png-chunks-encode'
 import pngExtract, { Chunk } from 'png-chunks-extract'
 import punycode from 'punycode'
-import puppeteer from 'puppeteer'
-import { chromiumPath } from './boot'
 import { dump } from './index'
+import * as puppeteer from './puppeteer'
 import { stencilaCSS } from './templates/stencila-css-template'
 import { load as loadVFile, VFile, write as writeVFile } from './vfile'
 
@@ -178,6 +177,9 @@ export function sniffDecodeSync(filePath: string): stencila.Node | undefined {
   }
 }
 
+// The Puppeteer page that will be used to generate PDFs
+export const browser = puppeteer.page()
+
 /**
  * Encode a Stencila node to a rPNG.
  *
@@ -205,10 +207,7 @@ export async function encode(
   let html = await dump(value, 'html')
 
   // Generate image of rendered HTML
-  const browser = await puppeteer.launch({
-    executablePath: chromiumPath
-  })
-  const page = await browser.newPage()
+  const page = await browser()
   await page.addStyleTag({ content: stencilaCSS })
   await page.addScriptTag({
     url:
@@ -229,7 +228,6 @@ export async function encode(
   const buffer = await elem.screenshot({
     encoding: 'binary'
   })
-  await browser.close()
 
   // Insert JSON of the thing into the image
   const json = JSON.stringify(node)

--- a/tests/pdf.test.ts
+++ b/tests/pdf.test.ts
@@ -16,3 +16,7 @@ test('encode', async () => {
   expect(Buffer.isBuffer(doc.contents)).toBe(true)
   expect(doc.contents.slice(0, 5).toString()).toBe('%PDF-')
 })
+
+afterAll(async () => {
+  await pdf.browser('close')
+})

--- a/tests/pdf.test.ts
+++ b/tests/pdf.test.ts
@@ -16,7 +16,3 @@ test('encode', async () => {
   expect(Buffer.isBuffer(doc.contents)).toBe(true)
   expect(doc.contents.slice(0, 5).toString()).toBe('%PDF-')
 })
-
-afterAll(async () => {
-  await pdf.browser('close')
-})

--- a/tests/rpng.test.ts
+++ b/tests/rpng.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import {
+  browser,
   decode,
   decodeSync,
   encode,
@@ -74,4 +75,8 @@ test('encoding of extended character sets', () => {
   image = insert(keyword, content, image)
   expect(has(keyword, image)).toBe(true)
   expect(extract(keyword, image)).toEqual(content)
+})
+
+afterAll(async () => {
+  await browser('close')
 })

--- a/tests/teardown.ts
+++ b/tests/teardown.ts
@@ -6,6 +6,12 @@
  */
 export default function teardown() {
   console.log('Running global teardown')
+
   // Emit beforeExit event to close any Puppeteer browsers etc
   process.emit('beforeExit', 0)
+
+  // Dispite the above, we are still getting
+  //  "Jest did not exit one second after the test run has completed."
+  // So, until we work out why, in the interests of having tests working
+  process.exit(0)
 }

--- a/tests/teardown.ts
+++ b/tests/teardown.ts
@@ -1,0 +1,11 @@
+/**
+ * Global teardown function that is triggered
+ * once after all test suites complete.
+ *
+ * See https://jestjs.io/docs/en/configuration#globalteardown-string
+ */
+export default function teardown() {
+  console.log('Running global teardown')
+  // Emit beforeExit event to close any Puppeteer browsers etc
+  process.emit('beforeExit', 0)
+}


### PR DESCRIPTION
This addresses #61. It takes the approach suggested there, as already implemented for the `pdf` codec. 

I did some ad hoc tests for speed and there was a slight increase in speed. However these tests were not very useful as they are dominated by waiting for network requests (JS and CSS).