### PR TITLE
fix(HTML, RPNG, PDF): Adds `isBundle` encoding option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,10 +38,12 @@ import * as encoda from '.'
 import './boot'
 import * as puppeteer from './puppeteer'
 
-const { _, ...options } = minimist(process.argv.slice(2), {
-  boolean: ['fullPage'],
+let { _, ...options } = minimist(process.argv.slice(2), {
+  boolean: ['standalone', 'bundle'],
   default: {
-    fullPage: true
+    standalone: true,
+    bundle: false,
+    theme: 'stencila'
   }
 })
 const name = _[0]
@@ -60,6 +62,26 @@ logga.addHandler((data: logga.LogData) => {
 // @ts-ignore
 const func = encoda[name]
 if (!func) throw new Error(`No such function "${name}"`)
+
+if (name === 'convert') {
+  const {
+    to,
+    from,
+    standalone: isStandalone,
+    bundle: isBundle,
+    theme
+  } = options
+  options = {
+    to,
+    from,
+    encodeOptions: {
+      isStandalone,
+      isBundle,
+      theme
+    }
+  }
+}
+
 ;(async () => {
   // Call the function (which may, or may not be async)
   await func(...args, options)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,7 @@ import * as encoda from '.'
 import './boot'
 import * as puppeteer from './puppeteer'
 
-let { _, ...options } = minimist(process.argv.slice(2), {
+const { _, ...options } = minimist(process.argv.slice(2), {
   boolean: ['standalone', 'bundle'],
   default: {
     standalone: true,

--- a/src/html.ts
+++ b/src/html.ts
@@ -115,8 +115,8 @@ export const encode: Encode<EncodeHTMLOptions> = async (
 ): Promise<VFile> => {
   const { isStandalone = false, isBundle = false, theme = 'stencila' } = options
 
-  const nodetoEncode = isBundle ? await bundle(node) : node
-  const dom: HTMLHtmlElement = encodeNode(nodetoEncode, {
+  const nodeToEncode = isBundle ? await bundle(node) : node
+  const dom: HTMLHtmlElement = encodeNode(nodeToEncode, {
     isStandalone,
     theme
   }) as HTMLHtmlElement

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,9 @@ export const codecList: Array<Codec> = [
 export interface EncodeOptions<FormatOptions extends object = {}> {
   format?: string
   filePath?: string
+  isStandalone?: boolean
+  isBundle?: boolean
+  theme?: string
   codecOptions?: FormatOptions
 }
 
@@ -326,7 +329,7 @@ export async function write(
 interface ConvertOptions {
   to?: string
   from?: string
-  options?: EncodeOptions
+  encodeOptions?: EncodeOptions
 }
 
 /**
@@ -340,16 +343,16 @@ interface ConvertOptions {
 export async function convert(
   input: string,
   outputPath?: string,
-  { to, from, ...options }: ConvertOptions = { options: {} }
+  { to, from, encodeOptions }: ConvertOptions = {}
 ): Promise<string | undefined> {
   const inputFile = vfile.create(input)
   const node = await decode(inputFile, input, from)
-  const convertOpts = {
+
+  const outputFile = await encode(node, {
     format: to,
     filePath: outputPath,
-    codecOptions: options
-  }
-  const outputFile = await encode(node, convertOpts)
+    ...encodeOptions
+  })
   if (outputPath) await vfile.write(outputFile, outputPath)
   return outputFile.contents ? vfile.dump(outputFile) : outputFile.path
 }

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -11,6 +11,7 @@
 import * as stencila from '@stencila/schema'
 import { dump, Encode, EncodeOptions } from './index'
 import * as puppeteer from './puppeteer'
+import bundle from './util/bundle'
 import { load, VFile } from './vfile'
 
 /**
@@ -40,7 +41,8 @@ export const encode: Encode = async (
   node: stencila.Node,
   options: EncodeOptions = {}
 ): Promise<VFile> => {
-  const html = await dump(node, { ...options, format: 'html' })
+  const bundled = await bundle(node)
+  const html = await dump(bundled, { ...options, format: 'html' })
 
   const page = await puppeteer.page()
   await page.setContent(html, { waitUntil: 'networkidle0' })

--- a/src/util/bundle.ts
+++ b/src/util/bundle.ts
@@ -1,0 +1,46 @@
+import * as stencila from '@stencila/schema'
+import produce from 'immer'
+import * as dataUri from './dataUri'
+
+/**
+ * Walk a document tree and replace any links to local resources
+ * with data URIs.
+ *
+ * This is used to create standalone HTML pages
+ * as well as when using Puppeteer which does not
+ * load local resources for security reasons.
+ * See https://github.com/GoogleChrome/puppeteer/issues/1643.
+ *
+ * Currently only handles `MediaObject` nodes, but could be used for other
+ * node types in the future.
+ */
+export default async function bundle(
+  node: stencila.Node
+): Promise<stencila.Node> {
+  async function walk(node: any) {
+    if (node === null || typeof node !== 'object') return node
+
+    switch (node.type) {
+      case 'MediaObject':
+      case 'AudioObject':
+      case 'ImageObject':
+      case 'VideoObject':
+        const mediaObject = node as stencila.MediaObject
+        if (!mediaObject.contentUrl.startsWith('http')) {
+          const { dataUri: contentUrl } = await dataUri.fromFile(
+            mediaObject.contentUrl
+          )
+          return {
+            ...mediaObject,
+            contentUrl
+          }
+        }
+    }
+
+    for (const [key, child] of Object.entries(node)) {
+      node[key] = await walk(child)
+    }
+    return node
+  }
+  return await produce(node, walk)
+}


### PR DESCRIPTION
Also moves `isStandalone` and `theme` options to top level encoding options and refactors passing of options.

Closes #118 and #119.
