### PR TITLE
Remove statically coded Thema theme names close

### DIFF
--- a/docs.ts
+++ b/docs.ts
@@ -4,9 +4,10 @@
  * to a tree of HTML in `docs`.
  */
 
+import * as logga from '@stencila/logga'
+import { themes } from '@stencila/thema'
 import { DirCodec } from './src/codecs/dir'
 import * as vfile from './src/util/vfile'
-import * as logga from '@stencila/logga'
 
 const { decode, encode } = new DirCodec()
 
@@ -24,6 +25,7 @@ logga.replaceHandlers((data: logga.LogData) => {
     ]
   })
   await encode(docs, {
-    filePath: 'docs'
+    filePath: 'docs',
+    theme: themes.stencila
   })
 })()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1550,9 +1550,9 @@
       }
     },
     "@stencila/thema": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@stencila/thema/-/thema-1.2.0.tgz",
-      "integrity": "sha512-M0lBPpiEtoZmc+7OYJzlYGGBPaw7Zqx2zJ+Pqx7lLGYfWSD/pO0LE2Mns3BF4KdSkxqjStc/oGaBzGwnZHDQvA=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@stencila/thema/-/thema-1.4.1.tgz",
+      "integrity": "sha512-ftueEoTEN0+wDZIJ7/3ePVpyS+K/asS8XRIZBdNXgVc5INNOYSp45A1tRxQ86db9MYriyiYfgPJRNq4nsnYNhA=="
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@stencila/logga": "^1.2.1",
     "@stencila/schema": "^0.27.0",
-    "@stencila/thema": "^1.2.0",
+    "@stencila/thema": "^1.4.1",
     "ajv": "^6.10.0",
     "appdata-path": "^1.0.0",
     "async-lock": "^1.2.0",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs-extra'
 import tempy from 'tempy'
 import { codecList, convert, dump, handled, load, match, read, write } from '..'
 import { JsonCodec } from '../codecs/json'
+import { defaultEncodeOptions } from '../codecs/types'
 import { YamlCodec } from '../codecs/yaml'
 import * as ssf from '../codecs/__mocks__/ssf'
 import { fixture } from './helpers'
@@ -16,15 +17,15 @@ describe('match', () => {
     expect(await match('./dir/file.json')).toBeInstanceOf(JsonCodec)
     expect(await match('./file.yaml')).toBeInstanceOf(YamlCodec)
     expect(await match('./file.yml')).toBeInstanceOf(YamlCodec)
-    expect(await match('./file.ssf')).toBeInstanceOf(ssf.Ssf)
-    expect(await match('./super-special-file')).toBeInstanceOf(ssf.Ssf)
+    expect(await match('./file.ssf')).toBeInstanceOf(ssf.SsfCodec)
+    expect(await match('./super-special-file')).toBeInstanceOf(ssf.SsfCodec)
   })
 
   it('works with format as extension name', async () => {
     expect(await match(undefined, 'json')).toBeInstanceOf(JsonCodec)
     expect(await match(undefined, 'yaml')).toBeInstanceOf(YamlCodec)
     expect(await match(undefined, 'yml')).toBeInstanceOf(YamlCodec)
-    expect(await match(undefined, 'ssf')).toBeInstanceOf(ssf.Ssf)
+    expect(await match(undefined, 'ssf')).toBeInstanceOf(ssf.SsfCodec)
   })
 
   it('works with format as media type', async () => {
@@ -32,18 +33,18 @@ describe('match', () => {
     expect(await match(undefined, 'text/yaml')).toBeInstanceOf(YamlCodec)
     expect(
       await match(undefined, 'application/vnd.super-corp.super-special-file')
-    ).toBeInstanceOf(ssf.Ssf)
+    ).toBeInstanceOf(ssf.SsfCodec)
   })
 
   it('works with file paths with format override', async () => {
     expect(await match('./file.foo', 'json')).toBeInstanceOf(JsonCodec)
     // expect(await match('./file.yaml', 'application/json')).toBeInstanceOf(json)
     // expect(await match('./file.json', 'text/yaml')).toBeInstanceOf(yaml)
-    expect(await match('./file.json', 'ssf')).toBeInstanceOf(ssf.Ssf)
+    expect(await match('./file.json', 'ssf')).toBeInstanceOf(ssf.SsfCodec)
   })
 
   it('works with content sniffing', async () => {
-    expect(await match('SSF: woot!')).toBeInstanceOf(ssf.Ssf)
+    expect(await match('SSF: woot!')).toBeInstanceOf(ssf.SsfCodec)
   })
 
   it('throws when unable to find a matching codec', async () => {
@@ -121,7 +122,7 @@ describe('write', () => {
 
   it('works with stdout', async () => {
     const consoleLog = jest.spyOn(console, 'log')
-    await write(simpleThing, '-', { format: 'json' })
+    await write(simpleThing, '-', { ...defaultEncodeOptions, format: 'json' })
     expect(consoleLog).toHaveBeenCalledWith(simpleThingJson)
   })
 })

--- a/src/__tests__/matchers.ts
+++ b/src/__tests__/matchers.ts
@@ -8,6 +8,7 @@ import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils'
 import mime from 'mime'
 import path from 'path'
 import { Codec } from '../codecs/types'
+import { getTheme } from '@stencila/thema'
 
 /**
  * A Jest matcher for testing that a codec is able
@@ -30,7 +31,10 @@ async function toInvert(codec: Codec, node: stencila.Node, fileName?: string) {
   }
   const outPath = path.join(__dirname, '__outputs__', fileName)
   await fs.ensureDir(path.dirname(outPath))
-  const file = await codec.encode(node, { filePath: outPath })
+  const file = await codec.encode(node, {
+    filePath: outPath,
+    theme: getTheme()
+  })
   const nodeDecoded = await codec.decode(file)
   try {
     expect(nodeDecoded).toEqual(node)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,13 +44,14 @@ import { default as processNode } from './process'
 import * as puppeteer from './util/puppeteer'
 import { coerce } from './util/coerce'
 import { validate } from './util/validate'
+import { getTheme, themes } from '@stencila/thema'
 
 const { _, ...options } = minimist(process.argv.slice(2), {
   boolean: ['standalone', 'bundle', 'debug'],
   default: {
     standalone: true,
     bundle: false,
-    theme: 'stencila',
+    theme: themes.stencila,
     debug: false
   }
 })
@@ -64,7 +65,9 @@ configure(options.debug)
 ;(async () => {
   try {
     if (command === 'convert') {
-      const { to, from, standalone, bundle, theme, ...rest } = options
+      const { to, from, standalone, bundle, ...rest } = options
+      const theme = getTheme(options.theme)
+
       await convert(args[0], args[1], {
         to,
         from,

--- a/src/codecs/__mocks__/ssf.ts
+++ b/src/codecs/__mocks__/ssf.ts
@@ -4,16 +4,17 @@
 
 import { Node } from '@stencila/schema'
 import { create, VFile } from '../../util/vfile'
-import { Codec } from '../types'
+import { Codec, defaultEncodeOptions } from '../types'
 
 export const fileNames = ['super-special-file']
 export const extNames = ['ssf']
 export const mediaTypes = ['application/vnd.super-corp.super-special-file']
 export const sniff = async (content: string) => /^SSF:/.test(content)
 export const decode = async (file: VFile) => null
-export const encode = async (node: Node, options: {} = {}) => create()
+export const encode = async (node: Node, options: {} = defaultEncodeOptions) =>
+  create()
 
-export class Ssf extends Codec implements Codec {
+export class SsfCodec extends Codec implements Codec {
   public readonly fileNames = fileNames
   public readonly extNames = extNames
   public readonly mediaTypes = mediaTypes

--- a/src/codecs/bib/index.ts
+++ b/src/codecs/bib/index.ts
@@ -5,7 +5,7 @@
 import stencila from '@stencila/schema'
 import * as vfile from '../../util/vfile'
 import { CSLCodec } from '../csl'
-import { Codec } from '../types'
+import { Codec, defaultEncodeOptions } from '../types'
 
 const csl = new CSLCodec()
 
@@ -21,6 +21,6 @@ export class BibCodec extends Codec implements Codec {
   public readonly encode = async (
     node: stencila.Node
   ): Promise<vfile.VFile> => {
-    return csl.encode(node, { format: 'bibtex' })
+    return csl.encode(node, { ...defaultEncodeOptions, format: 'bibtex' })
   }
 }

--- a/src/codecs/bib/index.ts
+++ b/src/codecs/bib/index.ts
@@ -5,7 +5,7 @@
 import stencila from '@stencila/schema'
 import * as vfile from '../../util/vfile'
 import { CSLCodec } from '../csl'
-import { Codec, defaultEncodeOptions } from '../types'
+import { Codec } from '../types'
 
 const csl = new CSLCodec()
 
@@ -21,6 +21,6 @@ export class BibCodec extends Codec implements Codec {
   public readonly encode = async (
     node: stencila.Node
   ): Promise<vfile.VFile> => {
-    return csl.encode(node, { ...defaultEncodeOptions, format: 'bibtex' })
+    return csl.encode(node, { ...this.defaultEncodeOptions, format: 'bibtex' })
   }
 }

--- a/src/codecs/csi/index.ts
+++ b/src/codecs/csi/index.ts
@@ -25,7 +25,11 @@ export class CsiCodec extends Codec implements Codec {
     node: stencila.Node
   ): Promise<vfile.VFile> => {
     const items = Array.isArray(node) ? node : [node]
-    const csi = items.map(item => typeof item === 'object' ? JSON.stringify(item) : `${item}`).join(', ')
+    const csi = items
+      .map(item =>
+        typeof item === 'object' ? JSON.stringify(item) : `${item}`
+      )
+      .join(', ')
     return vfile.load(csi)
   }
 }

--- a/src/codecs/csl/index.ts
+++ b/src/codecs/csl/index.ts
@@ -13,7 +13,7 @@ import Csl from 'csl-json'
 import { load } from '../..'
 import { logErrorNodeType, logWarnLoss, logWarnLossIfAny } from '../../log'
 import * as vfile from '../../util/vfile'
-import { Codec, defaultEncodeOptions, GlobalEncodeOptions } from '../types'
+import { Codec, GlobalEncodeOptions } from '../types'
 
 interface DecodeOptions {
   format: string
@@ -57,7 +57,7 @@ export class CSLCodec extends Codec<{}, DecodeOptions>
    */
   public readonly encode = async (
     node: stencila.Node,
-    options: GlobalEncodeOptions = defaultEncodeOptions
+    options: GlobalEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const { format = 'json' } = options
 

--- a/src/codecs/csl/index.ts
+++ b/src/codecs/csl/index.ts
@@ -13,7 +13,7 @@ import Csl from 'csl-json'
 import { load } from '../..'
 import { logErrorNodeType, logWarnLoss, logWarnLossIfAny } from '../../log'
 import * as vfile from '../../util/vfile'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, defaultEncodeOptions, GlobalEncodeOptions } from '../types'
 
 interface DecodeOptions {
   format: string
@@ -57,7 +57,7 @@ export class CSLCodec extends Codec<{}, DecodeOptions>
    */
   public readonly encode = async (
     node: stencila.Node,
-    options: GlobalEncodeOptions = {}
+    options: GlobalEncodeOptions = defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const { format = 'json' } = options
 

--- a/src/codecs/dar/dar.test.ts
+++ b/src/codecs/dar/dar.test.ts
@@ -6,6 +6,7 @@ import * as vfile from '../../util/vfile'
 // Fixtures
 import flat from '../../__fixtures__/collection-flat'
 import mixed from '../../__fixtures__/collection-mixed'
+import { defaultEncodeOptions } from '../types'
 
 const { decode, encode, sniff } = new DarCodec()
 
@@ -49,7 +50,7 @@ describe('encode', () => {
   it('works on flat collection', async () => {
     const dir = await outdir('flat.dar')
 
-    await encode(flat, { filePath: dir })
+    await encode(flat, { ...defaultEncodeOptions, filePath: dir })
 
     expect(await files(dir)).toEqual([
       'manifest.xml',
@@ -63,7 +64,7 @@ describe('encode', () => {
   it('works on mixed collection', async () => {
     const dir = await outdir('mixed.dar')
 
-    await encode(mixed, { filePath: dir })
+    await encode(mixed, { ...defaultEncodeOptions, filePath: dir })
 
     expect(await files(dir)).toEqual([
       'manifest.xml',
@@ -92,7 +93,7 @@ describe('encode', () => {
           }
         ]
       },
-      { filePath: dir }
+      { ...defaultEncodeOptions, filePath: dir }
     )
 
     expect(await manifest(dir)).toMatchSnapshot()

--- a/src/codecs/dar/index.ts
+++ b/src/codecs/dar/index.ts
@@ -20,7 +20,7 @@ import tempy from 'tempy'
 import { write } from '../..'
 import * as uri from '../../util/uri'
 import * as vfile from '../../util/vfile'
-import { Codec, defaultEncodeOptions, GlobalEncodeOptions } from '../types'
+import { Codec, GlobalEncodeOptions } from '../types'
 
 export class DarCodec extends Codec implements Codec {
   public readonly mediaTypes = []
@@ -66,7 +66,7 @@ export class DarCodec extends Codec implements Codec {
    */
   public encode: Codec['encode'] = async (
     node,
-    options = defaultEncodeOptions
+    options = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const { filePath } = options
 

--- a/src/codecs/dar/index.ts
+++ b/src/codecs/dar/index.ts
@@ -20,7 +20,7 @@ import tempy from 'tempy'
 import { write } from '../..'
 import * as uri from '../../util/uri'
 import * as vfile from '../../util/vfile'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, defaultEncodeOptions, GlobalEncodeOptions } from '../types'
 
 export class DarCodec extends Codec implements Codec {
   public readonly mediaTypes = []
@@ -66,7 +66,7 @@ export class DarCodec extends Codec implements Codec {
    */
   public encode: Codec['encode'] = async (
     node,
-    options = {}
+    options = defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const { filePath } = options
 

--- a/src/codecs/dir/dir.test.ts
+++ b/src/codecs/dir/dir.test.ts
@@ -4,6 +4,7 @@ import globby from 'globby'
 import path from 'path'
 import { DirCodec } from '.'
 import * as vfile from '../../util/vfile'
+import { defaultEncodeOptions, GlobalEncodeOptions } from '../types'
 
 const { decode, encode, sniff } = new DirCodec()
 
@@ -83,10 +84,13 @@ describe('decode', () => {
 })
 
 describe('encode', () => {
+  const e = (n: stencila.Node, options: Omit<GlobalEncodeOptions, 'theme'>) =>
+    encode(n, { ...defaultEncodeOptions, ...options })
+
   it('creates a directory', async () => {
     const dir = path.join(__dirname, '__outputs__', 'flat')
     await fs.remove(dir)
-    await encode(flatNode, { filePath: dir })
+    await e(flatNode, { filePath: dir })
     const files = await globby('**/*', { cwd: dir })
     expect(files.sort()).toEqual(['1.html', '2.html', '3.html', 'root.json'])
   })
@@ -94,7 +98,7 @@ describe('encode', () => {
   it('uses index.html for main files', async () => {
     const dir = path.join(__dirname, '__outputs__', 'shallow')
     await fs.remove(dir)
-    await encode(shallowNode, { filePath: dir })
+    await e(shallowNode, { filePath: dir })
     const files = await globby('**/*', { cwd: dir })
     expect(files.sort()).toEqual([
       'a/README.html',

--- a/src/codecs/dir/index.ts
+++ b/src/codecs/dir/index.ts
@@ -15,7 +15,7 @@ import trash from 'trash'
 import unixify from 'unixify'
 import { read, write } from '../..'
 import * as vfile from '../../util/vfile'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, defaultEncodeOptions, GlobalEncodeOptions } from '../types'
 
 const log = getLogger('encoda:dir')
 
@@ -184,7 +184,7 @@ export class DirCodec extends Codec<EncodeOptions, DecodeOptions>
 
   public readonly encode = async (
     node: stencila.Node,
-    options: EncodeOptions = {}
+    options: EncodeOptions = defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const dirPath = options.filePath || tempy.directory()
     const format = options.format || 'html'

--- a/src/codecs/dir/index.ts
+++ b/src/codecs/dir/index.ts
@@ -15,7 +15,7 @@ import trash from 'trash'
 import unixify from 'unixify'
 import { read, write } from '../..'
 import * as vfile from '../../util/vfile'
-import { Codec, defaultEncodeOptions, GlobalEncodeOptions } from '../types'
+import { Codec, GlobalEncodeOptions } from '../types'
 
 const log = getLogger('encoda:dir')
 
@@ -184,7 +184,7 @@ export class DirCodec extends Codec<EncodeOptions, DecodeOptions>
 
   public readonly encode = async (
     node: stencila.Node,
-    options: EncodeOptions = defaultEncodeOptions
+    options: EncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const dirPath = options.filePath || tempy.directory()
     const format = options.format || 'html'

--- a/src/codecs/dmagic/demo-magic.test.ts
+++ b/src/codecs/dmagic/demo-magic.test.ts
@@ -1,6 +1,7 @@
 import stencila from '@stencila/schema'
-import { DMagicCodec } from './'
 import { create, dump } from '../../util/vfile'
+import { defaultEncodeOptions } from '../types'
+import { DMagicCodec } from './'
 
 const { decode, encode } = new DMagicCodec()
 
@@ -12,7 +13,9 @@ test('decode', async () => {
 })
 
 test('encode', async () => {
-  expect(await dump(await encode(node, { isBundle: false }))).toEqual(bash)
+  expect(
+    await dump(await encode(node, { ...defaultEncodeOptions, isBundle: false }))
+  ).toEqual(bash)
   expect(await encode(node)).toBeTruthy()
 })
 

--- a/src/codecs/dmagic/index.ts
+++ b/src/codecs/dmagic/index.ts
@@ -8,7 +8,7 @@ import fs from 'fs-extra'
 import path from 'path'
 import { dump } from '../..'
 import * as vfile from '../../util/vfile'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, defaultEncodeOptions, GlobalEncodeOptions } from '../types'
 
 export class DMagicCodec extends Codec implements Codec {
   /**
@@ -41,7 +41,7 @@ export class DMagicCodec extends Codec implements Codec {
    */
   public readonly encode = async (
     node: stencila.Node,
-    options: GlobalEncodeOptions = {}
+    options: GlobalEncodeOptions = defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const { isBundle = true } = options
     let bash = await encodeNode(node)
@@ -79,10 +79,8 @@ async function encodeNode(node: stencila.Node): Promise<string> {
       const block = node as stencila.CodeBlock
       if (
         block.programmingLanguage &&
-        (
-          block.programmingLanguage !== 'bash' &&
-          block.programmingLanguage !== 'sh'
-        )
+        (block.programmingLanguage !== 'bash' &&
+          block.programmingLanguage !== 'sh')
       ) {
         return ''
       }

--- a/src/codecs/dmagic/index.ts
+++ b/src/codecs/dmagic/index.ts
@@ -8,7 +8,7 @@ import fs from 'fs-extra'
 import path from 'path'
 import { dump } from '../..'
 import * as vfile from '../../util/vfile'
-import { Codec, defaultEncodeOptions, GlobalEncodeOptions } from '../types'
+import { Codec, GlobalEncodeOptions } from '../types'
 
 export class DMagicCodec extends Codec implements Codec {
   /**
@@ -41,7 +41,7 @@ export class DMagicCodec extends Codec implements Codec {
    */
   public readonly encode = async (
     node: stencila.Node,
-    options: GlobalEncodeOptions = defaultEncodeOptions
+    options: GlobalEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const { isBundle = true } = options
     let bash = await encodeNode(node)

--- a/src/codecs/docx/index.ts
+++ b/src/codecs/docx/index.ts
@@ -3,11 +3,12 @@
  */
 
 import stencila from '@stencila/schema'
+import { getTheme } from '@stencila/thema'
 import path from 'path'
 import * as vfile from '../../util/vfile'
 import * as P from '../pandoc'
 import { dataDir } from '../pandoc/binary'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, defaultEncodeOptions, GlobalEncodeOptions } from '../types'
 
 const pandoc = new P.PandocCodec()
 
@@ -40,11 +41,15 @@ export class DocxCodec extends Codec<EncodeOptions>
 
   public readonly encode = async (
     node: stencila.Node,
-    { filePath, codecOptions = {} }: GlobalEncodeOptions<EncodeOptions> = {}
+    {
+      filePath,
+      codecOptions = {}
+    }: GlobalEncodeOptions<EncodeOptions> = defaultEncodeOptions
   ): Promise<vfile.VFile> =>
     pandoc.encode(node, {
       filePath,
       format: P.OutputFormat.docx,
+      theme: getTheme(),
       codecOptions: {
         flags: [
           `--reference-doc=${codecOptions.templatePath ||

--- a/src/codecs/docx/index.ts
+++ b/src/codecs/docx/index.ts
@@ -8,7 +8,7 @@ import path from 'path'
 import * as vfile from '../../util/vfile'
 import * as P from '../pandoc'
 import { dataDir } from '../pandoc/binary'
-import { Codec, defaultEncodeOptions, GlobalEncodeOptions } from '../types'
+import { Codec, GlobalEncodeOptions } from '../types'
 
 const pandoc = new P.PandocCodec()
 
@@ -41,10 +41,8 @@ export class DocxCodec extends Codec<EncodeOptions>
 
   public readonly encode = async (
     node: stencila.Node,
-    {
-      filePath,
-      codecOptions = {}
-    }: GlobalEncodeOptions<EncodeOptions> = defaultEncodeOptions
+    { filePath, codecOptions = {} }: GlobalEncodeOptions<EncodeOptions> = this
+      .defaultEncodeOptions
   ): Promise<vfile.VFile> =>
     pandoc.encode(node, {
       filePath,

--- a/src/codecs/html/html.test.ts
+++ b/src/codecs/html/html.test.ts
@@ -14,6 +14,7 @@ import '@testing-library/jest-dom/extend-expect'
 import fs from 'fs'
 import { JSDOM } from 'jsdom'
 import { dump, load } from '../../util/vfile'
+import { defaultEncodeOptions } from '../types'
 import { HTMLCodec } from './'
 
 const doc = (innerHTML: string) =>
@@ -21,8 +22,10 @@ const doc = (innerHTML: string) =>
 
 const { encode, decode } = new HTMLCodec()
 
-const e = async (node: stencila.Node, options = { isStandalone: false }) =>
-  dump(await encode(node, options))
+const e = async (
+  node: stencila.Node,
+  options = { ...defaultEncodeOptions, isStandalone: false }
+) => dump(await encode(node, options))
 
 const d = async (htmlString: string): Promise<stencila.Node> =>
   decode(load(htmlString))
@@ -351,7 +354,7 @@ describe('Encode & Decode Collections', () => {
 })
 
 test('encode with different themes', async () => {
-  const e = async (options = {}) =>
+  const e = async (options = defaultEncodeOptions) =>
     dump(await encode(kitchenSink.node, options))
 
   let html = await e({ theme: 'stencila' })
@@ -372,7 +375,7 @@ test('encode with different themes', async () => {
 })
 
 test('encode with bundling', async () => {
-  const e = async (options = {}) =>
+  const e = async (options = defaultEncodeOptions) =>
     dump(await encode(kitchenSink.node, options))
 
   const stylesheet = fs.readFileSync(

--- a/src/codecs/html/index.ts
+++ b/src/codecs/html/index.ts
@@ -137,7 +137,7 @@ export class HTMLCodec extends Codec implements Codec {
    */
   public readonly encode = async (
     node: stencila.Node,
-    options: GlobalEncodeOptions = defaultEncodeOptions
+    options: GlobalEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const {
       isStandalone = true,
@@ -456,7 +456,7 @@ function generateHtmlElement(
       'package.json'
     )).version
 
-    const themeBaseUrl = `https://unpkg.com/@stencila/thema@${themaVersion}/${themePath}}/${theme}`
+    const themeBaseUrl = `https://unpkg.com/@stencila/thema@${themaVersion}/${themePath}/${theme}`
     themeCss = h('link', {
       href: `${themeBaseUrl}/styles.css`,
       rel: 'stylesheet'

--- a/src/codecs/jats-pandoc/index.ts
+++ b/src/codecs/jats-pandoc/index.ts
@@ -5,7 +5,7 @@
 import stencila from '@stencila/schema'
 import * as vfile from '../../util/vfile'
 import * as P from '../pandoc'
-import { Codec } from '../types'
+import { Codec, defaultEncodeOptions } from '../types'
 
 const pandoc = new P.PandocCodec()
 
@@ -18,7 +18,7 @@ export class JatsPandocCodec extends Codec implements Codec {
 
   public readonly encode = async (
     node: stencila.Node,
-    options = {}
+    options = defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     return pandoc.encode(node, {
       ...options,

--- a/src/codecs/jats-pandoc/index.ts
+++ b/src/codecs/jats-pandoc/index.ts
@@ -5,7 +5,7 @@
 import stencila from '@stencila/schema'
 import * as vfile from '../../util/vfile'
 import * as P from '../pandoc'
-import { Codec, defaultEncodeOptions } from '../types'
+import { Codec } from '../types'
 
 const pandoc = new P.PandocCodec()
 
@@ -18,7 +18,7 @@ export class JatsPandocCodec extends Codec implements Codec {
 
   public readonly encode = async (
     node: stencila.Node,
-    options = defaultEncodeOptions
+    options = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     return pandoc.encode(node, {
       ...options,

--- a/src/codecs/latex/index.ts
+++ b/src/codecs/latex/index.ts
@@ -5,7 +5,7 @@
 import stencila from '@stencila/schema'
 import * as vfile from '../../util/vfile'
 import * as P from '../pandoc'
-import { Codec } from '../types'
+import { Codec, defaultEncodeOptions } from '../types'
 
 const pandoc = new P.PandocCodec()
 
@@ -22,7 +22,7 @@ export class LatexCodec extends Codec implements Codec {
 
   public readonly encode = async (
     node: stencila.Node,
-    options = {}
+    options = defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     return pandoc.encode(node, {
       ...options,

--- a/src/codecs/latex/index.ts
+++ b/src/codecs/latex/index.ts
@@ -5,7 +5,7 @@
 import stencila from '@stencila/schema'
 import * as vfile from '../../util/vfile'
 import * as P from '../pandoc'
-import { Codec, defaultEncodeOptions } from '../types'
+import { Codec } from '../types'
 
 const pandoc = new P.PandocCodec()
 
@@ -22,7 +22,7 @@ export class LatexCodec extends Codec implements Codec {
 
   public readonly encode = async (
     node: stencila.Node,
-    options = defaultEncodeOptions
+    options = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     return pandoc.encode(node, {
       ...options,

--- a/src/codecs/md/index.ts
+++ b/src/codecs/md/index.ts
@@ -577,7 +577,8 @@ function decodeCodeChunk(ext: Extension): stencila.CodeChunk {
     if (nodeType(first) === 'CodeBlock') {
       const codeBlock = first as stencila.CodeBlock
       const { programmingLanguage, meta, value } = codeBlock
-      if (programmingLanguage) codeChunk.programmingLanguage = programmingLanguage
+      if (programmingLanguage)
+        codeChunk.programmingLanguage = programmingLanguage
       if (meta) codeChunk.meta = meta
       if (value) codeChunk.text = value
     }

--- a/src/codecs/ods/index.ts
+++ b/src/codecs/ods/index.ts
@@ -4,7 +4,7 @@
 
 import stencila from '@stencila/schema'
 import * as vfile from '../../util/vfile'
-import { Codec } from '../types'
+import { Codec, defaultEncodeOptions } from '../types'
 import { XlsxCodec } from '../xlsx'
 
 const xlsx = new XlsxCodec()
@@ -23,6 +23,6 @@ export class ODSCodec extends Codec implements Codec {
   public readonly encode = async (
     node: stencila.Node
   ): Promise<vfile.VFile> => {
-    return xlsx.encode(node, { format: 'ods' })
+    return xlsx.encode(node, { ...defaultEncodeOptions, format: 'ods' })
   }
 }

--- a/src/codecs/ods/index.ts
+++ b/src/codecs/ods/index.ts
@@ -4,7 +4,7 @@
 
 import stencila from '@stencila/schema'
 import * as vfile from '../../util/vfile'
-import { Codec, defaultEncodeOptions } from '../types'
+import { Codec } from '../types'
 import { XlsxCodec } from '../xlsx'
 
 const xlsx = new XlsxCodec()
@@ -23,6 +23,6 @@ export class ODSCodec extends Codec implements Codec {
   public readonly encode = async (
     node: stencila.Node
   ): Promise<vfile.VFile> => {
-    return xlsx.encode(node, { ...defaultEncodeOptions, format: 'ods' })
+    return xlsx.encode(node, { ...this.defaultEncodeOptions, format: 'ods' })
   }
 }

--- a/src/codecs/odt/index.ts
+++ b/src/codecs/odt/index.ts
@@ -5,7 +5,7 @@
 import stencila from '@stencila/schema'
 import * as vfile from '../../util/vfile'
 import * as P from '../pandoc'
-import { Codec } from '../types'
+import { Codec, defaultEncodeOptions } from '../types'
 
 const pandoc = new P.PandocCodec()
 
@@ -23,7 +23,7 @@ export class ODTCodec extends Codec implements Codec {
 
   public readonly encode = async (
     node: stencila.Node,
-    options = {}
+    options = defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     return pandoc.encode(node, {
       ...options,

--- a/src/codecs/odt/index.ts
+++ b/src/codecs/odt/index.ts
@@ -5,7 +5,7 @@
 import stencila from '@stencila/schema'
 import * as vfile from '../../util/vfile'
 import * as P from '../pandoc'
-import { Codec, defaultEncodeOptions } from '../types'
+import { Codec } from '../types'
 
 const pandoc = new P.PandocCodec()
 
@@ -23,7 +23,7 @@ export class ODTCodec extends Codec implements Codec {
 
   public readonly encode = async (
     node: stencila.Node,
-    options = defaultEncodeOptions
+    options = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     return pandoc.encode(node, {
       ...options,

--- a/src/codecs/pandoc/index.ts
+++ b/src/codecs/pandoc/index.ts
@@ -16,7 +16,7 @@ import { write } from '../..'
 import { ensureBlockContent } from '../../util/ensureBlockContent'
 import * as vfile from '../../util/vfile'
 import { RPNGCodec } from '../rpng'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, defaultEncodeOptions, GlobalEncodeOptions } from '../types'
 import { binary, dataDir } from './binary'
 import * as P from './types'
 
@@ -94,7 +94,7 @@ export class PandocCodec extends Codec
       filePath,
       format = P.OutputFormat.json,
       codecOptions = { flags: [], ensureFile: false }
-    }: GlobalEncodeOptions<EncodeOptions> = {}
+    }: GlobalEncodeOptions<EncodeOptions> = defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     encodePromises = []
     const { standalone, pdoc } = encodeNode(node)
@@ -1027,7 +1027,11 @@ function encodeFallbackBlock(node: stencila.Node): P.Para {
 function encodeFallbackInline(node: stencila.Node): P.Image {
   const imagePath = tempy.file({ extension: 'png' })
   const promise = (async () => {
-    await write(node, imagePath, { format: 'rpng', isStandalone: false })
+    await write(node, imagePath, {
+      ...defaultEncodeOptions,
+      format: 'rpng',
+      isStandalone: false
+    })
   })()
   encodePromises.push(promise)
 

--- a/src/codecs/pandoc/index.ts
+++ b/src/codecs/pandoc/index.ts
@@ -94,7 +94,7 @@ export class PandocCodec extends Codec
       filePath,
       format = P.OutputFormat.json,
       codecOptions = { flags: [], ensureFile: false }
-    }: GlobalEncodeOptions<EncodeOptions> = defaultEncodeOptions
+    }: GlobalEncodeOptions<EncodeOptions> = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     encodePromises = []
     const { standalone, pdoc } = encodeNode(node)

--- a/src/codecs/pandoc/pandoc.test.ts
+++ b/src/codecs/pandoc/pandoc.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs-extra'
 import path from 'path'
 import { dump, load } from '../../util/vfile'
 import { RPNGCodec } from '../rpng'
+import { defaultEncodeOptions } from '../types'
 import { decodeMeta, emptyAttrs, encodeMeta, PandocCodec } from './'
 import * as P from './types'
 
@@ -558,6 +559,7 @@ describe('rPNG encoding & decoding of "special" node types', () => {
     'decode: %s',
     async (name: string, value: stencila.Node, done: jest.DoneCallback) => {
       const rPNG = await rpng.encode(value, {
+        ...defaultEncodeOptions,
         filePath: path.join(output, `${name}.png`)
       })
 

--- a/src/codecs/pdf/index.ts
+++ b/src/codecs/pdf/index.ts
@@ -7,7 +7,7 @@ import { dump } from '../..'
 import bundle from '../../util/bundle'
 import * as puppeteer from '../../util/puppeteer'
 import * as vfile from '../../util/vfile'
-import { Codec, defaultEncodeOptions, GlobalEncodeOptions } from '../types'
+import { Codec, GlobalEncodeOptions } from '../types'
 
 export class PDFCodec extends Codec implements Codec {
   /**
@@ -38,7 +38,7 @@ export class PDFCodec extends Codec implements Codec {
    */
   public readonly encode = async (
     node: stencila.Node,
-    options: GlobalEncodeOptions = defaultEncodeOptions
+    options: GlobalEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const bundled = await bundle(node)
     const html = await dump(bundled, 'html', options)

--- a/src/codecs/pdf/index.ts
+++ b/src/codecs/pdf/index.ts
@@ -7,7 +7,7 @@ import { dump } from '../..'
 import bundle from '../../util/bundle'
 import * as puppeteer from '../../util/puppeteer'
 import * as vfile from '../../util/vfile'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, defaultEncodeOptions, GlobalEncodeOptions } from '../types'
 
 export class PDFCodec extends Codec implements Codec {
   /**
@@ -38,7 +38,7 @@ export class PDFCodec extends Codec implements Codec {
    */
   public readonly encode = async (
     node: stencila.Node,
-    options: GlobalEncodeOptions = {}
+    options: GlobalEncodeOptions = defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const bundled = await bundle(node)
     const html = await dump(bundled, 'html', options)

--- a/src/codecs/pdf/pdf.test.ts
+++ b/src/codecs/pdf/pdf.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs-extra'
 import path from 'path'
 import * as vfile from '../../util/vfile'
 import articleSimple from '../../__fixtures__/article-simple'
+import { defaultEncodeOptions } from '../types'
 import { PDFCodec } from './'
 
 const { encode, decode } = new PDFCodec()
@@ -18,7 +19,7 @@ test('encode', async () => {
   const outputs = path.join(__dirname, '__outputs__')
   await fs.ensureDir(outputs)
   const filePath = path.join(outputs, 'pdf-encode.pdf')
-  const doc = await encode(articleSimple, { filePath })
+  const doc = await encode(articleSimple, { ...defaultEncodeOptions, filePath })
 
   expect(Buffer.isBuffer(doc.contents)).toBe(true)
   expect(doc.contents.slice(0, 5).toString()).toBe('%PDF-')

--- a/src/codecs/rpng/index.ts
+++ b/src/codecs/rpng/index.ts
@@ -13,7 +13,7 @@ import { dump } from '../../index'
 import bundle from '../../util/bundle'
 import * as puppeteer from '../../util/puppeteer'
 import * as vfile from '../../util/vfile'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, defaultEncodeOptions, GlobalEncodeOptions } from '../types'
 
 /**
  * The keyword to use for the PNG chunk containing the JSON
@@ -121,7 +121,7 @@ export class RPNGCodec extends Codec implements Codec {
    */
   public readonly encode = async (
     node: stencila.Node,
-    options: GlobalEncodeOptions = {}
+    options: GlobalEncodeOptions = defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const { filePath, isStandalone = false } = options
 

--- a/src/codecs/rpng/index.ts
+++ b/src/codecs/rpng/index.ts
@@ -13,7 +13,7 @@ import { dump } from '../../index'
 import bundle from '../../util/bundle'
 import * as puppeteer from '../../util/puppeteer'
 import * as vfile from '../../util/vfile'
-import { Codec, defaultEncodeOptions, GlobalEncodeOptions } from '../types'
+import { Codec, GlobalEncodeOptions } from '../types'
 
 /**
  * The keyword to use for the PNG chunk containing the JSON
@@ -121,7 +121,7 @@ export class RPNGCodec extends Codec implements Codec {
    */
   public readonly encode = async (
     node: stencila.Node,
-    options: GlobalEncodeOptions = defaultEncodeOptions
+    options: GlobalEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const { filePath, isStandalone = false } = options
 

--- a/src/codecs/tdp/index.ts
+++ b/src/codecs/tdp/index.ts
@@ -8,7 +8,7 @@ import stencila from '@stencila/schema'
 import datapackage from 'datapackage'
 import { dump } from '../..'
 import * as vfile from '../../util/vfile'
-import { Codec, defaultEncodeOptions, GlobalEncodeOptions } from '../types'
+import { Codec, GlobalEncodeOptions } from '../types'
 
 const logger = getLogger('encoda')
 
@@ -69,7 +69,7 @@ export class TDPCodec extends Codec implements Codec {
 
   public readonly encode = async (
     node: stencila.Node,
-    { filePath }: GlobalEncodeOptions = defaultEncodeOptions
+    { filePath }: GlobalEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const cw = node as stencila.CreativeWork
 

--- a/src/codecs/tdp/index.ts
+++ b/src/codecs/tdp/index.ts
@@ -8,7 +8,7 @@ import stencila from '@stencila/schema'
 import datapackage from 'datapackage'
 import { dump } from '../..'
 import * as vfile from '../../util/vfile'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, defaultEncodeOptions, GlobalEncodeOptions } from '../types'
 
 const logger = getLogger('encoda')
 
@@ -69,7 +69,7 @@ export class TDPCodec extends Codec implements Codec {
 
   public readonly encode = async (
     node: stencila.Node,
-    { filePath }: GlobalEncodeOptions = {}
+    { filePath }: GlobalEncodeOptions = defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const cw = node as stencila.CreativeWork
 

--- a/src/codecs/types.ts
+++ b/src/codecs/types.ts
@@ -1,4 +1,5 @@
 import * as stencila from '@stencila/schema'
+import { getTheme, ThemeNames } from '@stencila/thema'
 import { VFile } from '../util/vfile'
 
 export interface GlobalEncodeOptions<CodecOptions extends object = {}> {
@@ -6,8 +7,12 @@ export interface GlobalEncodeOptions<CodecOptions extends object = {}> {
   filePath?: string
   isStandalone?: boolean
   isBundle?: boolean
-  theme?: 'eLife' | 'stencila'
+  theme: ThemeNames
   codecOptions?: CodecOptions
+}
+
+export const defaultEncodeOptions: GlobalEncodeOptions = {
+  theme: getTheme()
 }
 
 /**

--- a/src/codecs/types.ts
+++ b/src/codecs/types.ts
@@ -68,6 +68,8 @@ export abstract class Codec<
     options?: DecodeOptions
   ) => Promise<stencila.Node>
 
+  protected defaultEncodeOptions = defaultEncodeOptions
+
   /**
    * Encode a `stencila.Node` to a `VFile`.
    *

--- a/src/codecs/xlsx/index.ts
+++ b/src/codecs/xlsx/index.ts
@@ -9,7 +9,7 @@ import { range } from 'fp-ts/lib/Array'
 import { pipe } from 'fp-ts/lib/pipeable'
 import * as xlsx from 'xlsx'
 import * as vfile from '../../util/vfile'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, defaultEncodeOptions, GlobalEncodeOptions } from '../types'
 
 const cellNameRegEx = /^([A-Z]+)([1-9][0-9]*)$/
 
@@ -30,7 +30,7 @@ export class XlsxCodec extends Codec implements Codec {
 
   public readonly encode = async (
     node: stencila.Node,
-    { format = 'xlsx' }: GlobalEncodeOptions = {}
+    { format = 'xlsx' }: GlobalEncodeOptions = defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const workbook = encodeNode(node)
     const buffer = xlsx.write(workbook, {

--- a/src/codecs/xlsx/index.ts
+++ b/src/codecs/xlsx/index.ts
@@ -9,7 +9,7 @@ import { range } from 'fp-ts/lib/Array'
 import { pipe } from 'fp-ts/lib/pipeable'
 import * as xlsx from 'xlsx'
 import * as vfile from '../../util/vfile'
-import { Codec, defaultEncodeOptions, GlobalEncodeOptions } from '../types'
+import { Codec, GlobalEncodeOptions } from '../types'
 
 const cellNameRegEx = /^([A-Z]+)([1-9][0-9]*)$/
 
@@ -30,7 +30,7 @@ export class XlsxCodec extends Codec implements Codec {
 
   public readonly encode = async (
     node: stencila.Node,
-    { format = 'xlsx' }: GlobalEncodeOptions = defaultEncodeOptions
+    { format = 'xlsx' }: GlobalEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const workbook = encodeNode(node)
     const buffer = xlsx.write(workbook, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,11 @@
 import * as stencila from '@stencila/schema'
 import mime from 'mime'
 import path from 'path'
-import { Codec, GlobalEncodeOptions } from './codecs/types'
+import {
+  Codec,
+  defaultEncodeOptions,
+  GlobalEncodeOptions
+} from './codecs/types'
 import * as vfile from './util/vfile'
 
 type VFile = vfile.VFile
@@ -222,7 +226,7 @@ export async function decode(
  */
 export const encode = async (
   node: stencila.Node,
-  options: GlobalEncodeOptions = {}
+  options: GlobalEncodeOptions = defaultEncodeOptions
 ): Promise<VFile> => {
   const { filePath, format } = options
   if (!(filePath || format)) {
@@ -258,7 +262,7 @@ export async function load(
 export async function dump(
   node: stencila.Node,
   format: string,
-  options: GlobalEncodeOptions = {}
+  options: GlobalEncodeOptions = defaultEncodeOptions
 ): Promise<string> {
   const file = await encode(node, { ...options, format })
   return vfile.dump(file)
@@ -291,7 +295,7 @@ export async function read(
 export async function write(
   node: stencila.Node,
   filePath: string,
-  options: GlobalEncodeOptions = {}
+  options: GlobalEncodeOptions = defaultEncodeOptions
 ): Promise<VFile> {
   const file = await encode(node, { ...options, filePath })
   await vfile.write(file, filePath)
@@ -321,6 +325,7 @@ export async function convert(
   const node = await decode(inputFile, input, from)
 
   const outputFile = await encode(node, {
+    ...defaultEncodeOptions,
     format: to,
     filePath: outputPath,
     ...encodeOptions

--- a/src/process.ts
+++ b/src/process.ts
@@ -2,6 +2,7 @@ import * as stencila from '@stencila/schema'
 import assert from 'assert'
 import path from 'path'
 import { dump, load, read, write } from '.'
+import { defaultEncodeOptions } from './codecs/types'
 import { coerce } from './util/coerce'
 import { validate } from './util/validate'
 
@@ -57,6 +58,7 @@ export default async function process(
             _get(meta.export),
             meta.to || code.programmingLanguage,
             {
+              ...defaultEncodeOptions,
               isStandalone: false
             }
           )
@@ -210,7 +212,7 @@ export default async function process(
   ): Promise<void> {
     try {
       const targetPath = './' + path.join(dir, target)
-      await write(node, targetPath, { format })
+      await write(node, targetPath, { ...defaultEncodeOptions, format })
     } catch (error) {
       throw Error(`Error: writing "${target}": ${error} `)
     }


### PR DESCRIPTION
Closes #245 

~~⚠️ This PR is dependent on https://github.com/stencila/thema/pull/12 and will fail until that PR is merged, and Thema updated in this PR~~ Done ✅ 

This PR:
- Removes hard-coded theme names, and instead uses the `themes` object exposed by Thema
- Adds a `defaultEncodeOptions` object that is used as the fallback value for `encode` functions, this was done to better reflect the fact that a `theme` value is always present and while optional, it's never `undefined`. The `defaultEncodeOptions` should also allow for easier future additions down the road.