### PR TITLE
Part Deux: CodeChunk component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1625,9 +1625,9 @@
       }
     },
     "@stencila/thema": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@stencila/thema/-/thema-1.4.3.tgz",
-      "integrity": "sha512-pVXUHAP/URd06uUQRz0HvU5FbiOciv1WxEEjaNRSYiAHopT697NXlydHLDWgqSlN3CIAN/K7JN8xqcNGsp/+XQ=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@stencila/thema/-/thema-1.5.1.tgz",
+      "integrity": "sha512-CsA9SKE6DNxS+OXBR2AlDgh7dTQifdmH5DnGaZynWVELz6bcjhYiYmqsKppe2M6UhvQG+UBTavWnFn43bPXjKg=="
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
@@ -5959,8 +5959,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5981,14 +5980,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6003,20 +6000,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6133,8 +6127,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6146,7 +6139,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6161,7 +6153,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6169,14 +6160,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6195,7 +6184,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6276,8 +6264,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6289,7 +6276,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6375,8 +6361,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6412,7 +6397,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6432,7 +6416,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6476,14 +6459,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@stencila/logga": "^1.3.0",
     "@stencila/schema": "^0.29.0",
-    "@stencila/thema": "^1.4.3",
+    "@stencila/thema": "^1.5.1",
     "ajv": "^6.10.0",
     "appdata-path": "^1.0.0",
     "async-lock": "^1.2.0",

--- a/src/codecs/html/index.ts
+++ b/src/codecs/html/index.ts
@@ -1178,7 +1178,7 @@ function decodeCodeBlock(elem: HTMLPreElement): stencila.CodeBlock {
 function encodeCodeBlock(block: stencila.CodeBlock): HTMLPreElement {
   const attrs = encodeDataAttrs(block.meta || {})
   const code = encodeCode(block, false)
-  return h('pre', attrs, code)
+  return h('pre', { attrs }, code)
 }
 
 function encodeCodeOutput(node: stencila.Node): HTMLElement {
@@ -1704,16 +1704,21 @@ function decodeDataAttrs(
   return Object.keys(dict).length ? dict : undefined
 }
 
+// These attribute names are fully-formed, and should not be prefixed with `data-`
+const reservedAttrs = ['slot', 'name']
+
 /**
  * Encode a dictionary of strings to `data-` attributes to add to
  * an element (the inverse of `decodeDataAttrs`).
  */
 function encodeDataAttrs(meta: { [key: string]: string }): typeof meta {
-  const attrs: { [key: string]: string } = {}
-  for (const [key, value] of Object.entries(meta)) {
-    attrs['data-' + key] = value
-  }
-  return attrs
+  return Object.entries(meta).reduce(
+    (attrs, [key, value]) => ({
+      ...attrs,
+      [reservedAttrs.includes(key) ? key : `data-${key}`]: value
+    }),
+    {}
+  )
 }
 
 /**


### PR DESCRIPTION
This PR is a followup to https://github.com/stencila/encoda/pull/270

It:
- Updates the Thema dependency to generate better styled CodeChunks
- Fixes the resolution of Web Components on UNPKG CDN
- Fixes encoding of `name` & `slot` attributes by not prefixing them with `data-`