### PR TITLE
HTML: Refactor decoding

### DIFF
--- a/src/codecs/html/html.test.ts
+++ b/src/codecs/html/html.test.ts
@@ -60,6 +60,20 @@ describe('String escaping', () => {
   })
 })
 
+describe('Decode container elements', () => {
+  test('Nested divs and spans', async () => {
+    expect(
+      await d('<div><div><p><span><strong>Stroonnng</strong<</span></p></div></div>'),
+    ).toEqual({
+      type: 'Paragraph',
+      content: [{
+        type: 'Strong',
+        content: ['Stroonnng']
+      }]
+    })
+  })
+})
+
 describe('Encode & Decode cite nodes', () => {
   const schemaNode = cite('myTarget')
   const htmlNode = `<cite><a href="#myTarget">myTarget</a></cite>`


### PR DESCRIPTION
This refactors the approach to decoding HTML to handle the container elements such as `div` and `span` where we wish to return an array of nodes.