### PR TITLE
fix: Refactor puppeteer usage to be more explicit with shutdown handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5139,8 +5139,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5161,14 +5160,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5183,20 +5180,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5313,8 +5307,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5326,7 +5319,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5341,7 +5333,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5349,14 +5340,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5375,7 +5364,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5456,8 +5444,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5469,7 +5456,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5555,8 +5541,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5592,7 +5577,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5612,7 +5596,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5656,14 +5639,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -46,18 +46,22 @@ export const encode: Encode = async (
   const html = await dump(node, { ...options, format: 'html' })
 
   const page = await browser()
-  await page.setContent(html, { waitUntil: 'networkidle0' })
-  const buffer = await page.pdf({
-    path: options.filePath,
-    format: 'A4',
-    printBackground: true,
-    margin: {
-      top: '2.54cm',
-      bottom: '2.54cm',
-      left: '2.54cm',
-      right: '2.54cm'
-    }
-  })
+  try {
+    await page.setContent(html, { waitUntil: 'networkidle0' })
+    const buffer = await page.pdf({
+      path: options.filePath,
+      format: 'A4',
+      printBackground: true,
+      margin: {
+        top: '2.54cm',
+        bottom: '2.54cm',
+        left: '2.54cm',
+        right: '2.54cm'
+      }
+    })
 
-  return load(buffer)
+    return load(buffer)
+  } finally {
+    await browser('close')
+  }
 }

--- a/src/puppeteer.ts
+++ b/src/puppeteer.ts
@@ -39,12 +39,6 @@ export function page() {
     page = undefined
   }
 
-  // Always shutdown before exiting the Node process
-  // We use `beforeExit` because async operations are not supported
-  // by `exit`.
-  // See https://nodejs.org/api/process.html#process_event_beforeexit
-  process.on('beforeExit', shutdown)
-
   function thunk(): Promise<puppeteer.Page>
   function thunk(close: 'close'): Promise<void>
   function thunk(close?: 'close') {

--- a/src/rpng.ts
+++ b/src/rpng.ts
@@ -220,27 +220,32 @@ export const encode: Encode<EncodeRPNGOptions> = async (
   // Generate image of rendered HTML
   const page = await browser()
 
-  await page.setContent(
-    `<div id="target" style="${
-      fullPage ? '' : 'display: inline-block; padding: 0.1rem'
-    }">${html}</div>`,
-    {
-      waitUntil: 'networkidle0'
-    }
-  )
+  let buffer
 
-  const elem = await page.$('#target')
-  if (!elem) throw new Error('Element not found!')
+  try {
+    await page.setContent(
+      `<div id="target" style="${
+        fullPage ? '' : 'display: inline-block; padding: 0.1rem'
+      }">${html}</div>`,
+      {
+        waitUntil: 'networkidle0'
+      }
+    )
 
-  const buffer = fullPage
-    ? await page.screenshot({
-        encoding: 'binary',
-        fullPage: true
-      })
-    : await elem.screenshot({
-        encoding: 'binary'
-      })
+    const elem = await page.$('#target')
+    if (!elem) throw new Error('Element not found!')
 
+    buffer = fullPage
+      ? await page.screenshot({
+          encoding: 'binary',
+          fullPage: true
+        })
+      : await elem.screenshot({
+          encoding: 'binary'
+        })
+  } finally {
+    await browser('close')
+  }
   // Insert JSON of the thing into the image
   const json = JSON.stringify(node)
   const image = insert(KEYWORD, json, buffer)


### PR DESCRIPTION
Ref: #100 

In cases like this I find it better to be explicit with handling the shutdown of the browser. I have added an explicit shutdown call inside a `finally` block for rpng and pdf. 

This will probably slow down the repeated calls to open/close the browser when building RPNGs. Whether or not that will be a problem remains to be seen. If it is, we can refactor so the base Encoda caller handles the browser opening and closing and passes it into the RPNG encode function.