### PR TITLE
Add ability to pass options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5066,7 +5066,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5087,12 +5088,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5107,17 +5110,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5234,7 +5240,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5246,6 +5253,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5260,6 +5268,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5267,12 +5276,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5291,6 +5302,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5371,7 +5383,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5383,6 +5396,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5468,7 +5482,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5504,6 +5519,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5523,6 +5539,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5566,12 +5583,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -3,6 +3,7 @@
  */
 
 import stencila from '@stencila/schema'
+import { Encode } from '.'
 import { VFile } from './vfile'
 import * as xlsx from './xlsx'
 
@@ -12,6 +13,6 @@ export async function decode(file: VFile): Promise<stencila.Node> {
   return xlsx.decode(file)
 }
 
-export async function encode(node: stencila.Node): Promise<VFile> {
+export const encode: Encode = async (node: stencila.Node): Promise<VFile> => {
   return xlsx.encode(node, undefined, 'csv')
 }

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -14,5 +14,5 @@ export async function decode(file: VFile): Promise<stencila.Node> {
 }
 
 export const encode: Encode = async (node: stencila.Node): Promise<VFile> => {
-  return xlsx.encode(node, undefined, 'csv')
+  return xlsx.encode(node, { format: 'csv' })
 }

--- a/src/demo-magic.ts
+++ b/src/demo-magic.ts
@@ -20,7 +20,7 @@
 import stencila from '@stencila/schema'
 import fs from 'fs-extra'
 import path from 'path'
-import { Encode } from '.'
+import { Encode, EncodeOptions } from '.'
 import * as md from './md'
 import type from './util/type'
 import { dump, load, VFile } from './vfile'
@@ -46,19 +46,22 @@ export async function decode(file: VFile): Promise<stencila.Node> {
   throw new Error('Decoding of Demo Magic scripts is not supported.')
 }
 
+interface DemoMagicOptions {
+  embed?: boolean
+}
+
 /**
  * Encode a Stencila `Node` to a `VFile` with `demo-magic.sh` content.
  *
  * @param thing The Stencila `Node` to encode
  * @returns A promise that resolves to a `VFile`
  */
-export const encode: Encode = async (
+export const encode: Encode<DemoMagicOptions> = async (
   node: stencila.Node,
-  filePath?: string,
-  options: any = { embed: true }
+  { codecOptions = { embed: true } }: EncodeOptions<DemoMagicOptions> = {}
 ): Promise<VFile> => {
   let bash = await encodeNode(node)
-  if (options.embed) {
+  if (codecOptions.embed) {
     if (!demoMagicSh) {
       demoMagicSh = await fs.readFile(
         path.join(__dirname, 'templates', 'demo-magic.sh'),
@@ -111,6 +114,6 @@ async function encodeNode(node: stencila.Node): Promise<string> {
  * Generate escaped Markdown suitable for inserting into Bash
  */
 async function escapedMd(node: stencila.Node): Promise<string> {
-  const markdown = await dump(await md.encode(node))
+  const markdown = await dump(await md.encode(node, {}))
   return markdown.replace(/`/g, '\\`')
 }

--- a/src/demo-magic.ts
+++ b/src/demo-magic.ts
@@ -20,6 +20,7 @@
 import stencila from '@stencila/schema'
 import fs from 'fs-extra'
 import path from 'path'
+import { Encode } from '.'
 import * as md from './md'
 import type from './util/type'
 import { dump, load, VFile } from './vfile'
@@ -51,11 +52,11 @@ export async function decode(file: VFile): Promise<stencila.Node> {
  * @param thing The Stencila `Node` to encode
  * @returns A promise that resolves to a `VFile`
  */
-export async function encode(
+export const encode: Encode = async (
   node: stencila.Node,
   filePath?: string,
   options: any = { embed: true }
-): Promise<VFile> {
+): Promise<VFile> => {
   let bash = await encodeNode(node)
   if (options.embed) {
     if (!demoMagicSh) {
@@ -91,8 +92,9 @@ async function encodeNode(node: stencila.Node): Promise<string> {
       if (
         block.language &&
         !(block.language == 'bash' || block.language == 'sh')
-      )
+      ) {
         return ''
+      }
       let bash = `pe "${block.value}"\n`
       if (block.meta) {
         if (block.meta.pause) bash += `z ${block.meta.pause}\n`

--- a/src/docx.ts
+++ b/src/docx.ts
@@ -4,6 +4,7 @@
 
 import stencila from '@stencila/schema'
 import path from 'path'
+import { Encode } from '.'
 import { home } from './boot'
 import * as pandoc from './pandoc'
 import { VFile } from './vfile'
@@ -29,11 +30,11 @@ const defaultDocxTemplatePath = path.join(
   'stencila-template.docx'
 )
 
-export async function encode(
+export const encode: Encode = async (
   node: stencila.Node,
   filePath?: string,
   templatePath: string = defaultDocxTemplatePath
-): Promise<VFile> {
+): Promise<VFile> => {
   return pandoc.encode(
     node,
     filePath,

--- a/src/docx.ts
+++ b/src/docx.ts
@@ -4,7 +4,7 @@
 
 import stencila from '@stencila/schema'
 import path from 'path'
-import { Encode } from '.'
+import { Encode, EncodeOptions } from '.'
 import { home } from './boot'
 import * as pandoc from './pandoc'
 import { VFile } from './vfile'
@@ -30,16 +30,23 @@ const defaultDocxTemplatePath = path.join(
   'stencila-template.docx'
 )
 
-export const encode: Encode = async (
-  node: stencila.Node,
-  filePath?: string,
-  templatePath: string = defaultDocxTemplatePath
-): Promise<VFile> => {
-  return pandoc.encode(
-    node,
-    filePath,
-    pandoc.OutputFormat.docx,
-    [`--reference-doc=${templatePath}`],
-    true
-  )
+interface DocXOptions {
+  templatePath?: string
 }
+
+export const encode: Encode<DocXOptions> = async (
+  node: stencila.Node,
+  { filePath, codecOptions }: EncodeOptions<DocXOptions> = {}
+): Promise<VFile> =>
+  pandoc.encode(node, {
+    filePath,
+    format: pandoc.OutputFormat.docx,
+    codecOptions: {
+      flags: [
+        `--reference-doc=${
+          codecOptions ? codecOptions.templatePath : defaultDocxTemplatePath
+        }`
+      ],
+      ensureFile: true
+    }
+  })

--- a/src/gdoc.ts
+++ b/src/gdoc.ts
@@ -28,6 +28,7 @@ import axios from 'axios'
 import crypto from 'crypto'
 import fs from 'fs'
 import { docs_v1 as GDoc } from 'googleapis'
+import { Encode } from '.'
 import type from './util/type'
 import { dump, load, VFile } from './vfile'
 
@@ -56,7 +57,7 @@ export async function decode(
  * @param node The `stencila.Node` to encode
  * @returns A promise that resolves to a `VFile`
  */
-export async function encode(node: stencila.Node): Promise<VFile> {
+export const encode: Encode = async (node: stencila.Node): Promise<VFile> => {
   const gdoc = encodeNode(node)
   const json = JSON.stringify(gdoc, null, '  ')
   return load(json)

--- a/src/html.ts
+++ b/src/html.ts
@@ -55,6 +55,7 @@ import h from 'hyperscript'
 import { html as beautifyHtml } from 'js-beautify'
 import jsdom from 'jsdom'
 import JSON5 from 'json5'
+import { Encode } from '.'
 import { stencilaCSS } from './templates/stencila-css-template'
 import type from './util/type'
 import { dump, load, VFile } from './vfile'
@@ -85,7 +86,7 @@ export async function decode(file: VFile): Promise<stencila.Node> {
  * @param node The `stencila.Node` to encode. Will be mutated to an `Node`.
  * @returns A promise that resolves to a `VFile`
  */
-export async function encode(node: stencila.Node): Promise<VFile> {
+export const encode: Encode = async (node: stencila.Node): Promise<VFile> => {
   const dom = encodeNode(node) as HTMLHtmlElement
   const beautifulHtml = beautifyHtml(dom.outerHTML, {
     indent_size: 2,

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ export const codecList: Array<Codec> = [
 
   // Data interchange formats
   yaml,
+  // @ts-ignore
   pandoc,
   json5,
   json
@@ -116,8 +117,14 @@ export interface Codec {
    *                 (Can be used by codecs that need to write more than one file when encoding)
    * @returns A promise that resolves to a `VFile`
    */
-  encode: (node: stencila.Node, filePath?: string) => Promise<VFile>
+  encode: (
+    node: stencila.Node,
+    filePath?: string,
+    format?: string
+  ) => Promise<VFile>
 }
+
+export type Encode = Codec['encode']
 
 /**
  * Match the codec based on file name, extension name, media type or by content sniffing.
@@ -222,11 +229,11 @@ export async function decode(
  * @param format The format to encode the node as.
  *               If undefined then determined from filePath or file path.
  */
-export async function encode(
+export const encode: Encode = async (
   node: stencila.Node,
   filePath?: string,
   format?: string
-): Promise<VFile> {
+): Promise<VFile> => {
   const codec = await match(filePath, format)
   return codec.encode(node, filePath)
 }

--- a/src/jats.ts
+++ b/src/jats.ts
@@ -5,6 +5,7 @@
  */
 
 import stencila from '@stencila/schema'
+import { Encode } from '.'
 import * as pandoc from './pandoc'
 import { VFile } from './vfile'
 
@@ -33,10 +34,10 @@ export async function decode(file: VFile): Promise<stencila.Node> {
   return pandoc.decode(file, pandoc.InputFormat.jats)
 }
 
-export async function encode(
+export const encode: Encode = async (
   node: stencila.Node,
   filePath?: string
-): Promise<VFile> {
+): Promise<VFile> => {
   return pandoc.encode(node, filePath, pandoc.OutputFormat.jats, [
     `--template=jats-template.xml`
   ])

--- a/src/jats.ts
+++ b/src/jats.ts
@@ -36,9 +36,11 @@ export async function decode(file: VFile): Promise<stencila.Node> {
 
 export const encode: Encode = async (
   node: stencila.Node,
-  filePath?: string
+  options = {}
 ): Promise<VFile> => {
-  return pandoc.encode(node, filePath, pandoc.OutputFormat.jats, [
-    `--template=jats-template.xml`
-  ])
+  return pandoc.encode(node, {
+    ...options,
+    format: pandoc.OutputFormat.jats,
+    codecOptions: { flags: [`--template=jats-template.xml`] }
+  })
 }

--- a/src/json.ts
+++ b/src/json.ts
@@ -3,6 +3,7 @@
  */
 
 import * as stencila from '@stencila/schema'
+import { Encode } from '.'
 import { dump, load, VFile } from './vfile'
 
 export const mediaTypes = ['application/json']
@@ -11,6 +12,6 @@ export async function decode(file: VFile): Promise<stencila.Node> {
   return JSON.parse(await dump(file))
 }
 
-export async function encode(node: stencila.Node): Promise<VFile> {
+export const encode: Encode = async (node: stencila.Node): Promise<VFile> => {
   return load(JSON.stringify(node, null, '  '))
 }

--- a/src/json5.ts
+++ b/src/json5.ts
@@ -31,6 +31,7 @@
 
 import stencila from '@stencila/schema'
 import json5 from 'json5'
+import { Encode } from '.'
 import { dump, load, VFile } from './vfile'
 
 /**
@@ -57,6 +58,6 @@ export async function decode(file: VFile): Promise<stencila.Node> {
  * @param thing The Stencila `Node` to encode
  * @returns A promise that resolves to a `VFile`
  */
-export async function encode(node: stencila.Node): Promise<VFile> {
+export const encode: Encode = async (node: stencila.Node): Promise<VFile> => {
   return load(json5.stringify(node, null, '  '))
 }

--- a/src/latex.ts
+++ b/src/latex.ts
@@ -3,6 +3,7 @@
  */
 
 import stencila from '@stencila/schema'
+import { Encode } from '.'
 import * as pandoc from './pandoc'
 import { VFile } from './vfile'
 
@@ -14,9 +15,9 @@ export async function decode(file: VFile): Promise<stencila.Node> {
   return pandoc.decode(file, pandoc.InputFormat.latex)
 }
 
-export async function encode(
+export const encode: Encode = async (
   node: stencila.Node,
   filePath?: string
-): Promise<VFile> {
+): Promise<VFile> => {
   return pandoc.encode(node, filePath, pandoc.OutputFormat.latex)
 }

--- a/src/latex.ts
+++ b/src/latex.ts
@@ -17,7 +17,10 @@ export async function decode(file: VFile): Promise<stencila.Node> {
 
 export const encode: Encode = async (
   node: stencila.Node,
-  filePath?: string
+  options = {}
 ): Promise<VFile> => {
-  return pandoc.encode(node, filePath, pandoc.OutputFormat.latex)
+  return pandoc.encode(node, {
+    ...options,
+    format: pandoc.OutputFormat.latex
+  })
 }

--- a/src/lib.d.ts
+++ b/src/lib.d.ts
@@ -1,15 +1,15 @@
 declare module 'png-chunks-extract' {
-  export type Chunk = { name: String; data: Uint8Array | Buffer }
+  export type Chunk = { name: string; data: Uint8Array | Buffer }
   export default function(data: Uint8Array | Buffer): Array<Chunk>
 }
 
 declare module 'png-chunks-encode' {
-  export type Chunk = { name: String; data: Uint8Array | Buffer }
+  export type Chunk = { name: string; data: Uint8Array | Buffer }
   export default function(chunks: Array<Chunk>): Uint8Array
 }
 
 declare module 'png-chunk-text' {
-  export type Chunk = { name: String; data: Uint8Array | Buffer }
+  export type Chunk = { name: string; data: Uint8Array | Buffer }
   type Value = string | object
 
   export function encode(key: string, value: Value): Chunk

--- a/src/md.ts
+++ b/src/md.ts
@@ -33,6 +33,7 @@ import * as UNIST from 'unist'
 import filter from 'unist-util-filter'
 // @ts-ignore
 import map from 'unist-util-map'
+import { Encode } from '.'
 import type from './util/type'
 import { dump, load, VFile } from './vfile'
 
@@ -97,7 +98,7 @@ export async function decode(file: VFile): Promise<stencila.Node> {
  * @param thing The `stencila.Node` to encode
  * @returns A promise that resolves to a `VFile`
  */
-export async function encode(node: stencila.Node): Promise<VFile> {
+export const encode: Encode = async (node: stencila.Node): Promise<VFile> => {
   let mdast = filter(
     encodeNode(node),
     (node: UNIST.Node | undefined) => typeof node !== 'undefined'

--- a/src/ods.ts
+++ b/src/ods.ts
@@ -3,6 +3,7 @@
  */
 
 import stencila from '@stencila/schema'
+import { Encode } from '.'
 import { VFile } from './vfile'
 import * as xlsx from './xlsx'
 
@@ -16,6 +17,6 @@ export async function decode(file: VFile): Promise<stencila.Node> {
   return xlsx.decode(file)
 }
 
-export async function encode(node: stencila.Node): Promise<VFile> {
+export const encode: Encode = async (node: stencila.Node): Promise<VFile> => {
   return xlsx.encode(node, undefined, 'ods')
 }

--- a/src/ods.ts
+++ b/src/ods.ts
@@ -18,5 +18,5 @@ export async function decode(file: VFile): Promise<stencila.Node> {
 }
 
 export const encode: Encode = async (node: stencila.Node): Promise<VFile> => {
-  return xlsx.encode(node, undefined, 'ods')
+  return xlsx.encode(node, { format: 'ods' })
 }

--- a/src/odt.ts
+++ b/src/odt.ts
@@ -17,7 +17,13 @@ export async function decode(file: VFile): Promise<stencila.Node> {
 
 export const encode: Encode = async (
   node: stencila.Node,
-  filePath?: string
+  options = {}
 ): Promise<VFile> => {
-  return pandoc.encode(node, filePath, pandoc.OutputFormat.odt, [], true)
+  return pandoc.encode(node, {
+    ...options,
+    format: pandoc.OutputFormat.odt,
+    codecOptions: {
+      ensureFile: true
+    }
+  })
 }

--- a/src/odt.ts
+++ b/src/odt.ts
@@ -3,6 +3,7 @@
  */
 
 import stencila from '@stencila/schema'
+import { Encode } from '.'
 import * as pandoc from './pandoc'
 import { VFile } from './vfile'
 
@@ -14,9 +15,9 @@ export async function decode(file: VFile): Promise<stencila.Node> {
   ])
 }
 
-export async function encode(
+export const encode: Encode = async (
   node: stencila.Node,
   filePath?: string
-): Promise<VFile> {
+): Promise<VFile> => {
   return pandoc.encode(node, filePath, pandoc.OutputFormat.odt, [], true)
 }

--- a/src/pandoc.ts
+++ b/src/pandoc.ts
@@ -50,13 +50,14 @@ export async function decode(
  * @param ensureFile Ensure that the output is a real file (ie. not stdout?)
  * @returns A promise that resolves to a `VFile`
  */
-export async function encode(
+//  TODO: Update interface to conform to Encode type
+export const encode = async (
   node: stencila.Node,
   filePath?: string,
   to: Pandoc.OutputFormat = Pandoc.OutputFormat.json,
   options: string[] = [],
   ensureFile: boolean = false
-): Promise<VFile> {
+): Promise<VFile> => {
   encodePromises = []
   const { standalone, pdoc } = encodeNode(node)
   await Promise.all(encodePromises)

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -9,7 +9,7 @@
  */
 
 import * as stencila from '@stencila/schema'
-import { dump } from './index'
+import { dump, Encode } from './index'
 import * as puppeteer from './puppeteer'
 import { load, VFile } from './vfile'
 
@@ -39,10 +39,10 @@ export const browser = puppeteer.page()
  * @param filePath The file system path to write the PDF to
  * @returns A promise that resolves to a `VFile`
  */
-export async function encode(
+export const encode: Encode = async (
   node: stencila.Node,
   filePath?: string
-): Promise<VFile> {
+): Promise<VFile> => {
   const html = await dump(node, 'html')
 
   const page = await browser()

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -9,7 +9,7 @@
  */
 
 import * as stencila from '@stencila/schema'
-import { dump, Encode } from './index'
+import { dump, Encode, EncodeOptions } from './index'
 import * as puppeteer from './puppeteer'
 import { load, VFile } from './vfile'
 
@@ -41,7 +41,7 @@ export const browser = puppeteer.page()
  */
 export const encode: Encode = async (
   node: stencila.Node,
-  filePath?: string
+  { filePath }: EncodeOptions = {}
 ): Promise<VFile> => {
   const html = await dump(node, 'html')
 

--- a/src/rpng.ts
+++ b/src/rpng.ts
@@ -21,7 +21,7 @@ import pngExtract, { Chunk } from 'png-chunks-extract'
 import punycode from 'punycode'
 import puppeteer from 'puppeteer'
 import { chromiumPath } from './boot'
-import { dump } from './index'
+import { dump, Encode } from './index'
 import { stencilaCSS } from './templates/stencila-css-template'
 import { load as loadVFile, VFile, write as writeVFile } from './vfile'
 
@@ -188,10 +188,10 @@ export function sniffDecodeSync(filePath: string): stencila.Node | undefined {
  * @param node The Stencila node to encode
  * @param filePath The file system path to write to
  */
-export async function encode(
+export const encode: Encode = async (
   node: stencila.Node,
   filePath?: string
-): Promise<VFile> {
+): Promise<VFile> => {
   // Generate HTML of the 'value' of the node, which depends on the
   // node type. In the future, we may make this part of the schema definitions
   // and have a `stencila.value()` function to retrieve the value for the node

--- a/src/rpng.ts
+++ b/src/rpng.ts
@@ -21,7 +21,7 @@ import pngExtract, { Chunk } from 'png-chunks-extract'
 import punycode from 'punycode'
 import puppeteer from 'puppeteer'
 import { chromiumPath } from './boot'
-import { dump, Encode } from './index'
+import { dump, Encode, EncodeOptions } from './index'
 import { stencilaCSS } from './templates/stencila-css-template'
 import { load as loadVFile, VFile, write as writeVFile } from './vfile'
 
@@ -190,7 +190,7 @@ export function sniffDecodeSync(filePath: string): stencila.Node | undefined {
  */
 export const encode: Encode = async (
   node: stencila.Node,
-  filePath?: string
+  { filePath }: EncodeOptions = {}
 ): Promise<VFile> => {
   // Generate HTML of the 'value' of the node, which depends on the
   // node type. In the future, we may make this part of the schema definitions

--- a/src/tdp.ts
+++ b/src/tdp.ts
@@ -18,7 +18,7 @@ import { getLogger } from '@stencila/logga'
 import stencila from '@stencila/schema'
 // @ts-ignore
 import datapackage from 'datapackage'
-import { Encode } from '.'
+import { Encode, EncodeOptions } from '.'
 import * as csv from './csv'
 import { create, dump, load, VFile } from './vfile'
 
@@ -74,7 +74,7 @@ export async function decode(file: VFile): Promise<stencila.Node> {
 
 export const encode: Encode = async (
   node: stencila.Node,
-  filePath?: string
+  { filePath }: EncodeOptions = {}
 ): Promise<VFile> => {
   let cw = node as stencila.CreativeWork
 

--- a/src/tdp.ts
+++ b/src/tdp.ts
@@ -18,6 +18,7 @@ import { getLogger } from '@stencila/logga'
 import stencila from '@stencila/schema'
 // @ts-ignore
 import datapackage from 'datapackage'
+import { Encode } from '.'
 import * as csv from './csv'
 import { create, dump, load, VFile } from './vfile'
 
@@ -71,10 +72,10 @@ export async function decode(file: VFile): Promise<stencila.Node> {
   return node
 }
 
-export async function encode(
+export const encode: Encode = async (
   node: stencila.Node,
   filePath?: string
-): Promise<VFile> {
+): Promise<VFile> => {
   let cw = node as stencila.CreativeWork
 
   // Create a package descriptor from meta-data

--- a/src/xlsx.ts
+++ b/src/xlsx.ts
@@ -10,6 +10,7 @@
 
 import stencila from '@stencila/schema'
 import * as xlsx from 'xlsx'
+import { Encode } from '.'
 import type from './util/type'
 import { load, VFile } from './vfile'
 
@@ -26,11 +27,11 @@ export async function decode(file: VFile): Promise<stencila.Node> {
   return decodeWorkbook(workbook)
 }
 
-export async function encode(
+export const encode: Encode = async (
   node: stencila.Node,
   filePath?: string,
   format: string = 'xlsx'
-): Promise<VFile> {
+): Promise<VFile> => {
   const workbook = encodeNode(node)
   const buffer = xlsx.write(workbook, {
     type: format === 'csv' ? 'string' : 'buffer',

--- a/src/xlsx.ts
+++ b/src/xlsx.ts
@@ -10,7 +10,7 @@
 
 import stencila from '@stencila/schema'
 import * as xlsx from 'xlsx'
-import { Encode } from '.'
+import { Encode, EncodeOptions } from '.'
 import type from './util/type'
 import { load, VFile } from './vfile'
 
@@ -29,8 +29,7 @@ export async function decode(file: VFile): Promise<stencila.Node> {
 
 export const encode: Encode = async (
   node: stencila.Node,
-  filePath?: string,
-  format: string = 'xlsx'
+  { format = 'xlsx' }: EncodeOptions = {}
 ): Promise<VFile> => {
   const workbook = encodeNode(node)
   const buffer = xlsx.write(workbook, {

--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -4,6 +4,7 @@
 
 import * as stencila from '@stencila/schema'
 import yaml from 'js-yaml'
+import { Encode } from '.'
 import { dump, load, VFile } from './vfile'
 
 export const mediaTypes = ['text/yaml']
@@ -13,7 +14,7 @@ export async function decode(file: VFile): Promise<stencila.Node> {
   return yaml.safeLoad(yml)
 }
 
-export async function encode(node: stencila.Node): Promise<VFile> {
+export const encode: Encode = async (node: stencila.Node): Promise<VFile> => {
   const yml = yaml.safeDump(node, {
     // "do not throw on invalid types (like function in the safe schema)
     // and skip pairs and single values with such types."

--- a/tests/csv.test.ts
+++ b/tests/csv.test.ts
@@ -99,7 +99,7 @@ test.skip('decode', async () => {
 })
 
 test('encode', async () => {
-  expect(await dump(await encode(simple.node))).toEqual(simple.content)
-  expect(await dump(await encode(named.node))).toEqual(named.content)
-  expect(await dump(await encode(formulas.node))).toEqual(formulas.content)
+  expect(await dump(await encode(simple.node, {}))).toEqual(simple.content)
+  expect(await dump(await encode(named.node, {}))).toEqual(named.content)
+  expect(await dump(await encode(formulas.node, {}))).toEqual(formulas.content)
 })

--- a/tests/demo-magic.test.ts
+++ b/tests/demo-magic.test.ts
@@ -9,9 +9,9 @@ test('decode', async () => {
 })
 
 test('encode', async () => {
-  expect(await dump(await encode(node, undefined, { embed: false }))).toEqual(
-    bash
-  )
+  expect(
+    await dump(await encode(node, { codecOptions: { embed: false } }))
+  ).toEqual(bash)
   expect(await encode(node)).toBeTruthy()
 })
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -31,7 +31,7 @@ describe('match', () => {
 
     // Required, but don't do anything
     decode: async (file: VFile) => null,
-    encode: async (node: stencila.Node, filePath?: string) => create()
+    encode: async (node: stencila.Node, options: {} = {}) => create()
   }
   codecList.push(ssf)
 
@@ -184,6 +184,7 @@ describe('convert', () => {
     it('returns a file path for "content-less" vfiles', async () => {
       const inp = `A paragraph\n`
       const out = tempy.file()
+      // tslint:disable-next-line: no-unnecessary-type-assertion
       const result = (await convert(inp, out, {
         from: 'md',
         to: 'docx'

--- a/tests/pandoc.test.ts
+++ b/tests/pandoc.test.ts
@@ -506,16 +506,27 @@ test('rpngs', async () => {
   // Generate the rPNGs
   const output = path.join(__dirname, 'output', 'pandoc-rpngs')
   fs.ensureDirSync(output)
-  const nullPng = await rpng.encode(null, path.join(output, 'null.png'))
-  const booleanPng = await rpng.encode(
-    boolean,
-    path.join(output, 'boolean.png')
-  )
-  const numberPng = await rpng.encode(number, path.join(output, 'number.png'))
-  const arrayPng = await rpng.encode(array, path.join(output, 'array.png'))
-  const objectPng = await rpng.encode(object, path.join(output, 'object.png'))
-  const thingPng = await rpng.encode(thing, path.join(output, 'thing.png'))
-  const personPng = await rpng.encode(person, path.join(output, 'person.png'))
+  const nullPng = await rpng.encode(null, {
+    filePath: path.join(output, 'null.png')
+  })
+  const booleanPng = await rpng.encode(boolean, {
+    filePath: path.join(output, 'boolean.png')
+  })
+  const numberPng = await rpng.encode(number, {
+    filePath: path.join(output, 'number.png')
+  })
+  const arrayPng = await rpng.encode(array, {
+    filePath: path.join(output, 'array.png')
+  })
+  const objectPng = await rpng.encode(object, {
+    filePath: path.join(output, 'object.png')
+  })
+  const thingPng = await rpng.encode(thing, {
+    filePath: path.join(output, 'thing.png')
+  })
+  const personPng = await rpng.encode(person, {
+    filePath: path.join(output, 'person.png')
+  })
 
   const pdoc: Pandoc.Document = {
     'pandoc-api-version': Pandoc.Version,

--- a/tests/pdf.test.ts
+++ b/tests/pdf.test.ts
@@ -11,7 +11,7 @@ test('decode', async () => {
 
 test('encode', async () => {
   const output = path.join(__dirname, 'output', 'pdf-encode.pdf')
-  const doc = await pdf.encode(articleSimple, output)
+  const doc = await pdf.encode(articleSimple, { filePath: output })
 
   expect(Buffer.isBuffer(doc.contents)).toBe(true)
   expect(doc.contents.slice(0, 5).toString()).toBe('%PDF-')


### PR DESCRIPTION
This PR changes and standardizes type signatures for `encode` functions within each codec.
It also adds some type safety to make sure that the methods are have the correct signature.
The immediate need for these changes was to allow for passing a `theme` argument for setting.