### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,14 +143,14 @@ npm run cover
 Or, manually test conversion using the `ts-node` and the `cli.ts` script:
 
 ```bash
-npx ts-node --files src/cli convert tests/fixtures/datatable/simple/simple.csv --to yaml
+npx ts-node --files src/cli convert simple.md simple.html
 ```
 
 If that is a bit slow, compile the Typescript to Javascript first and use `node` directly:
 
 ```bash
 npm run build
-node dist/cli convert tests/fixtures/datatable/simple/simple.csv --to yaml
+node dist/cli convert simple.md simple.html
 ```
 
 There's also a `Makefile` if you prefer to run tasks that way e.g.


### PR DESCRIPTION
`node dist/cli.js convert hello.md --to html` raises

```
(node:19924) UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type object
    at validateString (internal/validators.js:125:11)
    at Object.basename (path.js:1171:5)
    at match (/home/raniere/src/encoda/dist/index.js:79:35)
    at Object.exports.encode (/home/raniere/src/encoda/dist/index.js:171:25)
    at convert (/home/raniere/src/encoda/dist/index.js:234:38)
(node:19924) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:19924) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

because the output filename is missing.

`node dist/cli.js convert hello.md hello.html --to htm` works as expected.