### PR TITLE
Fix Pandoc DOCX template path

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "check:deps-used": "dependency-check --missing .",
     "check:deps-unused": "dependency-check --unused --no-dev --ignore-module @stencila/schema --ignore-module @stencila/thema .",
     "cli": "npx ts-node --files src/cli",
-    "build": "tsc && cp -r src/codecs/pandoc/templates/ dist/codecs/pandoc/",
+    "build": "tsc && cp -r src/codecs/pandoc/templates/. dist/codecs/pandoc/templates/",
     "docs": "npm run docs:readme && npm run docs:dogfood && npm run docs:ts",
     "docs:readme": "markdown-toc -i --maxdepth=4 README.md",
     "docs:dogfood": "npx ts-node --files docs.ts",


### PR DESCRIPTION
Follow up to https://github.com/stencila/encoda/commit/945b921392d78408d05a90573739eaf27b0859e4

Previously converting to docx straight from source would work:
``` sh
npx ts-node --files src/cli.ts convert --from html "<p>test</p>"  --to DOCX test.docx
```

but from the compiled code would fail:
``` sh
node dist/cli.js convert --from html "<p>test</p>"  --to DOCX test.docx
```