### PR TITLE
fix: Be more lenient with detecting output paths. Ref #90

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,7 @@ export async function match(
   let extName
   let mediaType
   // If the content is a path then begin with derived values
-  if (content && vfile.isPath(content, isOutput)) {
+  if (content && (vfile.isPath(content) || isOutput)) {
     fileName = path.basename(content)
     extName = path
       .extname(content)

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,17 +146,25 @@ export type CustomCodec<Options extends EncodeOptions = {}> = (
  * If the supplied format contains a forward slash then it is assumed to be a media type,
  * otherwise an extension name.
  *
+ * If trying to find a codec for an output, then `content` is more likely to be a path than
+ * actual content. This is passed through to `vfile.isPath` for detection.
+ *
  * @param content The content as a file path (e.g. `../folder/file.txt`) or raw content
  * @param format The format as a media type (e.g. `text/plain`) or extension name (e.g. `txt`)
+ * @param isOutput `true` if attempting to find a match for an output file
  * @returns A promise that resolves to the `Codec` to use
  */
-export async function match(content?: string, format?: string): Promise<Codec> {
+export async function match(
+  content?: string,
+  format?: string,
+  isOutput: boolean = false
+): Promise<Codec> {
   // Resolve variables used to match a codec...
   let fileName
   let extName
   let mediaType
   // If the content is a path then begin with derived values
-  if (content && vfile.isPath(content)) {
+  if (content && vfile.isPath(content, isOutput)) {
     fileName = path.basename(content)
     extName = path
       .extname(content)
@@ -247,7 +255,7 @@ export const encode: Encode = async (
   node: stencila.Node,
   { filePath, format }: EncodeOptions = {}
 ): Promise<VFile> => {
-  const codec = await match(filePath, format)
+  const codec = await match(filePath, format, true)
   return codec.encode(node, { filePath })
 }
 

--- a/src/vfile.ts
+++ b/src/vfile.ts
@@ -109,12 +109,22 @@ export async function write(vfile: VFile, path: string): Promise<void> {
  * For all other strings, this function does check for presence, returning `true`
  * if the file exists.
  *
+ * If we know this to be an output path (`isOutput` is true) then the path does
+ * not need to exist. If `content` looks like a path or file name (has a 1-5
+ * character extension) then assume it is a path.
+ *
  * @param content The string to assess.
+ * @param isOutput `true` if this is to be an output path.
  */
-export function isPath(content: string): boolean {
+export function isPath(content: string, isOutput: boolean = false): boolean {
   if (/^(\/)|(\\)|([A-Z]:\\)|(\.(\/|\\))|(\.\.(\/|\\))/.test(content)) {
     return true
   }
   if (fs.existsSync(content)) return true
+
+  if (isOutput) {
+    return /.+\.\w{1,5}$/.test(content)
+  }
+
   return false
 }

--- a/src/vfile.ts
+++ b/src/vfile.ts
@@ -97,7 +97,8 @@ export async function write(vfile: VFile, path: string): Promise<void> {
  * path. This function, assesses whether a file is a file system path or not.
  *
  * If the string starts with `/`, `./`, `../` (or Windows compatible backslash
- * equivalents as well as drive letter prefixed strings e.g. `C:\`)
+ * equivalents as well as drive letter prefixed strings e.g. `C:\`),
+ * or has a 1-5 character extension,
  * then it is assumed to be a path but the presence of the path is not checked.
  * The reason for not checking presence
  * here is because "if the content looks like a path then the user probably meant
@@ -109,22 +110,13 @@ export async function write(vfile: VFile, path: string): Promise<void> {
  * For all other strings, this function does check for presence, returning `true`
  * if the file exists.
  *
- * If we know this to be an output path (`isOutput` is true) then the path does
- * not need to exist. If `content` looks like a path or file name (has a 1-5
- * character extension) then assume it is a path.
- *
  * @param content The string to assess.
- * @param isOutput `true` if this is to be an output path.
  */
 export function isPath(content: string, isOutput: boolean = false): boolean {
   if (/^(\/)|(\\)|([A-Z]:\\)|(\.(\/|\\))|(\.\.(\/|\\))/.test(content)) {
     return true
   }
+  if (/.+\.\w{1,5}$/.test(content)) return true
   if (fs.existsSync(content)) return true
-
-  if (isOutput) {
-    return /.+\.\w{1,5}$/.test(content)
-  }
-
   return false
 }

--- a/tests/vfile.test.ts
+++ b/tests/vfile.test.ts
@@ -1,6 +1,7 @@
 import { isPath } from '../src/vfile'
 
 test('isPath', () => {
+  // Directory specified, with or without file extension
   expect(isPath('/')).toBe(true)
   expect(isPath('C:\\')).toBe(true)
   expect(isPath('/foo/bar.txt')).toBe(true)
@@ -12,19 +13,13 @@ test('isPath', () => {
   expect(isPath('..\\..\\')).toBe(true)
   expect(isPath('../../foo.txt')).toBe(true)
 
-  // A file local to where tests are executed that does exist
-  expect(isPath('package.json')).toBe(true)
-
-  expect(isPath('foo.txt')).toBe(false)
+  // Current directory
+  expect(isPath('foo.txt')).toBe(true)
+  expect(isPath('foo/bar.txt')).toBe(true)
   expect(isPath('a: foo')).toBe(false)
-  expect(isPath('foo/bar.txt')).toBe(false)
   expect(isPath('Foo bar baz')).toBe(false)
 
-  // if isPath is output path, then anything that looks like it has an
-  // extension is expected to path
-  expect(isPath('foo.txt', true)).toBe(true)
-  expect(isPath('a: foo', true)).toBe(false)
-  expect(isPath('foo/bar.txt', true)).toBe(true)
-  expect(isPath('Foo bar baz', true)).toBe(false)
-  expect(isPath('-', true)).toBe(false)
+  // A file local to where tests are executed that does exist
+  // but has no extension
+  expect(isPath('LICENSE')).toBe(true)
 })

--- a/tests/vfile.test.ts
+++ b/tests/vfile.test.ts
@@ -19,4 +19,12 @@ test('isPath', () => {
   expect(isPath('a: foo')).toBe(false)
   expect(isPath('foo/bar.txt')).toBe(false)
   expect(isPath('Foo bar baz')).toBe(false)
+
+  // if isPath is output path, then anything that looks like it has an
+  // extension is expected to path
+  expect(isPath('foo.txt', true)).toBe(true)
+  expect(isPath('a: foo', true)).toBe(false)
+  expect(isPath('foo/bar.txt', true)).toBe(true)
+  expect(isPath('Foo bar baz', true)).toBe(false)
+  expect(isPath('-', true)).toBe(false)
 })


### PR DESCRIPTION
I added an `isOuput` flag, which means `isPath` will be more lenient, since it's unlikely that we'd be passing content as the output argument on the command line (as per example in https://github.com/stencila/encoda/issues/90#issuecomment-499746559)