### PR TITLE
Pandoc updates

### DIFF
--- a/src/codecs/pandoc/__file_snapshots__/cite.yaml
+++ b/src/codecs/pandoc/__file_snapshots__/cite.yaml
@@ -1,0 +1,46 @@
+type: Article
+title: Untitled
+authors: []
+bibliography:
+  - author:
+      - family:
+          type: Paragraph
+          content:
+            - Watson
+        given:
+          type: Paragraph
+          content:
+            - J. D.
+      - family:
+          type: Paragraph
+          content:
+            - Crick
+        given:
+          type: Paragraph
+          content:
+            - F. H. C.
+    id:
+      type: Paragraph
+      content:
+        - WatsonCrick1953
+content:
+  - type: Paragraph
+    content:
+      - 'Citations in line '
+      - target: WatsonCrick1953
+        citationMode: normal
+        type: Cite
+        content:
+          - '@WatsonCrick1953'
+      - ' or grouped in brackets '
+      - items:
+          - target: WatsonCrick1953
+            citationMode: normal
+            type: Cite
+            content:
+              - '[@WatsonCrick1953; @WatsonCrick1953]'
+          - target: WatsonCrick1953
+            citationMode: normal
+            type: Cite
+        type: CiteGroup
+      - .

--- a/src/codecs/pandoc/__fixtures__/README.md
+++ b/src/codecs/pandoc/__fixtures__/README.md
@@ -1,0 +1,11 @@
+# Test fixtures for Pandoc
+
+These tests fixtures are intended to be used with the `pandoc` codec, which by default imports and exports Pandoc JSON. But because no one wants to write Pandoc JSON by hand, this folder contains files in other formats from which Pandoc JSON is generated using `pandoc-json.sh` e.g.
+
+```bash
+./pandoc-json.sh cite.md > cite.pandoc.json
+```
+
+This provides an easy way to quickly see the structure of the Pandoc JSON that needs to be decoded/encoded by this codec.
+
+Please don't use these "other format" files e.g. `*.md` in the Pandoc tests. Instead prefer adding fixtures to the codec for the "other format" e.g. `md` codec.

--- a/src/codecs/pandoc/__fixtures__/cite-bib-file.bib
+++ b/src/codecs/pandoc/__fixtures__/cite-bib-file.bib
@@ -1,0 +1,9 @@
+@article{WatsonCrick1953,
+  title={Molecular structure of nucleic acids},
+  author={Watson, James D and Crick, Francis HC and others},
+  journal={Nature},
+  volume={171},
+  number={4356},
+  pages={737--738},
+  year={1953}
+}

--- a/src/codecs/pandoc/__fixtures__/cite-bib-file.md
+++ b/src/codecs/pandoc/__fixtures__/cite-bib-file.md
@@ -1,0 +1,5 @@
+---
+bibliography: cite-bib-file.bib
+---
+
+Bibliography in a file @WatsonCrick1953.

--- a/src/codecs/pandoc/__fixtures__/cite-bib-file.pandoc.json
+++ b/src/codecs/pandoc/__fixtures__/cite-bib-file.pandoc.json
@@ -1,0 +1,81 @@
+{
+  "blocks": [
+    {
+      "t": "Para",
+      "c": [
+        {
+          "t": "Str",
+          "c": "Bibliography"
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Str",
+          "c": "in"
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Str",
+          "c": "a"
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Str",
+          "c": "file"
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Cite",
+          "c": [
+            [
+              {
+                "citationSuffix": [],
+                "citationNoteNum": 0,
+                "citationMode": {
+                  "t": "AuthorInText"
+                },
+                "citationPrefix": [],
+                "citationId": "WatsonCrick1953",
+                "citationHash": 0
+              }
+            ],
+            [
+              {
+                "t": "Str",
+                "c": "@WatsonCrick1953"
+              }
+            ]
+          ]
+        },
+        {
+          "t": "Str",
+          "c": "."
+        }
+      ]
+    }
+  ],
+  "pandoc-api-version": [
+    1,
+    17,
+    5,
+    4
+  ],
+  "meta": {
+    "bibliography": {
+      "t": "MetaInlines",
+      "c": [
+        {
+          "t": "Str",
+          "c": "cite-bib-file.bib"
+        }
+      ]
+    }
+  }
+}

--- a/src/codecs/pandoc/__fixtures__/cite.md
+++ b/src/codecs/pandoc/__fixtures__/cite.md
@@ -1,0 +1,11 @@
+---
+bibliography:
+  - id: WatsonCrick1953
+    author:
+      - family: Watson
+        given: J. D.
+      - family: Crick
+        given: F. H. C.
+---
+
+Citations in line @WatsonCrick1953 or grouped in brackets [@WatsonCrick1953; @WatsonCrick1953].

--- a/src/codecs/pandoc/__fixtures__/cite.pandoc.json
+++ b/src/codecs/pandoc/__fixtures__/cite.pandoc.json
@@ -1,0 +1,227 @@
+{
+  "blocks": [
+    {
+      "t": "Para",
+      "c": [
+        {
+          "t": "Str",
+          "c": "Citations"
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Str",
+          "c": "in"
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Str",
+          "c": "line"
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Cite",
+          "c": [
+            [
+              {
+                "citationSuffix": [],
+                "citationNoteNum": 0,
+                "citationMode": {
+                  "t": "AuthorInText"
+                },
+                "citationPrefix": [],
+                "citationId": "WatsonCrick1953",
+                "citationHash": 0
+              }
+            ],
+            [
+              {
+                "t": "Str",
+                "c": "@WatsonCrick1953"
+              }
+            ]
+          ]
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Str",
+          "c": "or"
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Str",
+          "c": "grouped"
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Str",
+          "c": "in"
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Str",
+          "c": "brackets"
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Cite",
+          "c": [
+            [
+              {
+                "citationSuffix": [],
+                "citationNoteNum": 0,
+                "citationMode": {
+                  "t": "NormalCitation"
+                },
+                "citationPrefix": [],
+                "citationId": "WatsonCrick1953",
+                "citationHash": 0
+              },
+              {
+                "citationSuffix": [],
+                "citationNoteNum": 0,
+                "citationMode": {
+                  "t": "NormalCitation"
+                },
+                "citationPrefix": [],
+                "citationId": "WatsonCrick1953",
+                "citationHash": 0
+              }
+            ],
+            [
+              {
+                "t": "Str",
+                "c": "[@WatsonCrick1953;"
+              },
+              {
+                "t": "Space"
+              },
+              {
+                "t": "Str",
+                "c": "@WatsonCrick1953]"
+              }
+            ]
+          ]
+        },
+        {
+          "t": "Str",
+          "c": "."
+        }
+      ]
+    }
+  ],
+  "pandoc-api-version": [
+    1,
+    17,
+    5,
+    4
+  ],
+  "meta": {
+    "bibliography": {
+      "t": "MetaList",
+      "c": [
+        {
+          "t": "MetaMap",
+          "c": {
+            "author": {
+              "t": "MetaList",
+              "c": [
+                {
+                  "t": "MetaMap",
+                  "c": {
+                    "family": {
+                      "t": "MetaInlines",
+                      "c": [
+                        {
+                          "t": "Str",
+                          "c": "Watson"
+                        }
+                      ]
+                    },
+                    "given": {
+                      "t": "MetaInlines",
+                      "c": [
+                        {
+                          "t": "Str",
+                          "c": "J."
+                        },
+                        {
+                          "t": "Space"
+                        },
+                        {
+                          "t": "Str",
+                          "c": "D."
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "t": "MetaMap",
+                  "c": {
+                    "family": {
+                      "t": "MetaInlines",
+                      "c": [
+                        {
+                          "t": "Str",
+                          "c": "Crick"
+                        }
+                      ]
+                    },
+                    "given": {
+                      "t": "MetaInlines",
+                      "c": [
+                        {
+                          "t": "Str",
+                          "c": "F."
+                        },
+                        {
+                          "t": "Space"
+                        },
+                        {
+                          "t": "Str",
+                          "c": "H."
+                        },
+                        {
+                          "t": "Space"
+                        },
+                        {
+                          "t": "Str",
+                          "c": "C."
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            "id": {
+              "t": "MetaInlines",
+              "c": [
+                {
+                  "t": "Str",
+                  "c": "WatsonCrick1953"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/codecs/pandoc/__fixtures__/pandoc-json.sh
+++ b/src/codecs/pandoc/__fixtures__/pandoc-json.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# A little script for generating test fixture in Pandoc JSON
+# from files in other formats which are eiseir to author
+
+../../../../vendor/pandoc/bin/pandoc $1 --to json | jq .
+

--- a/src/codecs/pandoc/types.ts
+++ b/src/codecs/pandoc/types.ts
@@ -354,10 +354,8 @@ export interface Citation {
   citationHash: number
 }
 
-export enum CitationMode {
-  'AuthorInText',
-  'SuppressAuthor',
-  'NormalCitation'
+export interface CitationMode {
+  t: 'AuthorInText' | 'SuppressAuthor' | 'NormalCitation'
 }
 
 /**


### PR DESCRIPTION
This adds handling for nodes that are currently not handled by the `pandoc` codec. The impetus for this wanting to demo conversion of a published article from JATS to Word and back again. This took a long time and resulted in a messy `.docx` because any unhandled node gets converted to a rPNG.

- [x] `Superscript` and `Subscript` - straightforward.
- [ ] `Cite` and `CiteGroup` - currently implemented but needs more consideration, in particular on how these get eventually encoded to `docx`
- [ ] `Math` - this is something that is often requested and seems well supported in Pandoc - but we do not yet have support in the schema for these node types

This is WIP and, given our current workplan, I'm just parking it here to come back to when conversion to/from Word is more of a priority.