### PR TITLE
refactor(IPYNB): Use types generated from JSON Schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -682,43 +682,6 @@
         "@types/yargs": "^12.0.9"
       }
     },
-    "@jupyterlab/coreutils": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-2.2.1.tgz",
-      "integrity": "sha512-XkGMBXqEAnENC4fK/L3uEqqxyNUtf4TI/1XNDln7d5VOPHQJSBTbYlBAZ0AQotn2qbs4WqmV6icxje2ITVedqQ==",
-      "dev": true,
-      "requires": {
-        "@phosphor/algorithm": "^1.1.2",
-        "@phosphor/coreutils": "^1.3.0",
-        "@phosphor/disposable": "^1.1.2",
-        "@phosphor/signaling": "^1.2.2",
-        "ajv": "~5.1.6",
-        "comment-json": "^1.1.3",
-        "minimist": "~1.2.0",
-        "moment": "~2.21.0",
-        "path-posix": "~1.0.0",
-        "url-parse": "~1.4.3"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.1.6.tgz",
-          "integrity": "sha1-Sy8aGd7Ok9V6whYDfj6XkcfdFWQ=",
-          "dev": true,
-          "requires": {
-            "co": "^4.6.0",
-            "json-schema-traverse": "^0.3.0",
-            "json-stable-stringify": "^1.0.1"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-          "dev": true
-        }
-      }
-    },
     "@marionebl/sander": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz",
@@ -789,36 +752,6 @@
           "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
           "dev": true
         }
-      }
-    },
-    "@phosphor/algorithm": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.1.3.tgz",
-      "integrity": "sha512-+dkdYTBglR+qGnLVQdCvYojNZMGxf+xSl1Jeksha3pm7niQktSFz2aR5gEPu/nI5LM8T8slTpqE4Pjvq8P+IVA==",
-      "dev": true
-    },
-    "@phosphor/coreutils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@phosphor/coreutils/-/coreutils-1.3.1.tgz",
-      "integrity": "sha512-9OHCn8LYRcPU/sbHm5v7viCA16Uev3gbdkwqoQqlV+EiauDHl70jmeL7XVDXdigl66Dz0LI11C99XOxp+s3zOA==",
-      "dev": true
-    },
-    "@phosphor/disposable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/disposable/-/disposable-1.1.3.tgz",
-      "integrity": "sha512-yH5/HZzOyp37y+G/6X1hem3EfQCsUMtiStacG9W5F7mRsO4UuIXGxY3/XyJHAzy9UFrInOJD7alurQc/4wYhbQ==",
-      "dev": true,
-      "requires": {
-        "@phosphor/algorithm": "^1.1.3"
-      }
-    },
-    "@phosphor/signaling": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/signaling/-/signaling-1.2.3.tgz",
-      "integrity": "sha512-DMwS0m9OgfY5ljpTsklRQPUQpTyg4obz85FyImRDacUVxUVbas95djIDEbU4s1TMzdHBBO+gfki3V4giXUvXzw==",
-      "dev": true,
-      "requires": {
-        "@phosphor/algorithm": "^1.1.3"
       }
     },
     "@semantic-release/changelog": {
@@ -1514,6 +1447,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/cli-color": {
+      "version": "0.3.29",
+      "resolved": "https://registry.npmjs.org/@types/cli-color/-/cli-color-0.3.29.tgz",
+      "integrity": "sha1-yDpx/gLIx+HM7ASN1qJFjR9sluo=",
+      "dev": true
+    },
     "@types/escape-html": {
       "version": "0.0.20",
       "resolved": "https://registry.npmjs.org/@types/escape-html/-/escape-html-0.0.20.tgz",
@@ -1645,6 +1584,12 @@
         }
       }
     },
+    "@types/json-schema": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
+      "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+      "dev": true
+    },
     "@types/json5": {
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.30.tgz",
@@ -1689,6 +1634,15 @@
       "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
       "dev": true
     },
+    "@types/mz": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/mz/-/mz-0.0.32.tgz",
+      "integrity": "sha512-cy3yebKhrHuOcrJGkfwNHhpTXQLgmXSv1BX+4p32j+VUQ6aP2eJ5cL7OvGcAQx75fCTFaAIIAKewvqL+iwSd4g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.0.tgz",
@@ -1704,6 +1658,12 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.0.tgz",
       "integrity": "sha512-J5D3z703XTDIGQFYXsnU9uRCW9e9mMEFO0Kpe6kykyiboqziru/RlZ0hM2P+PKTG4NHG1SjLrqae/NrV2iJApQ==",
+      "dev": true
+    },
+    "@types/prettier": {
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.16.4.tgz",
+      "integrity": "sha512-MG7ExKBo7AQ5UrL1awyYLNinNM/kyXgE4iP4Ul9fB+T7n768Z5Xem8IZeP6Bna0xze8gkDly49Rgge2HOEw4xA==",
       "dev": true
     },
     "@types/puppeteer": {
@@ -1969,6 +1929,12 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
       "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+      "dev": true
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
       "dev": true
     },
     "anymatch": {
@@ -2873,6 +2839,28 @@
       "integrity": "sha512-uQWrpRm+iZZUCAp7ZZJQbd4Za9I3AjR/3YTjmcnAtkauaIm/T5CT6U8zVI6e60T6OANqBFAzuR9/HB3NzuZCRA==",
       "dev": true
     },
+    "cli-color": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.4.0.tgz",
+      "integrity": "sha512-xu6RvQqqrWEo6MPR1eixqGPywhYBHRs653F9jfXB2Hx4jdM/3WxiNE1vppRmxtMIfl16SFYTpYlrnqH/HsK/2w==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.1.1",
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "memoizee": "^0.4.14",
+        "timers-ext": "^0.1.5"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
+      }
+    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -3344,6 +3332,16 @@
       "dev": true,
       "requires": {
         "array-find-index": "^1.0.1"
+      }
+    },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
       }
     },
     "d3-time": {
@@ -3964,10 +3962,32 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es5-ext": {
+      "version": "0.10.50",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
+      "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "^1.0.0"
+      }
+    },
     "es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
     },
     "es6-promise": {
       "version": "4.2.6",
@@ -3980,6 +4000,28 @@
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-html": {
@@ -4194,6 +4236,16 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
     },
     "event-target-shim": {
       "version": "5.0.1",
@@ -4727,6 +4779,12 @@
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
       "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
     },
+    "format-util": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
+      "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU=",
+      "dev": true
+    },
     "fp-ts": {
       "version": "2.0.0-rc.4",
       "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.0.0-rc.4.tgz",
@@ -4801,8 +4859,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4823,14 +4880,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4845,20 +4900,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4975,8 +5027,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4988,7 +5039,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5003,7 +5053,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5011,14 +5060,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5037,7 +5084,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5118,8 +5164,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5131,7 +5176,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5217,8 +5261,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5254,7 +5297,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5274,7 +5316,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5318,14 +5359,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -7397,6 +7436,48 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
+    "json-schema-ref-parser": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
+      "integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^3.12.1",
+        "ono": "^4.0.11"
+      }
+    },
+    "json-schema-to-typescript": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-6.1.3.tgz",
+      "integrity": "sha512-6nG2EPSyu3Po0FYsMEw/RpJDd6dqBr8DYIbqPZsxrRFE8g0Mxzbt6L6vlKJYrcPe9707INivn4NPJfemlXSLKw==",
+      "dev": true,
+      "requires": {
+        "@types/cli-color": "^0.3.29",
+        "@types/json-schema": "^7.0.3",
+        "@types/lodash": "^4.14.121",
+        "@types/minimist": "^1.2.0",
+        "@types/mz": "0.0.32",
+        "@types/node": "^11.10.4",
+        "@types/prettier": "^1.16.1",
+        "cli-color": "^1.4.0",
+        "json-schema-ref-parser": "^6.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.11",
+        "minimist": "^1.2.0",
+        "mz": "^2.7.0",
+        "prettier": "^1.16.4",
+        "stdin": "0.0.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "11.13.15",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.15.tgz",
+          "integrity": "sha512-x6ypl5Uzly+j23hbxmMzf12Eb4lOhIEqQz0HuczpTUa1KIx1GpbN/o4E3aAED20UoEsdK0wvyY8QcffuWSLDkw==",
+          "dev": true
+        }
+      }
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -7790,6 +7871,15 @@
         "yallist": "^2.1.2"
       }
     },
+    "lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "~0.10.2"
+      }
+    },
     "macos-release": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.2.0.tgz",
@@ -7954,6 +8044,22 @@
           "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
           "dev": true
         }
+      }
+    },
+    "memoizee": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
+      "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.45",
+        "es6-weak-map": "^2.0.2",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.1",
+        "lru-queue": "0.1",
+        "next-tick": "1",
+        "timers-ext": "^0.1.5"
       }
     },
     "meow": {
@@ -8141,6 +8247,17 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "requires": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "nan": {
       "version": "2.13.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
@@ -8182,6 +8299,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
       "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=",
+      "dev": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
     "nice-try": {
@@ -12305,6 +12428,15 @@
         }
       }
     },
+    "ono": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
+      "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
+      "dev": true,
+      "requires": {
+        "format-util": "^1.0.3"
+      }
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -12571,12 +12703,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
-    },
-    "path-posix": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
-      "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8=",
       "dev": true
     },
     "path-type": {
@@ -13027,12 +13153,6 @@
         "object-assign": "^4.1.0",
         "strict-uri-encode": "^1.0.0"
       }
-    },
-    "querystringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
-      "dev": true
     },
     "quick-lru": {
       "version": "1.1.0",
@@ -13530,12 +13650,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
-    },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
     "resolve": {
@@ -14180,6 +14294,12 @@
         }
       }
     },
+    "stdin": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/stdin/-/stdin-0.0.1.tgz",
+      "integrity": "sha1-0wQZgarsPf28d6GzjWNy449ftx4=",
+      "dev": true
+    },
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
@@ -14470,6 +14590,24 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "thenify": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "dev": true,
+      "requires": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "dev": true,
+      "requires": {
+        "thenify": ">= 3.1.0 < 4"
+      }
+    },
     "throat": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
@@ -14495,6 +14633,16 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+    },
+    "timers-ext": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "dev": true,
+      "requires": {
+        "es5-ext": "~0.10.46",
+        "next-tick": "1"
+      }
     },
     "tiny-emitter": {
       "version": "2.1.0",
@@ -14955,6 +15103,12 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
+    "type": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.0.1.tgz",
+      "integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==",
+      "dev": true
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -15293,16 +15447,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
       "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg="
-    },
-    "url-parse": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
-      "dev": true,
-      "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
     },
     "url-parse-lax": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "xlsx": "^0.14.2"
   },
   "devDependencies": {
-    "@jupyterlab/coreutils": "^2.2.1",
     "@stencila/dev-config": "^1.0.5",
     "@stencila/typescript-boilerplate": "^1.1.1",
     "@types/async-lock": "^1.1.1",
@@ -92,6 +91,7 @@
     "delay": "^4.2.0",
     "dependency-check": "^3.3.0",
     "googleapis": "^40.0.0",
+    "json-schema-to-typescript": "^6.1.3",
     "markdown-toc": "^1.2.0",
     "typescript": "^3.5.2"
   },

--- a/src/codecs/ipynb/ipynb.test.ts
+++ b/src/codecs/ipynb/ipynb.test.ts
@@ -1,15 +1,15 @@
 import * as stencila from '@stencila/schema'
+import { dump, load } from '../../util/vfile'
 import {
   decode,
   decodeMultilineString,
   encode,
-  encodeMultilineString,
-  nbformat
+  encodeMultilineString
 } from './'
-import { dump, load } from '../../util/vfile'
+import nbformat4 from './nbformat-v4'
 
 test('decode', async () => {
-  const decode_ = async (ipynb: nbformat.INotebookContent) =>
+  const decode_ = async (ipynb: nbformat4.Notebook) =>
     await decode(await load(JSON.stringify(ipynb)))
 
   expect(await decode_(kitchenSink.ipynb)).toEqual(kitchenSink.node)
@@ -33,7 +33,7 @@ test('encode+decode MultilineString', () => {
 })
 
 interface TestCase {
-  ipynb: nbformat.INotebookContent
+  ipynb: nbformat4.Notebook
   node: stencila.Article
 }
 
@@ -65,7 +65,6 @@ const kitchenSink: TestCase = {
         outputs: [
           {
             text: 'Hello from Python 3',
-            metadata: {},
             output_type: 'stream',
             name: 'stdout'
           }

--- a/src/codecs/ipynb/nbformat-v3.d.ts
+++ b/src/codecs/ipynb/nbformat-v3.d.ts
@@ -1,0 +1,289 @@
+/* Generated from nbformat-v3.schema.json. Do not edit. See nbformat.js. */
+
+export type Output = Pyout | DisplayData | Stream | Pyerr
+
+/**
+ * IPython Notebook v3.0 JSON schema.
+ */
+export interface Notebook {
+  /**
+   * Notebook root-level metadata.
+   */
+  metadata: {
+    /**
+     * Kernel information.
+     */
+    kernel_info?: {
+      /**
+       * Name of the kernel specification.
+       */
+      name: string
+      /**
+       * The programming language which this kernel runs.
+       */
+      language: string
+      /**
+       * The codemirror mode to use for code in this language.
+       */
+      codemirror_mode?: string
+      [k: string]: any
+    }
+    /**
+     * Hash of the notebook.
+     */
+    signature?: string
+    [k: string]: any
+  }
+  /**
+   * Notebook format (minor number). Incremented for backward compatible changes to the notebook format.
+   */
+  nbformat_minor: number
+  /**
+   * Notebook format (major number). Incremented between backwards incompatible changes to the notebook format.
+   */
+  nbformat: number
+  /**
+   * Original notebook format (major number) before converting the notebook between versions.
+   */
+  orig_nbformat?: number
+  /**
+   * Original notebook format (minor number) before converting the notebook between versions.
+   */
+  orig_nbformat_minor?: number
+  /**
+   * Array of worksheets
+   */
+  worksheets: Worksheet[]
+}
+export interface Worksheet {
+  /**
+   * Array of cells of the current notebook.
+   */
+  cells: (RawCell | MarkdownCell | HeadingCell | CodeCell)[]
+  /**
+   * metadata of the current worksheet
+   */
+  metadata?: {
+    [k: string]: any
+  }
+}
+/**
+ * Notebook raw nbconvert cell.
+ */
+export interface RawCell {
+  /**
+   * String identifying the type of cell.
+   */
+  cell_type: 'raw'
+  /**
+   * Cell-level metadata.
+   */
+  metadata?: {
+    /**
+     * Raw cell metadata format for nbconvert.
+     */
+    format?: string
+    /**
+     * The cell's name. If present, must be a non-empty string.
+     */
+    name?: string
+    /**
+     * The cell's tags. Tags must be unique, and must not contain commas.
+     */
+    tags?: string[]
+    [k: string]: any
+  }
+  /**
+   * Contents of the cell, represented as an array of lines.
+   */
+  source: string | string[]
+}
+/**
+ * Notebook markdown cell.
+ */
+export interface MarkdownCell {
+  /**
+   * String identifying the type of cell.
+   */
+  cell_type: 'markdown' | 'html'
+  /**
+   * Cell-level metadata.
+   */
+  metadata?: {
+    /**
+     * The cell's name. If present, must be a non-empty string.
+     */
+    name?: string
+    /**
+     * The cell's tags. Tags must be unique, and must not contain commas.
+     */
+    tags?: string[]
+    [k: string]: any
+  }
+  /**
+   * Contents of the cell, represented as an array of lines.
+   */
+  source: string | string[]
+}
+/**
+ * Notebook heading cell.
+ */
+export interface HeadingCell {
+  /**
+   * String identifying the type of cell.
+   */
+  cell_type: 'heading'
+  /**
+   * Cell-level metadata.
+   */
+  metadata?: {
+    [k: string]: any
+  }
+  /**
+   * Contents of the cell, represented as an array of lines.
+   */
+  source: string | string[]
+  /**
+   * Level of heading cells.
+   */
+  level: number
+}
+/**
+ * Notebook code cell.
+ */
+export interface CodeCell {
+  /**
+   * String identifying the type of cell.
+   */
+  cell_type: 'code'
+  /**
+   * The cell's language (always Python)
+   */
+  language: string
+  /**
+   * Whether the cell is collapsed/expanded.
+   */
+  collapsed?: boolean
+  /**
+   * Cell-level metadata.
+   */
+  metadata?: {
+    [k: string]: any
+  }
+  /**
+   * Contents of the cell, represented as an array of lines.
+   */
+  input: string | string[]
+  /**
+   * Execution, display, or stream outputs.
+   */
+  outputs: Output[]
+  /**
+   * The code cell's prompt number. Will be null if the cell has not been run.
+   */
+  prompt_number?: number | null
+}
+/**
+ * Result of executing a code cell.
+ */
+export interface Pyout {
+  /**
+   * Type of cell output.
+   */
+  output_type: 'pyout'
+  /**
+   * A result's prompt number.
+   */
+  prompt_number: number
+  text?: string | string[]
+  latex?: string | string[]
+  png?: string | string[]
+  jpeg?: string | string[]
+  svg?: string | string[]
+  html?: string | string[]
+  javascript?: string | string[]
+  json?: string | string[]
+  pdf?: string | string[]
+  /**
+   * Cell output metadata.
+   */
+  metadata?: {
+    [k: string]: any
+  }
+  /**
+   * mimetype output (e.g. text/plain), represented as either an array of strings or a string.
+   *
+   * This interface was referenced by `Pyout`'s JSON-Schema definition
+   * via the `patternProperty` "^[a-zA-Z0-9]+/[a-zA-Z0-9\-\+\.]+$".
+   */
+  [k: string]: any
+}
+/**
+ * Data displayed as a result of code cell execution.
+ */
+export interface DisplayData {
+  /**
+   * Type of cell output.
+   */
+  output_type: 'display_data'
+  text?: string | string[]
+  latex?: string | string[]
+  png?: string | string[]
+  jpeg?: string | string[]
+  svg?: string | string[]
+  html?: string | string[]
+  javascript?: string | string[]
+  json?: string | string[]
+  pdf?: string | string[]
+  /**
+   * Cell output metadata.
+   */
+  metadata?: {
+    [k: string]: any
+  }
+  /**
+   * mimetype output (e.g. text/plain), represented as either an array of strings or a string.
+   *
+   * This interface was referenced by `DisplayData`'s JSON-Schema definition
+   * via the `patternProperty` "[a-zA-Z0-9]+/[a-zA-Z0-9\-\+\.]+$".
+   */
+  [k: string]: any
+}
+/**
+ * Stream output from a code cell.
+ */
+export interface Stream {
+  /**
+   * Type of cell output.
+   */
+  output_type: 'stream'
+  /**
+   * The stream type/destination.
+   */
+  stream: string
+  /**
+   * The stream's text output, represented as an array of strings.
+   */
+  text: string | string[]
+}
+/**
+ * Output of an error that occurred during code cell execution.
+ */
+export interface Pyerr {
+  /**
+   * Type of cell output.
+   */
+  output_type: 'pyerr'
+  /**
+   * The name of the error.
+   */
+  ename: string
+  /**
+   * The value, or message, of the error.
+   */
+  evalue: string
+  /**
+   * The error's traceback, represented as an array of strings.
+   */
+  traceback: string[]
+}

--- a/src/codecs/ipynb/nbformat-v3.schema.json
+++ b/src/codecs/ipynb/nbformat-v3.schema.json
@@ -1,0 +1,367 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "IPython Notebook v3.0 JSON schema.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["metadata", "nbformat_minor", "nbformat", "worksheets"],
+  "properties": {
+    "metadata": {
+      "description": "Notebook root-level metadata.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "kernel_info": {
+          "description": "Kernel information.",
+          "type": "object",
+          "required": ["name", "language"],
+          "properties": {
+            "name": {
+              "description": "Name of the kernel specification.",
+              "type": "string"
+            },
+            "language": {
+              "description": "The programming language which this kernel runs.",
+              "type": "string"
+            },
+            "codemirror_mode": {
+              "description": "The codemirror mode to use for code in this language.",
+              "type": "string"
+            }
+          }
+        },
+        "signature": {
+          "description": "Hash of the notebook.",
+          "type": "string"
+        }
+      }
+    },
+    "nbformat_minor": {
+      "description": "Notebook format (minor number). Incremented for backward compatible changes to the notebook format.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "nbformat": {
+      "description": "Notebook format (major number). Incremented between backwards incompatible changes to the notebook format.",
+      "type": "integer",
+      "minimum": 3,
+      "maximum": 3
+    },
+    "orig_nbformat": {
+      "description": "Original notebook format (major number) before converting the notebook between versions.",
+      "type": "integer",
+      "minimum": 1
+    },
+    "orig_nbformat_minor": {
+      "description": "Original notebook format (minor number) before converting the notebook between versions.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "worksheets": {
+      "description": "Array of worksheets",
+      "type": "array",
+      "items": { "$ref": "#/definitions/worksheet" }
+    }
+  },
+
+  "definitions": {
+    "worksheet": {
+      "additionalProperties": false,
+      "required": ["cells"],
+      "properties": {
+        "cells": {
+          "description": "Array of cells of the current notebook.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "oneOf": [
+              { "$ref": "#/definitions/raw_cell" },
+              { "$ref": "#/definitions/markdown_cell" },
+              { "$ref": "#/definitions/heading_cell" },
+              { "$ref": "#/definitions/code_cell" }
+            ]
+          }
+        },
+        "metadata": {
+          "type": "object",
+          "description": "metadata of the current worksheet"
+        }
+      }
+    },
+    "raw_cell": {
+      "description": "Notebook raw nbconvert cell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cell_type", "source"],
+      "properties": {
+        "cell_type": {
+          "description": "String identifying the type of cell.",
+          "enum": ["raw"]
+        },
+        "metadata": {
+          "description": "Cell-level metadata.",
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "format": {
+              "description": "Raw cell metadata format for nbconvert.",
+              "type": "string"
+            },
+            "name": { "$ref": "#/definitions/misc/metadata_name" },
+            "tags": { "$ref": "#/definitions/misc/metadata_tags" }
+          }
+        },
+        "source": { "$ref": "#/definitions/misc/source" }
+      }
+    },
+
+    "markdown_cell": {
+      "description": "Notebook markdown cell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cell_type", "source"],
+      "properties": {
+        "cell_type": {
+          "description": "String identifying the type of cell.",
+          "enum": ["markdown", "html"]
+        },
+        "metadata": {
+          "description": "Cell-level metadata.",
+          "type": "object",
+          "properties": {
+            "name": { "$ref": "#/definitions/misc/metadata_name" },
+            "tags": { "$ref": "#/definitions/misc/metadata_tags" }
+          },
+          "additionalProperties": true
+        },
+        "source": { "$ref": "#/definitions/misc/source" }
+      }
+    },
+
+    "heading_cell": {
+      "description": "Notebook heading cell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cell_type", "source", "level"],
+      "properties": {
+        "cell_type": {
+          "description": "String identifying the type of cell.",
+          "enum": ["heading"]
+        },
+        "metadata": {
+          "description": "Cell-level metadata.",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "source": { "$ref": "#/definitions/misc/source" },
+        "level": {
+          "description": "Level of heading cells.",
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+
+    "code_cell": {
+      "description": "Notebook code cell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cell_type", "input", "outputs", "language"],
+      "properties": {
+        "cell_type": {
+          "description": "String identifying the type of cell.",
+          "enum": ["code"]
+        },
+        "language": {
+          "description": "The cell's language (always Python)",
+          "type": "string"
+        },
+        "collapsed": {
+          "description": "Whether the cell is collapsed/expanded.",
+          "type": "boolean"
+        },
+        "metadata": {
+          "description": "Cell-level metadata.",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "input": { "$ref": "#/definitions/misc/source" },
+        "outputs": {
+          "description": "Execution, display, or stream outputs.",
+          "type": "array",
+          "items": { "$ref": "#/definitions/output" }
+        },
+        "prompt_number": {
+          "description": "The code cell's prompt number. Will be null if the cell has not been run.",
+          "type": ["integer", "null"],
+          "minimum": 0
+        }
+      }
+    },
+    "output": {
+      "type": "object",
+      "oneOf": [
+        { "$ref": "#/definitions/pyout" },
+        { "$ref": "#/definitions/display_data" },
+        { "$ref": "#/definitions/stream" },
+        { "$ref": "#/definitions/pyerr" }
+      ]
+    },
+    "pyout": {
+      "description": "Result of executing a code cell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["output_type", "prompt_number"],
+      "properties": {
+        "output_type": {
+          "description": "Type of cell output.",
+          "enum": ["pyout"]
+        },
+        "prompt_number": {
+          "description": "A result's prompt number.",
+          "type": ["integer"],
+          "minimum": 0
+        },
+        "text": { "$ref": "#/definitions/misc/multiline_string" },
+        "latex": { "$ref": "#/definitions/misc/multiline_string" },
+        "png": { "$ref": "#/definitions/misc/multiline_string" },
+        "jpeg": { "$ref": "#/definitions/misc/multiline_string" },
+        "svg": { "$ref": "#/definitions/misc/multiline_string" },
+        "html": { "$ref": "#/definitions/misc/multiline_string" },
+        "javascript": { "$ref": "#/definitions/misc/multiline_string" },
+        "json": { "$ref": "#/definitions/misc/multiline_string" },
+        "pdf": { "$ref": "#/definitions/misc/multiline_string" },
+        "metadata": { "$ref": "#/definitions/misc/output_metadata" }
+      },
+      "patternProperties": {
+        "^[a-zA-Z0-9]+/[a-zA-Z0-9\\-\\+\\.]+$": {
+          "description": "mimetype output (e.g. text/plain), represented as either an array of strings or a string.",
+          "$ref": "#/definitions/misc/multiline_string"
+        }
+      }
+    },
+
+    "display_data": {
+      "description": "Data displayed as a result of code cell execution.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["output_type"],
+      "properties": {
+        "output_type": {
+          "description": "Type of cell output.",
+          "enum": ["display_data"]
+        },
+        "text": { "$ref": "#/definitions/misc/multiline_string" },
+        "latex": { "$ref": "#/definitions/misc/multiline_string" },
+        "png": { "$ref": "#/definitions/misc/multiline_string" },
+        "jpeg": { "$ref": "#/definitions/misc/multiline_string" },
+        "svg": { "$ref": "#/definitions/misc/multiline_string" },
+        "html": { "$ref": "#/definitions/misc/multiline_string" },
+        "javascript": { "$ref": "#/definitions/misc/multiline_string" },
+        "json": { "$ref": "#/definitions/misc/multiline_string" },
+        "pdf": { "$ref": "#/definitions/misc/multiline_string" },
+        "metadata": { "$ref": "#/definitions/misc/output_metadata" }
+      },
+      "patternProperties": {
+        "[a-zA-Z0-9]+/[a-zA-Z0-9\\-\\+\\.]+$": {
+          "description": "mimetype output (e.g. text/plain), represented as either an array of strings or a string.",
+          "$ref": "#/definitions/misc/multiline_string"
+        }
+      }
+    },
+
+    "stream": {
+      "description": "Stream output from a code cell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["output_type", "stream", "text"],
+      "properties": {
+        "output_type": {
+          "description": "Type of cell output.",
+          "enum": ["stream"]
+        },
+        "stream": {
+          "description": "The stream type/destination.",
+          "type": "string"
+        },
+        "text": {
+          "description": "The stream's text output, represented as an array of strings.",
+          "$ref": "#/definitions/misc/multiline_string"
+        }
+      }
+    },
+
+    "pyerr": {
+      "description": "Output of an error that occurred during code cell execution.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["output_type", "ename", "evalue", "traceback"],
+      "properties": {
+        "output_type": {
+          "description": "Type of cell output.",
+          "enum": ["pyerr"]
+        },
+        "ename": {
+          "description": "The name of the error.",
+          "type": "string"
+        },
+        "evalue": {
+          "description": "The value, or message, of the error.",
+          "type": "string"
+        },
+        "traceback": {
+          "description": "The error's traceback, represented as an array of strings.",
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+
+    "misc": {
+      "metadata_name": {
+        "description": "The cell's name. If present, must be a non-empty string.",
+        "type": "string",
+        "pattern": "^.+$"
+      },
+      "metadata_tags": {
+        "description": "The cell's tags. Tags must be unique, and must not contain commas.",
+        "type": "array",
+        "uniqueItems": true,
+        "items": {
+          "type": "string",
+          "pattern": "^[^,]+$"
+        }
+      },
+      "source": {
+        "description": "Contents of the cell, represented as an array of lines.",
+        "$ref": "#/definitions/misc/multiline_string"
+      },
+      "prompt_number": {
+        "description": "The code cell's prompt number. Will be null if the cell has not been run.",
+        "type": ["integer", "null"],
+        "minimum": 0
+      },
+      "mimetype": {
+        "patternProperties": {
+          "^[a-zA-Z0-9\\-\\+]+/[a-zA-Z0-9\\-\\+]+": {
+            "description": "The cell's mimetype output (e.g. text/plain), represented as either an array of strings or a string.",
+            "$ref": "#/definitions/misc/multiline_string"
+          }
+        }
+      },
+      "output_metadata": {
+        "description": "Cell output metadata.",
+        "type": "object",
+        "additionalProperties": true
+      },
+      "multiline_string": {
+        "oneOf": [
+          { "type": "string" },
+          {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/codecs/ipynb/nbformat-v4.d.ts
+++ b/src/codecs/ipynb/nbformat-v4.d.ts
@@ -1,0 +1,327 @@
+/* Generated from nbformat-v4.schema.json. Do not edit. See nbformat.js. */
+
+export type Cell = RawCell | MarkdownCell | CodeCell
+export type Output = ExecuteResult | DisplayData | Stream | Error
+
+/**
+ * Jupyter Notebook v4.2 JSON schema.
+ */
+export interface Notebook {
+  /**
+   * Notebook root-level metadata.
+   */
+  metadata: {
+    /**
+     * Kernel information.
+     */
+    kernelspec?: {
+      /**
+       * Name of the kernel specification.
+       */
+      name: string
+      /**
+       * Name to display in UI.
+       */
+      display_name: string
+      [k: string]: any
+    }
+    /**
+     * Kernel information.
+     */
+    language_info?: {
+      /**
+       * The programming language which this kernel runs.
+       */
+      name: string
+      /**
+       * The codemirror mode to use for code in this language.
+       */
+      codemirror_mode?:
+        | string
+        | {
+            [k: string]: any
+          }
+      /**
+       * The file extension for files in this language.
+       */
+      file_extension?: string
+      /**
+       * The mimetype corresponding to files in this language.
+       */
+      mimetype?: string
+      /**
+       * The pygments lexer to use for code in this language.
+       */
+      pygments_lexer?: string
+      [k: string]: any
+    }
+    /**
+     * Original notebook format (major number) before converting the notebook between versions. This should never be written to a file.
+     */
+    orig_nbformat?: number
+    /**
+     * The title of the notebook document
+     */
+    title?: string
+    /**
+     * The author(s) of the notebook document
+     */
+    authors?: any[]
+    [k: string]: any
+  }
+  /**
+   * Notebook format (minor number). Incremented for backward compatible changes to the notebook format.
+   */
+  nbformat_minor: number
+  /**
+   * Notebook format (major number). Incremented between backwards incompatible changes to the notebook format.
+   */
+  nbformat: number
+  /**
+   * Array of cells of the current notebook.
+   */
+  cells: Cell[]
+}
+/**
+ * Notebook raw nbconvert cell.
+ */
+export interface RawCell {
+  /**
+   * String identifying the type of cell.
+   */
+  cell_type: 'raw'
+  /**
+   * Cell-level metadata.
+   */
+  metadata: {
+    /**
+     * Raw cell metadata format for nbconvert.
+     */
+    format?: string
+    /**
+     * Official Jupyter Metadata for Raw Cells
+     */
+    jupyter?: {
+      [k: string]: any
+    }
+    /**
+     * The cell's name. If present, must be a non-empty string. Cell names are expected to be unique across all the cells in a given notebook. This criterion cannot be checked by the json schema and must be established by an additional check.
+     */
+    name?: string
+    /**
+     * The cell's tags. Tags must be unique, and must not contain commas.
+     */
+    tags?: string[]
+    [k: string]: any
+  }
+  /**
+   * Media attachments (e.g. inline images), stored as mimebundle keyed by filename.
+   */
+  attachments?: {
+    /**
+     * The attachment's data stored as a mimebundle.
+     *
+     * This interface was referenced by `undefined`'s JSON-Schema definition
+     * via the `patternProperty` ".*".
+     */
+    [k: string]: {
+      /**
+       * mimetype output (e.g. text/plain), represented as either an array of strings or a string.
+       */
+      [k: string]: string | string[]
+    }
+  }
+  /**
+   * Contents of the cell, represented as an array of lines.
+   */
+  source: string | string[]
+}
+/**
+ * Notebook markdown cell.
+ */
+export interface MarkdownCell {
+  /**
+   * String identifying the type of cell.
+   */
+  cell_type: 'markdown'
+  /**
+   * Cell-level metadata.
+   */
+  metadata: {
+    /**
+     * The cell's name. If present, must be a non-empty string. Cell names are expected to be unique across all the cells in a given notebook. This criterion cannot be checked by the json schema and must be established by an additional check.
+     */
+    name?: string
+    /**
+     * The cell's tags. Tags must be unique, and must not contain commas.
+     */
+    tags?: string[]
+    /**
+     * Official Jupyter Metadata for Markdown Cells
+     */
+    jupyter?: {
+      [k: string]: any
+    }
+    [k: string]: any
+  }
+  /**
+   * Media attachments (e.g. inline images), stored as mimebundle keyed by filename.
+   */
+  attachments?: {
+    /**
+     * The attachment's data stored as a mimebundle.
+     *
+     * This interface was referenced by `undefined`'s JSON-Schema definition
+     * via the `patternProperty` ".*".
+     */
+    [k: string]: {
+      /**
+       * mimetype output (e.g. text/plain), represented as either an array of strings or a string.
+       */
+      [k: string]: string | string[]
+    }
+  }
+  /**
+   * Contents of the cell, represented as an array of lines.
+   */
+  source: string | string[]
+}
+/**
+ * Notebook code cell.
+ */
+export interface CodeCell {
+  /**
+   * String identifying the type of cell.
+   */
+  cell_type: 'code'
+  /**
+   * Cell-level metadata.
+   */
+  metadata: {
+    /**
+     * Official Jupyter Metadata for Code Cells
+     */
+    jupyter?: {
+      [k: string]: any
+    }
+    /**
+     * Whether the cell's output is collapsed/expanded.
+     */
+    collapsed?: boolean
+    /**
+     * Whether the cell's output is scrolled, unscrolled, or autoscrolled.
+     */
+    scrolled?: true | false | 'auto'
+    /**
+     * The cell's name. If present, must be a non-empty string. Cell names are expected to be unique across all the cells in a given notebook. This criterion cannot be checked by the json schema and must be established by an additional check.
+     */
+    name?: string
+    /**
+     * The cell's tags. Tags must be unique, and must not contain commas.
+     */
+    tags?: string[]
+    [k: string]: any
+  }
+  /**
+   * Contents of the cell, represented as an array of lines.
+   */
+  source: string | string[]
+  /**
+   * Execution, display, or stream outputs.
+   */
+  outputs: Output[]
+  /**
+   * The code cell's prompt number. Will be null if the cell has not been run.
+   */
+  execution_count: number | null
+}
+/**
+ * Result of executing a code cell.
+ */
+export interface ExecuteResult {
+  /**
+   * Type of cell output.
+   */
+  output_type: 'execute_result'
+  /**
+   * A result's prompt number.
+   */
+  execution_count: number | null
+  /**
+   * A mime-type keyed dictionary of data
+   */
+  data: {
+    /**
+     * mimetype output (e.g. text/plain), represented as either an array of strings or a string.
+     */
+    [k: string]: string | string[]
+  }
+  /**
+   * Cell output metadata.
+   */
+  metadata: {
+    [k: string]: any
+  }
+}
+/**
+ * Data displayed as a result of code cell execution.
+ */
+export interface DisplayData {
+  /**
+   * Type of cell output.
+   */
+  output_type: 'display_data'
+  /**
+   * A mime-type keyed dictionary of data
+   */
+  data: {
+    /**
+     * mimetype output (e.g. text/plain), represented as either an array of strings or a string.
+     */
+    [k: string]: string | string[]
+  }
+  /**
+   * Cell output metadata.
+   */
+  metadata: {
+    [k: string]: any
+  }
+}
+/**
+ * Stream output from a code cell.
+ */
+export interface Stream {
+  /**
+   * Type of cell output.
+   */
+  output_type: 'stream'
+  /**
+   * The name of the stream (stdout, stderr).
+   */
+  name: string
+  /**
+   * The stream's text output, represented as an array of strings.
+   */
+  text: string | string[]
+}
+/**
+ * Output of an error that occurred during code cell execution.
+ */
+export interface Error {
+  /**
+   * Type of cell output.
+   */
+  output_type: 'error'
+  /**
+   * The name of the error.
+   */
+  ename: string
+  /**
+   * The value, or message, of the error.
+   */
+  evalue: string
+  /**
+   * The error's traceback, represented as an array of strings.
+   */
+  traceback: string[]
+}

--- a/src/codecs/ipynb/nbformat-v4.schema.json
+++ b/src/codecs/ipynb/nbformat-v4.schema.json
@@ -1,0 +1,431 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Jupyter Notebook v4.2 JSON schema.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["metadata", "nbformat_minor", "nbformat", "cells"],
+  "properties": {
+    "metadata": {
+      "description": "Notebook root-level metadata.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "kernelspec": {
+          "description": "Kernel information.",
+          "type": "object",
+          "required": ["name", "display_name"],
+          "properties": {
+            "name": {
+              "description": "Name of the kernel specification.",
+              "type": "string"
+            },
+            "display_name": {
+              "description": "Name to display in UI.",
+              "type": "string"
+            }
+          }
+        },
+        "language_info": {
+          "description": "Kernel information.",
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "description": "The programming language which this kernel runs.",
+              "type": "string"
+            },
+            "codemirror_mode": {
+              "description": "The codemirror mode to use for code in this language.",
+              "oneOf": [{ "type": "string" }, { "type": "object" }]
+            },
+            "file_extension": {
+              "description": "The file extension for files in this language.",
+              "type": "string"
+            },
+            "mimetype": {
+              "description": "The mimetype corresponding to files in this language.",
+              "type": "string"
+            },
+            "pygments_lexer": {
+              "description": "The pygments lexer to use for code in this language.",
+              "type": "string"
+            }
+          }
+        },
+        "orig_nbformat": {
+          "description": "Original notebook format (major number) before converting the notebook between versions. This should never be written to a file.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "title": {
+          "description": "The title of the notebook document",
+          "type": "string"
+        },
+        "authors": {
+          "description": "The author(s) of the notebook document",
+          "type": "array",
+          "item": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    "nbformat_minor": {
+      "description": "Notebook format (minor number). Incremented for backward compatible changes to the notebook format.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "nbformat": {
+      "description": "Notebook format (major number). Incremented between backwards incompatible changes to the notebook format.",
+      "type": "integer",
+      "minimum": 4,
+      "maximum": 4
+    },
+    "cells": {
+      "description": "Array of cells of the current notebook.",
+      "type": "array",
+      "items": { "$ref": "#/definitions/cell" }
+    }
+  },
+
+  "definitions": {
+    "cell": {
+      "type": "object",
+      "oneOf": [
+        { "$ref": "#/definitions/raw_cell" },
+        { "$ref": "#/definitions/markdown_cell" },
+        { "$ref": "#/definitions/code_cell" }
+      ]
+    },
+
+    "raw_cell": {
+      "description": "Notebook raw nbconvert cell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cell_type", "metadata", "source"],
+      "properties": {
+        "cell_type": {
+          "description": "String identifying the type of cell.",
+          "enum": ["raw"]
+        },
+        "metadata": {
+          "description": "Cell-level metadata.",
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "format": {
+              "description": "Raw cell metadata format for nbconvert.",
+              "type": "string"
+            },
+            "jupyter": {
+              "description": "Official Jupyter Metadata for Raw Cells",
+              "type": "object",
+              "additionalProperties": true,
+              "source_hidden": {
+                "description": "Whether the source is hidden.",
+                "type": "boolean"
+              }
+            },
+            "name": { "$ref": "#/definitions/misc/metadata_name" },
+            "tags": { "$ref": "#/definitions/misc/metadata_tags" }
+          }
+        },
+        "attachments": { "$ref": "#/definitions/misc/attachments" },
+        "source": { "$ref": "#/definitions/misc/source" }
+      }
+    },
+
+    "markdown_cell": {
+      "description": "Notebook markdown cell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cell_type", "metadata", "source"],
+      "properties": {
+        "cell_type": {
+          "description": "String identifying the type of cell.",
+          "enum": ["markdown"]
+        },
+        "metadata": {
+          "description": "Cell-level metadata.",
+          "type": "object",
+          "properties": {
+            "name": { "$ref": "#/definitions/misc/metadata_name" },
+            "tags": { "$ref": "#/definitions/misc/metadata_tags" },
+            "jupyter": {
+              "description": "Official Jupyter Metadata for Markdown Cells",
+              "type": "object",
+              "additionalProperties": true,
+              "source_hidden": {
+                "description": "Whether the source is hidden.",
+                "type": "boolean"
+              }
+            }
+          },
+          "additionalProperties": true
+        },
+        "attachments": { "$ref": "#/definitions/misc/attachments" },
+        "source": { "$ref": "#/definitions/misc/source" }
+      }
+    },
+
+    "code_cell": {
+      "description": "Notebook code cell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "cell_type",
+        "metadata",
+        "source",
+        "outputs",
+        "execution_count"
+      ],
+      "properties": {
+        "cell_type": {
+          "description": "String identifying the type of cell.",
+          "enum": ["code"]
+        },
+        "metadata": {
+          "description": "Cell-level metadata.",
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "jupyter": {
+              "description": "Official Jupyter Metadata for Code Cells",
+              "type": "object",
+              "additionalProperties": true,
+              "source_hidden": {
+                "description": "Whether the source is hidden.",
+                "type": "boolean"
+              },
+              "outputs_hidden": {
+                "description": "Whether the outputs are hidden.",
+                "type": "boolean"
+              }
+            },
+            "collapsed": {
+              "description": "Whether the cell's output is collapsed/expanded.",
+              "type": "boolean"
+            },
+            "scrolled": {
+              "description": "Whether the cell's output is scrolled, unscrolled, or autoscrolled.",
+              "enum": [true, false, "auto"]
+            },
+            "name": { "$ref": "#/definitions/misc/metadata_name" },
+            "tags": { "$ref": "#/definitions/misc/metadata_tags" }
+          }
+        },
+        "source": { "$ref": "#/definitions/misc/source" },
+        "outputs": {
+          "description": "Execution, display, or stream outputs.",
+          "type": "array",
+          "items": { "$ref": "#/definitions/output" }
+        },
+        "execution_count": {
+          "description": "The code cell's prompt number. Will be null if the cell has not been run.",
+          "type": ["integer", "null"],
+          "minimum": 0
+        }
+      }
+    },
+
+    "unrecognized_cell": {
+      "description": "Unrecognized cell from a future minor-revision to the notebook format.",
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["cell_type", "metadata"],
+      "properties": {
+        "cell_type": {
+          "description": "String identifying the type of cell.",
+          "not": {
+            "enum": ["markdown", "code", "raw"]
+          }
+        },
+        "metadata": {
+          "description": "Cell-level metadata.",
+          "type": "object",
+          "properties": {
+            "name": { "$ref": "#/definitions/misc/metadata_name" },
+            "tags": { "$ref": "#/definitions/misc/metadata_tags" }
+          },
+          "additionalProperties": true
+        }
+      }
+    },
+
+    "output": {
+      "type": "object",
+      "oneOf": [
+        { "$ref": "#/definitions/execute_result" },
+        { "$ref": "#/definitions/display_data" },
+        { "$ref": "#/definitions/stream" },
+        { "$ref": "#/definitions/error" }
+      ]
+    },
+
+    "execute_result": {
+      "description": "Result of executing a code cell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["output_type", "data", "metadata", "execution_count"],
+      "properties": {
+        "output_type": {
+          "description": "Type of cell output.",
+          "enum": ["execute_result"]
+        },
+        "execution_count": {
+          "description": "A result's prompt number.",
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "data": { "$ref": "#/definitions/misc/mimebundle" },
+        "metadata": { "$ref": "#/definitions/misc/output_metadata" }
+      }
+    },
+
+    "display_data": {
+      "description": "Data displayed as a result of code cell execution.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["output_type", "data", "metadata"],
+      "properties": {
+        "output_type": {
+          "description": "Type of cell output.",
+          "enum": ["display_data"]
+        },
+        "data": { "$ref": "#/definitions/misc/mimebundle" },
+        "metadata": { "$ref": "#/definitions/misc/output_metadata" }
+      }
+    },
+
+    "stream": {
+      "description": "Stream output from a code cell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["output_type", "name", "text"],
+      "properties": {
+        "output_type": {
+          "description": "Type of cell output.",
+          "enum": ["stream"]
+        },
+        "name": {
+          "description": "The name of the stream (stdout, stderr).",
+          "type": "string"
+        },
+        "text": {
+          "description": "The stream's text output, represented as an array of strings.",
+          "$ref": "#/definitions/misc/multiline_string"
+        }
+      }
+    },
+
+    "error": {
+      "description": "Output of an error that occurred during code cell execution.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["output_type", "ename", "evalue", "traceback"],
+      "properties": {
+        "output_type": {
+          "description": "Type of cell output.",
+          "enum": ["error"]
+        },
+        "ename": {
+          "description": "The name of the error.",
+          "type": "string"
+        },
+        "evalue": {
+          "description": "The value, or message, of the error.",
+          "type": "string"
+        },
+        "traceback": {
+          "description": "The error's traceback, represented as an array of strings.",
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+
+    "unrecognized_output": {
+      "description": "Unrecognized output from a future minor-revision to the notebook format.",
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["output_type"],
+      "properties": {
+        "output_type": {
+          "description": "Type of cell output.",
+          "not": {
+            "enum": ["execute_result", "display_data", "stream", "error"]
+          }
+        }
+      }
+    },
+
+    "misc": {
+      "metadata_name": {
+        "description": "The cell's name. If present, must be a non-empty string. Cell names are expected to be unique across all the cells in a given notebook. This criterion cannot be checked by the json schema and must be established by an additional check.",
+        "type": "string",
+        "pattern": "^.+$"
+      },
+      "metadata_tags": {
+        "description": "The cell's tags. Tags must be unique, and must not contain commas.",
+        "type": "array",
+        "uniqueItems": true,
+        "items": {
+          "type": "string",
+          "pattern": "^[^,]+$"
+        }
+      },
+      "attachments": {
+        "description": "Media attachments (e.g. inline images), stored as mimebundle keyed by filename.",
+        "type": "object",
+        "patternProperties": {
+          ".*": {
+            "description": "The attachment's data stored as a mimebundle.",
+            "$ref": "#/definitions/misc/mimebundle"
+          }
+        }
+      },
+      "source": {
+        "description": "Contents of the cell, represented as an array of lines.",
+        "$ref": "#/definitions/misc/multiline_string"
+      },
+      "execution_count": {
+        "description": "The code cell's prompt number. Will be null if the cell has not been run.",
+        "type": ["integer", "null"],
+        "minimum": 0
+      },
+      "mimebundle": {
+        "description": "A mime-type keyed dictionary of data",
+        "type": "object",
+        "additionalProperties": {
+          "description": "mimetype output (e.g. text/plain), represented as either an array of strings or a string.",
+          "$ref": "#/definitions/misc/multiline_string"
+        },
+        "patternProperties": {
+          "^application/(.*\\+)?json$": {
+            "description": "Mimetypes with JSON output, can be any type"
+          }
+        }
+      },
+      "output_metadata": {
+        "description": "Cell output metadata.",
+        "type": "object",
+        "additionalProperties": true
+      },
+      "multiline_string": {
+        "oneOf": [
+          { "type": "string" },
+          {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/codecs/ipynb/nbformat.js
+++ b/src/codecs/ipynb/nbformat.js
@@ -1,0 +1,39 @@
+/**
+ * A script to convert Jupyter Notebook's JSON Schema into Typescript definitions.
+ *
+ * The `nbformat-vX.schema.json` files were obtained from:
+ *    - https://github.com/jupyter/nbformat/blob/master/nbformat/v3/nbformat.v3.schema.json
+ *    - https://github.com/jupyter/nbformat/blob/master/nbformat/v4/nbformat.v4.schema.json
+ *
+ * To regenerate files:
+ *
+ * ```bash
+ * node nbformat.js
+ * ```
+ */
+
+const fs = require('fs-extra')
+const { compile } = require('json-schema-to-typescript')
+
+;(async () => {
+  for (const version of ['v3', 'v4']) {
+    const source = `nbformat-${version}.schema.json`
+    const schema = await fs.readJSON(source)
+    let ts = await compile(schema, 'Notebook', {
+      bannerComment: `/* Generated from ${source}. Do not edit. See nbformat.js. */\n`,
+      style: { semi: false, singleQuote: true }
+    })
+    if (version == 'v3') {
+      /**
+       * Correct the `patternProperty` type in `Pyout` and `DisplayData` which needs to
+       * allow for other properties e.g. `prompt_number`, `text`, `latex` etc
+       * properties being optional i.e. `undefined`, or of other types e.g. `number`
+       */
+      ts = ts.replace(
+        /  \[k: string\]: string \| string\[\]/g,
+        '  [k: string]: any'
+      )
+    }
+    await fs.writeFile(`nbformat-${version}.d.ts`, ts)
+  }
+})()


### PR DESCRIPTION
This refactors the  `ipynb` codec to use Jupyter type definitions generated directly from JSON Schema, rather than those in `@jupyter/coreutils` (which, at present, deviate from the JSON Schema). It replaces #132. Incorporating the JSON Schema for Jupyter will also allow runtime validation of notebooks during I/O.