### PR TITLE
docs(HTML Readme): Add proposed microdata details

### DIFF
--- a/src/codecs/html/README.md
+++ b/src/codecs/html/README.md
@@ -108,8 +108,16 @@ Some of the main external dependencies:
         * values: `td`
         * schema (items, uniqueItems): `data`? (maybe unnecessary for styling)
         * name: `th`?
+* SoftwareSourceCode:
+    * codeRepository: `a href`
+    * codeSampleType: `data`?
+    * maintainers: `ol` of `span` Person/Organization itemtypes
+    * programmingLanguage: `data` or `span` (maybe unnecessary for styling)
+    * runtimePlatform: `ol` of `data` or `span`
+    * softwareRequirements: `ol` of `span` SoftwareSourceCode/SoftwareApplication
+    * targetProducts: `ol` of `span` SoftwareApplication
 
-### Schema nodes we won't be adding microdata to
+### Schema nodes with direct mapping to semantic tags
 * Delete: `del`
 * Emphasis: `em`
 * Heading: 
@@ -119,8 +127,37 @@ Some of the main external dependencies:
 * Link: `a`
     * content
     * target => href
-* List: `ol`, `ul` (with `input type="checkbox"` option)
+* List: `ol`, `ul` 
+  * ListItem => `li` (with `li` > `input type="checkbox"` option)
 * Quote
-* Strong
-* Subscript
-* Superscript
+* Strong => `strong`
+* Subscript => `sub`
+* Superscript => `sup`
+* Table => `table`. `table` > `tr`, or `table` > `thead`/`tfoot` > `tr`
+    * TableRow => `tr`.
+        * `kind`: header => `thead` > `tr`
+        * `kind`: footer => `tfoot` > `tr`
+    * TableCell => `th`, `td`
+        * `colspan`, `rowspan`
+        * `kind`: header => `th`
+        * `kind`: data => `td`
+* ThematicBreak: `hr`? (not sure if we should consider other options, such as splitting nodes by ThematicBreaks and grouping them into `section` tags instead)
+* VideoObject: `video`
+    * caption => `track`
+    * thumbnail => poster (attribute)
+    * transcript => `track`? (not sure if different from caption)
+
+### Schema nodes we won't be adding microdata to
+* BlockContent
+* CodeBlock?
+* CreativeWorkTypes
+* Entity
+* Environment?
+* Include?
+    * source
+    * mediaType
+    * hash
+    * content
+* InlineContent
+* Mark
+* Thing

--- a/src/codecs/html/README.md
+++ b/src/codecs/html/README.md
@@ -45,16 +45,11 @@ Some of the main external dependencies:
 
 ### Schema nodes to add microdata to
 * Article
-    * `div` `itemtype='schema:Article'`
+    * `article` `itemtype='schema:Article'`
     * itemprops:
         * authors* (author?): `ol`
         * title*: `h1`? (+ `title`)
         * environment: `data`?
-* Audio
-    * `audio`
-    * itemprops:
-        * caption*: `figcaption`
-        * transcript
 * Brand
     * `picture`/`img` `itemtype='schema:Brand'`
     * itemprops:
@@ -62,22 +57,23 @@ Some of the main external dependencies:
         * logo*: `source`/`image`
         * reviews
 * Code
-    * `div` `itemtype='stencila:Code'`
+    * `code` `itemtype='stencila:Code'`
     * itemprops:
         * language* (maybe important for setting syntax highlighting): `data`
-        * value*: `code`
+        * value*: set as `code` textContent
 * CodeChunk
-    * `div` `itemtype='stencila:CodeChunk'`
+    * `<pre><code>...</code></pre>` `itemtype='stencila:CodeChunk'`
     * itemprops:
-        * outputs: `ol` of `samp`/`output` (possibly include `figure`/`table`)
+        * outputs: `pre` containing `samp`/`output` (see https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element)
+            * In future, consider including `figure`/`table`
 * CodeExpression
-    * `div` `itemtype='stencila:CodeExpr'`
+    * `code` `itemtype='stencila:CodeExpr'`
     * itemprops:
-        * value:`code` (syntax highlighting from Code node's language prop)
+        * value: set as `code` textContent (syntax highlighting from SoftwareSourceCode node's programmingLanguage prop)
 * Collection
-    * `nav` `itemtype='schema:Collection'`
+    * `ol` `itemtype='schema:Collection'`
     * itemprops:
-        * parts: `ol` of CreativeWorks/Articles (just title, author, and URIs/relative links?)
+        * parts: `li > a href` CreativeWorks/Articles (just title, author, and URIs/relative links?)
 * ContactPoint
     * `address` `itemtype='schema:contactPoint'`
     * itemprops:
@@ -118,6 +114,9 @@ Some of the main external dependencies:
     * targetProducts: `ol` of `span` SoftwareApplication
 
 ### Schema nodes with direct mapping to semantic tags
+* AudioObject: `audio`
+    * name: `figcaption`, or `p`
+    * caption, transcript => `track` (if `video`), or `data`. [Consider using `video` instead of `audio` to enable captions](https://www.iandevlin.com/blog/2015/12/html5/webvtt-and-audio/), or display separately as `div`.
 * Delete: `del`
 * Emphasis: `em`
 * Heading: 
@@ -145,7 +144,7 @@ Some of the main external dependencies:
 * VideoObject: `video`
     * caption => `track`
     * thumbnail => poster (attribute)
-    * transcript => `track`? (not sure if different from caption)
+    * transcript => `track`?
 
 ### Schema nodes we won't be adding microdata to
 * BlockContent

--- a/src/codecs/html/README.md
+++ b/src/codecs/html/README.md
@@ -56,11 +56,27 @@ Some of the main external dependencies:
         * name: maybe unnecessary, just use in alt tag?
         * logo*: `source`/`image`
         * reviews
+* Cite
+    * `ul` `itemtype='stencila:Cite'`
+    * itemprops:
+        * citationMode: `data`? (maybe unnecessary for styling)
+        * pageStart: `span`
+        * pageEnd: `span`
+        * pagination: `span`
+        * prefix: `span`
+        * suffix: `span`
+        * target: `a href`
+        * authors: (not listed in schema, but seems necessary) `ol`
+        * title: (not listed in schema, but seems necessary) `span`
+* CiteGroup
+    * `ol` `itemtype='stencila:CiteGroup'`
+    * itemprops:
+        * items: `li ul` for each Cite (see above)
 * Code
     * `code` `itemtype='stencila:Code'`
+        * value*: set as `code` textContent
     * itemprops:
         * language* (maybe important for setting syntax highlighting): `data`
-        * value*: set as `code` textContent
 * CodeChunk
     * `<pre><code>...</code></pre>` `itemtype='stencila:CodeChunk'`
     * itemprops:
@@ -68,7 +84,6 @@ Some of the main external dependencies:
             * In future, consider including `figure`/`table`
 * CodeExpression
     * `code` `itemtype='stencila:CodeExpr'`
-    * itemprops:
         * value: set as `code` textContent (syntax highlighting from SoftwareSourceCode node's programmingLanguage prop)
 * Collection
     * `ol` `itemtype='schema:Collection'`
@@ -83,18 +98,18 @@ Some of the main external dependencies:
 * CreativeWork:
     * `div` `itemtype='schema:CreativeWork'`
     * itemprops:
-        * authors: `ol` of `span` Person/Organization itemtypes.
-        * citations: `ol` of title/authors/`a href`
+        * authors: `ol` of `span` Person `name` (or combined `givenNames`+`familyNames`)/Organization `legalName`.
+        * references: `ol itemprop='stencila:CiteGroup'` of `li ul` Cite itemtypes (see above) with `ol` authors, `a href` target, `span` title
         * content: `article`/`div` with `sections`
         * dateCreated: `span time`
         * dateModified: `span time`
         * datePublished/date: `span time`
-        * editors: `ol` of `span` Person itemtypes
-        * funders: `ol` of `span` Person/Organization itemtypes
+        * editors: `ol` of `span` Person `name` (or combined `givenNames`+`familyNames`)
+        * funders: `ol` of `span` Person `name` (or combined `givenNames`+`familyNames`)/Organization `legalName`.
         * isPartOf: `data`?
         * licenses: `ol` of `a href`
         * parts/hasPart: `ol` of figure/table/object/URI (maybe unnecessary for styling)
-        * publisher: `span` Person/Organization itemtype
+        * publisher: `span` Person `name` (or combined `givenNames`+`familyNames`)/Organization `legalName`.
         * text: `data`? (maybe unnecessary for styling)
         * title/headline: `h1`
         * version: `span`
@@ -104,10 +119,57 @@ Some of the main external dependencies:
         * values: `td`
         * schema (items, uniqueItems): `data`? (maybe unnecessary for styling)
         * name: `th`?
+* Organization:
+    * `div` `itemtype='schema:Organization'`
+    * legalName: set as `div` textContent
+    * Need to determine which itemprops are important to show. Maybe just `address`, `brand`, `departments`, and `legalName`.
+    * itemprops:
+        * address: `address` `itemprop='schema:address'`
+        * brands: `ul` of `picture`/`img` (see `Brand` above)
+        * contactPoints: `ul` of `li address` (see `ContactPoint` above)
+        * departments: `ul` of `span` Organization `legalName`
+        * funders: `data`? (maybe unnecessary for styling, since `funders` included seperately in CreativeWork)
+        * parentOrganization: `data`? (maybe unnecessary for styling)
+* Periodical:
+    * dateStart, dateEnd: `data`? (maybe unnecessary for styling)
+    * issn: `p`
+* Person:
+    * `div` `itemtype='schema:Person'`
+    * Need to determine which itemprops are important to show. Maybe just `affiliations`, `familyNames`, `givenNames`, `name`, `honorificPrefix`, `honorificSuffix`, and `jobTitle`.
+    * itemprops:
+        * address: `address` `itemprop='schema:address'` or `data`? (maybe unnecessary for styling)
+        * affiliations: `ul` of `span` Organization `legalName` + `departments`
+        * emails: `data`? (maybe unnecessary for styling)
+        * familyNames: `ul` of `span`
+        * funders: `data`? (maybe unnecessary for styling)
+        * givenNames: `ul` of `span`
+        * honorificPrefix: `span`
+        * honorificSuffix: `span`
+        * jobTitle: `span`
+        * memberOf: `ul` of `span` Organization `legalName` + `departments`, or `data`? (maybe unnecessary for styling)
+        * telephoneNumbers: `data`? (maybe unnecessary for styling)
+* PublicationIssue:
+    * `ul` `itemtype='stencila:PublicationIssue'`
+    * itemprops:
+        * issueNumber: `span`
+        * pageStart: `span`
+        * pageEnd: `span`
+        * pagination: `span`
+        * authors: `ol` of `span` Person `name` (or combined `givenNames`+`familyNames`)/Organization `legalName`.
+        * title/headline: `span`
+* PublicationVolume:
+    * `ul` `itemtype='stencila:PublicationVolume'`
+    * itemprops:
+        * pageStart: `span`
+        * pageEnd: `span`
+        * pagination: `span`
+        * volumeNumber: `span`
+        * authors: `ol` of `span` Person `name` (or combined `givenNames`+`familyNames`)/Organization `legalName`.
+        * title/headline: `span`
 * SoftwareSourceCode:
     * codeRepository: `a href`
     * codeSampleType: `data`?
-    * maintainers: `ol` of `span` Person/Organization itemtypes
+    * maintainers: `ol` of `span` Person `name` (or combined `givenNames`+`familyNames`)/Organization `legalName`.
     * programmingLanguage: `data` or `span` (maybe unnecessary for styling)
     * runtimePlatform: `ol` of `data` or `span`
     * softwareRequirements: `ol` of `span` SoftwareSourceCode/SoftwareApplication
@@ -115,20 +177,27 @@ Some of the main external dependencies:
 
 ### Schema nodes with direct mapping to semantic tags
 * AudioObject: `audio`
-    * name: `figcaption`, or `p`
+    * name => `figcaption`, or `p`
     * caption, transcript => `track` (if `video`), or `data`. [Consider using `video` instead of `audio` to enable captions](https://www.iandevlin.com/blog/2015/12/html5/webvtt-and-audio/), or display separately as `div`.
+    * contentUrl => `audio src`
 * Delete: `del`
 * Emphasis: `em`
-* Heading: 
+* Heading: `h1` ... `h6`
 * ImageObject: `figure`
     * thumbnail => `img`
     * caption => `figcaption`
+    * contentUrl => `img src`
 * Link: `a`
     * content
     * target => href
-* List: `ol`, `ul` 
-  * ListItem => `li` (with `li` > `input type="checkbox"` option)
-* Quote
+* List: `ol`, `ul`
+    * ListItem => `li` (with `li` > `input type="checkbox"` option)
+* Paragraph => `p`
+* Quote => `q`
+    * citation => `q cite`
+* QuoteBlock => `blockquote`
+    * citation => `blockquote cite`
+    * content => `p` for each array item
 * Strong => `strong`
 * Subscript => `sub`
 * Superscript => `sup`
@@ -145,6 +214,7 @@ Some of the main external dependencies:
     * caption => `track`
     * thumbnail => poster (attribute)
     * transcript => `track`?
+    * contentUrl => `source src`
 
 ### Schema nodes we won't be adding microdata to
 * BlockContent
@@ -159,4 +229,27 @@ Some of the main external dependencies:
     * content
 * InlineContent
 * Mark
+* MediaObject?
+    * bitrate
+    * contentSize
+    * contentUrl (necessary for `audio`, `img`, `video`)
+    * embedUrl
+    * format
+* Mount?
+* Node
+* Product?
+  * brand
+  * logo
+  * productID
+* ResourceParameters?
+    * resourceLimit
+    * resourceRequested
+* SoftwareApplication?
+    * softwareRequirements
+    * softwareVersion
+* SoftwareSession?
+    * volumeMounts
+    * cpuResource
+    * memoryResource
+    * environment
 * Thing

--- a/src/codecs/html/README.md
+++ b/src/codecs/html/README.md
@@ -19,9 +19,9 @@ completely as possible. One way we achieve through JSON-LD metadata.
 For SDT nodes that do not have a natural HTML counterpart, we use
 [custom elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements).
 
-### Generate pretty HTML
+### Maximize machine-readability of HTML
 
-Because it's easier to debug.
+Use semantic tags whenever possible, and microdata `itemtype` and `itemprop` attributes to allow for semantic search, and hydration of web components from HTML.
 
 ## Dependencies
 
@@ -38,3 +38,89 @@ Some of the main external dependencies:
 - `js-beautify` for pretty generated HTML.
 
 - `json5` for more human readable representation of arbitrary values.
+
+---
+
+## Microdata and semantic tag usage (WIP)
+
+### Schema nodes to add microdata to
+* Article
+    * `div` `itemtype='schema:Article'`
+    * itemprops:
+        * authors* (author?): `ol`
+        * title*: `h1`? (+ `title`)
+        * environment: `data`?
+* Audio
+    * `audio`
+    * itemprops:
+        * caption*: `figcaption`
+        * transcript
+* Brand
+    * `picture`/`img` `itemtype='schema:Brand'`
+    * itemprops:
+        * name: maybe unnecessary, just use in alt tag?
+        * logo*: `source`/`image`
+        * reviews
+* Code
+    * `div` `itemtype='stencila:Code'`
+    * itemprops:
+        * language* (maybe important for setting syntax highlighting): `data`
+        * value*: `code`
+* CodeChunk
+    * `div` `itemtype='stencila:CodeChunk'`
+    * itemprops:
+        * outputs: `ol` of `samp`/`output` (possibly include `figure`/`table`)
+* CodeExpression
+    * `div` `itemtype='stencila:CodeExpr'`
+    * itemprops:
+        * value:`code` (syntax highlighting from Code node's language prop)
+* Collection
+    * `nav` `itemtype='schema:Collection'`
+    * itemprops:
+        * parts: `ol` of CreativeWorks/Articles (just title, author, and URIs/relative links?)
+* ContactPoint
+    * `address` `itemtype='schema:contactPoint'`
+    * itemprops:
+        * availableLanguages: `ul` of `data`? if not `p` (maybe unnecessary for styling)
+        * emails: `ol` of `a href`
+        * telephone: `a href`
+* CreativeWork:
+    * `div` `itemtype='schema:CreativeWork'`
+    * itemprops:
+        * authors: `ol` of `span` Person/Organization itemtypes.
+        * citations: `ol` of title/authors/`a href`
+        * content: `article`/`div` with `sections`
+        * dateCreated: `span time`
+        * dateModified: `span time`
+        * datePublished/date: `span time`
+        * editors: `ol` of `span` Person itemtypes
+        * funders: `ol` of `span` Person/Organization itemtypes
+        * isPartOf: `data`?
+        * licenses: `ol` of `a href`
+        * parts/hasPart: `ol` of figure/table/object/URI (maybe unnecessary for styling)
+        * publisher: `span` Person/Organization itemtype
+        * text: `data`? (maybe unnecessary for styling)
+        * title/headline: `h1`
+        * version: `span`
+* DataTable:
+    * `table` or `figure table` `itemtype='stencila:Datatable'`
+    * columns: probably want to convert these DatatableColumns into rows when encoding into HTML, so they're made up of `tr` and `td`/`th`. Maybe keep as `data`?
+        * values: `td`
+        * schema (items, uniqueItems): `data`? (maybe unnecessary for styling)
+        * name: `th`?
+
+### Schema nodes we won't be adding microdata to
+* Delete: `del`
+* Emphasis: `em`
+* Heading: 
+* ImageObject: `figure`
+    * thumbnail => `img`
+    * caption => `figcaption`
+* Link: `a`
+    * content
+    * target => href
+* List: `ol`, `ul` (with `input type="checkbox"` option)
+* Quote
+* Strong
+* Subscript
+* Superscript

--- a/src/codecs/html/README.md
+++ b/src/codecs/html/README.md
@@ -211,9 +211,9 @@ Some of the main external dependencies:
         * `kind`: data => `td`
 * ThematicBreak: `hr`? (not sure if we should consider other options, such as splitting nodes by ThematicBreaks and grouping them into `section` tags instead)
 * VideoObject: `video`
-    * caption => `track`
+    * caption => `track`. Consider conforming to `uri string` and referencing a `.vtt` file.
     * thumbnail => poster (attribute)
-    * transcript => `track`?
+    * transcript => `track`? Consider making `transcript` a nested `CreativeWork` or `Article`.
     * contentUrl => `source src`
 
 ### Schema nodes we won't be adding microdata to


### PR DESCRIPTION
Adds documentation on approach to encoding to HTML, in particular use of the Microdata https://www.w3.org/TR/microdata/