### PR TITLE
Add more node types & extract more data from HTML nodes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,13 @@
   "extends": "@stencila/eslint-config",
   "rules": {
     "@typescript-eslint/strict-boolean-expressions": 0
-  }
+  },
+  "overrides": [
+    {
+      "files": ["*.test.ts"],
+      "env": {
+        "jest": true
+      }
+    }
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5715,9 +5715,9 @@
       "dev": true
     },
     "fp-ts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.0.0.tgz",
-      "integrity": "sha512-oz8L+EZiztqGVLhgdL+63b4hpfdJkEKH/4vRoS/AuUwYqmn7vHAzWMu1jtoYfB0pPxo5UioWVT2XOuftyivUSQ=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.0.5.tgz",
+      "integrity": "sha512-opI5r+rVlpZE7Rhk0YtqsrmxGkbIw0dRNqGca8FEAMMnjomXotG+R9QkLQg20onx7R8qhepAn4CCOP8usma/Xw=="
     },
     "frac": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1435,6 +1435,12 @@
         }
       }
     },
+    "@sheerun/mutationobserver-shim": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
+      "integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==",
+      "dev": true
+    },
     "@sindresorhus/df": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/df/-/df-2.1.0.tgz",
@@ -1554,6 +1560,84 @@
       "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
       "requires": {
         "defer-to-connect": "^1.0.1"
+      }
+    },
+    "@testing-library/dom": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.1.0.tgz",
+      "integrity": "sha512-qivqFvnbVIH3DyArFofEU/jlOhkGIioIemOy9A9M/NQTpPyDDQmtVkAfoB18RKN581f0s/RJMRBbq9WfMIhFTw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@sheerun/mutationobserver-shim": "^0.3.2",
+        "@types/testing-library__dom": "^6.0.0",
+        "aria-query": "3.0.0",
+        "pretty-format": "^24.8.0",
+        "wait-for-expect": "^1.3.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+          "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
+      }
+    },
+    "@testing-library/jest-dom": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-4.0.1.tgz",
+      "integrity": "sha512-UHai1O5zN6UIqZ0SR35BsAEM0FED4xXoOQnE6tzdeIPa8FaAor5zaM30qK49Ynjd/rcC3DbA9jqR+0C5WD2Xng==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.1",
+        "chalk": "^2.4.1",
+        "css": "^2.2.3",
+        "css.escape": "^1.5.1",
+        "jest-diff": "^24.0.0",
+        "jest-matcher-utils": "^24.0.0",
+        "lodash": "^4.17.11",
+        "pretty-format": "^24.0.0",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+          "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
+        },
+        "redent": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+          "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+          "dev": true,
+          "requires": {
+            "indent-string": "^4.0.0",
+            "strip-indent": "^3.0.0"
+          }
+        },
+        "strip-indent": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+          "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+          "dev": true,
+          "requires": {
+            "min-indent": "^1.0.0"
+          }
+        }
       }
     },
     "@types/async-lock": {
@@ -1881,6 +1965,12 @@
       "integrity": "sha512-MG7ExKBo7AQ5UrL1awyYLNinNM/kyXgE4iP4Ul9fB+T7n768Z5Xem8IZeP6Bna0xze8gkDly49Rgge2HOEw4xA==",
       "dev": true
     },
+    "@types/pretty-format": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/pretty-format/-/pretty-format-20.0.1.tgz",
+      "integrity": "sha512-Oh7wnvVUCtVIWnCHQWe9qDZKn0fGyk5AMq99jXml0x39K59P+z9qe31CNRtop9TceCpS7NmoK+J9eGeCnyFgnw==",
+      "dev": true
+    },
     "@types/punycode": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/punycode/-/punycode-2.1.0.tgz",
@@ -1918,6 +2008,15 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
+    },
+    "@types/testing-library__dom": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-6.0.0.tgz",
+      "integrity": "sha512-AmAPJGaH2M45JVzccn2kNRtgNQClnJka938YV1af22pgV+JULAEeaIkmS1qN3SLPqu5Hh0rDZDsc0Uxjt15SGw==",
+      "dev": true,
+      "requires": {
+        "@types/pretty-format": "*"
+      }
     },
     "@types/tough-cookie": {
       "version": "2.3.5",
@@ -2208,6 +2307,24 @@
       "integrity": "sha1-oMoMvCmltz6Dbuvhy/bF4OTrgvk=",
       "dev": true
     },
+    "aria-query": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+      "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7",
+        "commander": "^2.11.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "dev": true
+        }
+      }
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -2312,6 +2429,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "ast-types-flow": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
       "dev": true
     },
     "astral-regex": {
@@ -3658,10 +3781,36 @@
       "integrity": "sha512-KMvcQ07H0kMpzl2aO1mgyp+F+LVk+z+QMpN01noMUv0Uu4mqg4KyJjeM2u2716qU9ZgPq1Kr30DXqhT4RuEg1w==",
       "dev": true
     },
+    "css": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.5.2",
+        "urix": "^0.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "css-selector-parser": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.3.0.tgz",
       "integrity": "sha1-XxrUPi2O77/cME/NOaUhZklD4+s="
+    },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "dev": true
     },
     "cssom": {
       "version": "0.3.6",
@@ -9651,6 +9800,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+    },
+    "min-indent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
+      "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -16886,6 +17041,12 @@
         "webidl-conversions": "^4.0.2",
         "xml-name-validator": "^3.0.0"
       }
+    },
+    "wait-for-expect": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.3.0.tgz",
+      "integrity": "sha512-8fJU7jiA96HfGPt+P/UilelSAZfhMBJ52YhKzlmZQvKEZU2EcD1GQ0yqGB6liLdHjYtYAoGVigYwdxr5rktvzA==",
+      "dev": true
     },
     "walker": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,8 @@
   "devDependencies": {
     "@gerrit0/typedoc": "0.15.5",
     "@stencila/dev-config": "1.1.3",
+    "@testing-library/dom": "^6.1.0",
+    "@testing-library/jest-dom": "^4.0.1",
     "@types/async-lock": "1.1.1",
     "@types/content-type": "1.1.3",
     "@types/escape-html": "0.0.20",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "check:deps-used": "dependency-check --missing .",
     "check:deps-unused": "dependency-check --unused --no-dev --ignore-module @stencila/schema --ignore-module @stencila/thema .",
     "cli": "npx ts-node --files src/cli",
-    "build": "tsc && cp -r src/codecs/pandoc/templates/. dist/codecs/pandoc/templates/",
+    "build": "tsc -p tsconfig.prod.json && cp -r src/codecs/pandoc/templates/. dist/codecs/pandoc/templates/",
     "docs": "npm run docs:readme && npm run docs:dogfood && npm run docs:ts",
     "docs:readme": "markdown-toc -i --maxdepth=4 README.md",
     "docs:dogfood": "npx ts-node --files docs.ts",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "content-type": "^1.0.4",
     "datapackage": "^1.1.1",
     "escape-html": "^1.0.3",
-    "fp-ts": "^2.0.0",
+    "fp-ts": "^2.0.5",
     "fs-extra": "^8.1.0",
     "get-stdin": "^7.0.0",
     "github-slugger": "^1.2.1",

--- a/src/__tests__/matchers.ts
+++ b/src/__tests__/matchers.ts
@@ -5,6 +5,7 @@ import { toMatchFile } from 'jest-file-snapshot'
 import mime from 'mime'
 import path from 'path'
 import { Codec } from '../codecs/types'
+import '@testing-library/jest-dom/extend-expect'
 
 /**
  * Add https://github.com/satya164/jest-file-snapshot

--- a/src/__tests__/matchers.ts
+++ b/src/__tests__/matchers.ts
@@ -1,21 +1,13 @@
 import stencila from '@stencila/schema'
 import { nodeType } from '@stencila/schema/dist/util'
+import '@testing-library/jest-dom/extend-expect'
 import fs from 'fs-extra'
+import diff from 'jest-diff'
 import { toMatchFile } from 'jest-file-snapshot'
+import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils'
 import mime from 'mime'
 import path from 'path'
 import { Codec } from '../codecs/types'
-import '@testing-library/jest-dom/extend-expect'
-
-/**
- * Add https://github.com/satya164/jest-file-snapshot
- *
- * > Jest matcher to write snapshots to a separate file instead of the
- * default snapshot file used by Jest. Writing a snapshot to a separate
- * file means you have proper syntax highlighting in the output file,
- * and better readability without those pesky escape characters.
- */
-expect.extend({ toMatchFile })
 
 /**
  * A Jest matcher for testing that a codec is able
@@ -65,12 +57,90 @@ async function toInvert(codec: Codec, node: stencila.Node, fileName?: string) {
   }
 }
 
-expect.extend({ toInvert })
+const stripWhitespace = (s: string) =>
+  s
+    .replace(/>\s+</g, `><`)
+    .replace(/\s+/g, ` `)
+    .replace(/\s+\<\//g, '</')
+    .replace(/\>\s+/g, '>')
+
+/**
+ * Compares text values disregarding whitespace differences (including newlines).
+ * based on https://stackoverflow.com/a/48459005
+ */
+const toEqualStringContent = (
+  received: string,
+  expected: string,
+  printOriginalValues?: boolean
+) => {
+  const compressedExpected = stripWhitespace(expected)
+  const compressedReceived = stripWhitespace(received)
+  const pass = compressedExpected === compressedReceived
+
+  if (pass) {
+    return {
+      message: () =>
+        (printOriginalValues
+          ? `Uncompressed expected value:\n` + `  ${printExpected(expected)}\n`
+          : '') +
+        `Expected value with compressed whitespace to not equal:\n` +
+        `  ${printExpected(compressedExpected)}\n` +
+        (printOriginalValues
+          ? `Uncompressed received value:\n` + `  ${printReceived(received)}\n`
+          : '') +
+        `Received value with compressed whitespace:\n` +
+        `  ${printReceived(compressedReceived)}`,
+      pass: true
+    }
+  } else {
+    return {
+      message: () => {
+        // `expected ${received} to match string ${expected}`,
+        const diffString = diff(compressedExpected, compressedReceived, {
+          expand: true
+        })
+
+        return (
+          `${matcherHint(`.${toEqualStringContent}`)}\n\n` +
+          (printOriginalValues
+            ? `Uncompressed expected value:\n` +
+              `  ${printExpected(expected)}\n`
+            : '') +
+          `Expected value with compressed whitespace to equal:\n` +
+          `  ${printExpected(compressedExpected)}\n` +
+          (printOriginalValues
+            ? `Uncompressed received value:\n` +
+              `  ${printReceived(received)}\n`
+            : '') +
+          `Received value with compressed whitespace:\n` +
+          `  ${printReceived(compressedReceived)}${
+            diffString ? `\n\nDifference:\n\n${diffString}` : ``
+          }`
+        )
+      },
+      pass: false
+    }
+  }
+}
+
+/**
+ * Add https://github.com/satya164/jest-file-snapshot
+ *
+ * > Jest matcher to write snapshots to a separate file instead of the
+ * default snapshot file used by Jest. Writing a snapshot to a separate
+ * file means you have proper syntax highlighting in the output file,
+ * and better readability without those pesky escape characters.
+ */
+expect.extend({ toInvert, toMatchFile, toEqualStringContent })
 
 declare global {
   namespace jest {
     interface Matchers<R> {
       toInvert(node: stencila.Node, fileName?: string): R
+      /**
+       * Compares text values disregarding whitespace differences (including newlines).
+       */
+      toEqualStringContent(expected: string, printOriginalValues?: boolean): R
     }
   }
 }

--- a/src/codecs/html/__snapshots__/html.test.ts.snap
+++ b/src/codecs/html/__snapshots__/html.test.ts.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Encode & Decode references encode - citegroup and references 1`] = `
+"<article>
+  <h1 role=\\"title\\">An example of using the CiteGroup node type</h1>
+  <p>Citing two articles </p><ol itemtype=\\"schema:CiteGroup\\">
+      <li><cite><a href=\\"#some-one-else-1991\\">some-one-else-1991</a></cite></li>
+      <li><cite><a href=\\"#updated-works-2009\\">updated-works-2009</a></cite></li>
+      <li><cite><a href=\\"http://www.fullUrl.com\\">http://www.fullUrl.com</a></cite></li>
+    </ol>.<p></p>
+  <section>
+    <h2>References</h2>
+    <ol itemprop=\\"references\\">
+      <li id=\\"some-one-else-1991\\" itemscope=\\"true\\" itemtype=\\"https://schema.org/CreativeWork\\" itemprop=\\"citation\\"><span itemprop=\\"title\\" itemscope=\\"true\\">Another article by someone
+          else</span>
+        <ol itemprop=\\"authors\\" itemscope=\\"true\\">
+          <li itemscope=\\"true\\" itemtype=\\"https://schema.org/Person\\" itemprop=\\"author\\"><span itemprop=\\"familyName\\">Else</span><span itemprop=\\"givenName\\">SomeOne</span></li>
+        </ol><time itemprop=\\"datePublished\\" datetime=\\"1991\\">1991</time>
+      </li>
+      <li id=\\"update-works-2009\\" itemscope=\\"true\\" itemtype=\\"https://schema.org/CreativeWork\\" itemprop=\\"citation\\"><span itemprop=\\"title\\" itemscope=\\"true\\">A Better Updated Work</span>
+        <ol itemprop=\\"authors\\" itemscope=\\"true\\">
+          <li itemscope=\\"true\\" itemtype=\\"https://schema.org/Person\\" itemprop=\\"author\\"><span itemprop=\\"familyName\\">Person</span><span itemprop=\\"givenName\\">SomeBetter</span></li>
+        </ol><time itemprop=\\"datePublished\\" datetime=\\"2009\\">2009</time>
+      </li>
+    </ol>
+  </section>
+</article>"
+`;

--- a/src/codecs/html/html.test.ts
+++ b/src/codecs/html/html.test.ts
@@ -17,18 +17,6 @@ import { JSDOM } from 'jsdom'
 import { dump, load } from '../../util/vfile'
 import { HTMLCodec } from './'
 
-declare global {
-  namespace jest {
-    interface Matchers<R> {
-      toInvert(node: stencila.Node, fileName?: string): R
-      /**
-       * Compares text values disregarding whitespace differences (including newlines).
-       */
-      toEqualStringContent(expected: string, printOriginalValues?: boolean): R
-    }
-  }
-}
-
 const doc = (innerHTML: string) =>
   new JSDOM(innerHTML).window.document.documentElement
 

--- a/src/codecs/html/html.test.ts
+++ b/src/codecs/html/html.test.ts
@@ -1,17 +1,33 @@
 import stencila, {
+  article,
   cite,
+  citeGroup,
+  collection,
+  creativeWork,
   figure,
   imageObject,
   link,
-  collection,
-  citeGroup
+  person,
+  publicationIssue
 } from '@stencila/schema'
-import { getByText, prettyDOM } from '@testing-library/dom'
+import { getByText } from '@testing-library/dom'
 import '@testing-library/jest-dom/extend-expect'
 import fs from 'fs'
 import { JSDOM } from 'jsdom'
 import { dump, load } from '../../util/vfile'
 import { HTMLCodec } from './'
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toInvert(node: stencila.Node, fileName?: string): R
+      /**
+       * Compares text values disregarding whitespace differences (including newlines).
+       */
+      toEqualStringContent(expected: string, printOriginalValues?: boolean): R
+    }
+  }
+}
 
 const doc = (innerHTML: string) =>
   new JSDOM(innerHTML).window.document.documentElement
@@ -53,7 +69,7 @@ describe('String escaping', () => {
 
 describe('Encode & Decode cite nodes', () => {
   const schemaNode = cite('myTarget')
-  const htmlNode = `<cite><a href="${schemaNode.target}">${schemaNode.target}</a></cite>`
+  const htmlNode = `<cite><a href="#myTarget">myTarget</a></cite>`
 
   test('encode', async () => {
     expect(await e(schemaNode)).toEqual(htmlNode)
@@ -78,7 +94,7 @@ describe('Encode & Decode cite nodes', () => {
 
   test('decode with prefix & suffix', async () => {
     const actual = await d(
-      `<cite><span itemprop="citePrefix">(</span><a href="myTarget">myTarget</a><span itemprop="citeSuffix">)</span></cite>`
+      `<cite><span itemprop="citePrefix">(</span><a href="#myTarget">myTarget</a><span itemprop="citeSuffix">)</span></cite>`
     )
 
     expect(actual).toHaveProperty('target', 'myTarget')
@@ -113,6 +129,164 @@ describe('Encode & Decode cite group nodes', () => {
 
   test('decode', async () => {
     expect(await decode(load(htmlNode))).toEqual(schemaNode)
+  })
+})
+
+describe('Encode & Decode references', () => {
+  const schemaNode = article([], 'Untitled', {
+    references: [
+      creativeWork({
+        title:
+          'Cell flow reorients the axis of planar polarity in the wing epithelium of Drosophila',
+        datePublished: '2010',
+        // issueNumber: 142,
+        // title: 'Cell',
+        // pagination: '773-786',
+        url: 'https://doi.org/10.1016/j.cell.2010.07.042',
+        authors: [
+          person({
+            givenNames: ['B'],
+            familyNames: ['Aigouy'],
+            url: 'https://scholar.google.com/scholar?q=%22author:B+Aigouy%22'
+          }),
+          person({
+            givenNames: ['R'],
+            familyNames: ['Farhadifar'],
+            url:
+              'https://scholar.google.com/scholar?q=%22author:R+Farhadifar%22'
+          })
+        ]
+      })
+    ]
+  })
+
+  const schemaNodeCiteGroups = {
+    type: 'Article',
+    title: 'An example of using the CiteGroup node type',
+    authors: [
+      {
+        type: 'Person',
+        givenNames: ['Joe'],
+        familyNames: ['Bloggs']
+      }
+    ],
+    content: [
+      {
+        type: 'Paragraph',
+        content: [
+          'Citing two articles ',
+          {
+            type: 'CiteGroup',
+            items: [
+              { type: 'Cite', target: 'some-one-else-1991' },
+              { type: 'Cite', target: 'updated-works-2009' },
+              { type: 'Cite', target: 'http://www.fullUrl.com' }
+            ]
+          },
+          '.'
+        ]
+      }
+    ],
+    references: [
+      {
+        type: 'Article',
+        id: 'some-one-else-1991',
+        title: 'Another article by someone else',
+        authors: [
+          {
+            type: 'Person',
+            givenNames: ['Some', 'One'],
+            familyNames: ['Else']
+          }
+        ],
+        datePublished: '1991'
+      },
+      {
+        type: 'Article',
+        id: 'update-works-2009',
+        title: 'A Better Updated Work',
+        authors: [
+          {
+            type: 'Person',
+            givenNames: ['Some', 'Better'],
+            familyNames: ['Person']
+          }
+        ],
+        datePublished: '2009'
+      }
+    ]
+  }
+
+  const articleRefs = `<article>
+  <h2>
+    References
+  </h2>
+
+  <ol itemprop="references">
+    <li
+      itemscope="true"
+      itemtype="https://schema.org/CreativeWork"
+      itemprop="citation"
+    >
+      <a
+        href="https://doi.org/10.1016/j.cell.2010.07.042"
+        itemprop="title"
+        itemscope="true"
+      >
+        Cell flow reorients the axis of planar polarity in the wing epithelium
+        of Drosophila
+      </a>
+      <ol itemprop="authors" itemscope="true">
+        <li
+          itemscope="true"
+          itemtype="https://schema.org/Person"
+          itemprop="author"
+        >
+          <a href="https://scholar.google.com/scholar?q=%22author:B+Aigouy%22">
+            <span itemprop="familyName">Aigouy</span>
+            <span itemprop="givenName">B</span>
+          </a>
+        </li>
+        <li
+          itemscope="true"
+          itemtype="https://schema.org/Person"
+          itemprop="author"
+        >
+          <a
+            href="https://scholar.google.com/scholar?q=%22author:R+Farhadifar%22"
+          >
+            <span itemprop="familyName">Farhadifar</span>
+            <span itemprop="givenName">R</span>
+          </a>
+        </li>
+      </ol>
+      <time itemprop="datePublished" datetime="2010">2010</time>
+      <a href="https://doi.org/10.1016/j.cell.2010.07.042" itemprop="url">
+        https://doi.org/10.1016/j.cell.2010.07.042
+      </a>
+    </li>
+  </ol>
+</article>
+`
+
+  test('encode', async () => {
+    const actual = doc(await e(schemaNode)).querySelector(
+      '[itemprop="references"]'
+    )
+
+    const expected = doc(articleRefs).querySelector('[itemprop="references"]')
+    expect(actual!.outerHTML).toEqualStringContent(expected!.outerHTML)
+  })
+
+  test('encode - citegroup and references', async () => {
+    const actual = doc(await e(schemaNodeCiteGroups)).querySelector('article')
+    expect(actual!.outerHTML).toMatchSnapshot()
+  })
+
+  test('decode', async () => {
+    const actual = await d(articleRefs)
+
+    expect(actual).toMatchObject(schemaNode)
   })
 })
 
@@ -180,6 +354,11 @@ describe('Encode & Decode Collections', () => {
     const fig = actual.querySelectorAll('figure')
 
     expect(collectionHTML).toHaveAttribute('itemtype', 'schema:Collection')
+    expect(fig[0]).toHaveAttribute(
+      'itemtype',
+      'https://schema.org/CreativeWork'
+    )
+    expect(fig[0]).toHaveAttribute('itemscope', 'true')
     expect(fig).toHaveLength(2)
   })
 

--- a/src/codecs/ipynb/ipynb.test.ts
+++ b/src/codecs/ipynb/ipynb.test.ts
@@ -21,19 +21,30 @@ const json2ipynb = async (name: string) =>
     await ipynb.encode(await json.decode(await vfile.read(fixture(name))))
   )
 
-test('decode', async () => {
-  expect(await ipynb2json('metadata-v4.ipynb')).toMatchFile(
-    snapshot('metadata-v4.json')
-  )
-  expect(await ipynb2json('running-code.ipynb')).toMatchFile(
-    snapshot('running-code.json')
-  )
-  expect(await ipynb2json('sunspots.ipynb')).toMatchFile(
-    snapshot('sunspots.json')
-  )
-  expect(await ipynb2json('well-switching.ipynb')).toMatchFile(
-    snapshot('well-switching.json')
-  )
+describe('decode', () => {
+  test('metadata-v4', async () => {
+    expect(await ipynb2json('metadata-v4.ipynb')).toMatchFile(
+      snapshot('metadata-v4.json')
+    )
+  })
+
+  test('running-code', async () => {
+    expect(await ipynb2json('running-code.ipynb')).toMatchFile(
+      snapshot('running-code.json')
+    )
+  })
+
+  test('sunspots', async () => {
+    expect(await ipynb2json('sunspots.ipynb')).toMatchFile(
+      snapshot('sunspots.json')
+    )
+  })
+
+  test('well switching', async () => {
+    expect(await ipynb2json('well-switching.ipynb')).toMatchFile(
+      snapshot('well-switching.json')
+    )
+  })
 })
 
 test('encode', async () => {

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,0 +1,24 @@
+export const isDefined = <T>(n: T): n is NonNullable<typeof n> => n != null
+
+export const reduceNonNullable = <A, B>(callback: (sourceNode: A) => B) => (
+  convertedNodes: NonNullable<B>[] = [],
+  sourceNode?: A
+): NonNullable<B>[] => {
+  const decodedNode = sourceNode ? callback(sourceNode) : undefined
+  return isDefined(decodedNode)
+    ? [...convertedNodes, decodedNode]
+    : convertedNodes
+}
+
+/**
+ * Removes all properties that are undefined from a given object.
+ * Note that `null` values are considered explicit falsy values, and are not removed.
+ */
+export const compactObj = <O extends object>(o: O): O => {
+  return Object.entries(o).reduce(
+    (compacted: O, [k, v]) => {
+      return v !== undefined ? { ...compacted, [k]: v } : compacted
+    },
+    {} as O // eslint-disable-line
+  )
+}

--- a/src/util/transform.ts
+++ b/src/util/transform.ts
@@ -18,11 +18,15 @@ export default async function transform(
 ): Promise<stencila.Node> {
   async function walk(node: stencila.Node): Promise<stencila.Node> {
     const transformed = await transformer(node)
-    if (stencila.isPrimitive(transformed)) return transformed
+    if (stencila.isPrimitive(transformed) || transformed === undefined) {
+      return transformed
+    }
+
     for (const [key, child] of Object.entries(transformed)) {
       // @ts-ignore
       transformed[key] = await walk(child)
     }
+
     return transformed
   }
   return produce(node, walk)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,5 @@
     /* Avoid `import * as` syntax */
     "esModuleInterop": true
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["**/*.test.ts", "**/__tests__", "**/__fixtures__"]
+  "include": ["src/**/*.ts"]
 }

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,0 +1,5 @@
+{
+  /* See https://www.typescriptlang.org/docs/handbook/compiler-options.html */
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.test.ts", "**/__tests__", "**/__fixtures__"]
+}


### PR DESCRIPTION
Closes #216 and implements transforming more data surrounding references and citations (this includes `Person`, `Organization`, `CreativeWork`, and a few other nodes)

@jwijay Please note that some of the HTML structure you were working with in Thema might not line up 100% with the results of Encoda, so it's something we should review together. I tried to follow the outline detailed in [your PR](https://github.com/stencila/encoda/pull/200), while keeping the output as lean and semantic as possible. However I think there were differences when compared to the test HTML found in the [Thema PR](https://github.com/stencila/thema/pull/10).

This PR:
- Adds support for Cite, CiteGroup, Figure, Collection nodes
- Handles more props on Article/Person/Org/Ref/CreativeWork nodes (both Stencila Schema and HTML elements)
- Fixes [a failing test](https://travis-ci.org/stencila/encoda/jobs/574556462#L578-L583) due to [unhandled `undefined` value](https://github.com/stencila/encoda/commit/2388d7b2be6dab6ad754c1cd7cdce56845feb68a#diff-eed3108d015c259115fb4f93110337cc)
- Fix test failures due to false TypeScript errors by [adding a `tsconfig.prod.json` file](https://github.com/stencila/encoda/pull/233/commits/a9fe1f81bbe85245f2e12bc0b4e68f82b748643d). The default config file is used by default, but the new prod config is used when running `npm run build`. This fixes errors which would show up when running tests locally. Namely complaints about the Jest matchers not being defined (see screenshot below)
![Screen Shot 2019-08-21 at 16 03 46](https://user-images.githubusercontent.com/1646307/63464434-44e5e400-c42d-11e9-9985-36923a30a8ec.png)
- Adds a new custom Jest matcher called `toEqualStringContent` which compares two strings, disregarding the whitespace. Useful for comparing HTML outputs without caring about indentation

I've also identified a couple bugs/contradictions in the test-cases and will address them separately.

Has to do with the definition of `Inline` and `BlockContent` schemas and whether:
- `BlockQuote` content can be a `string (InlineContent)`
- How to handle a `<stencila-array>` or a `<stencila-thing> {Person}` inside a `Paragraph`

![Screen Shot 2019-08-21 at 16 08 21](https://user-images.githubusercontent.com/1646307/63464765-e836f900-c42d-11e9-91f0-8911d8eef2e1.png)