### PR TITLE
Wrap CodeOutput in <output> tags, Encode CodeExpressions inline HTML elements

### DIFF
--- a/src/codecs/html/html.test.ts
+++ b/src/codecs/html/html.test.ts
@@ -2,6 +2,7 @@ import stencila, {
   article,
   cite,
   citeGroup,
+  codeExpression,
   collection,
   creativeWork,
   figure,
@@ -15,7 +16,7 @@ import fs from 'fs'
 import { JSDOM } from 'jsdom'
 import * as vfile from '../../util/vfile'
 import { defaultEncodeOptions } from '../types'
-import { HTMLCodec, decodeHref } from './'
+import { decodeHref, HTMLCodec } from './'
 
 const doc = (innerHTML: string) =>
   new JSDOM(innerHTML).window.document.documentElement
@@ -111,6 +112,29 @@ describe('Encode & Decode cite nodes', () => {
     expect(actual).toHaveProperty('target', 'myTarget')
     expect(actual).toHaveProperty('prefix', '(')
     expect(actual).toHaveProperty('suffix', ')')
+  })
+})
+
+describe('Encode & Decode code-expression nodes', () => {
+  const codeExpressionSchema = codeExpression('x * 2', {
+    output: '42',
+    programmingLanguage: 'python'
+  })
+  const codeExpressionHTML =
+    '<stencila-codeexpression programming-language="python"><code slot="code">x * 2</code><output slot="output">42</output></stencila-codeexpression>'
+
+  test('encode', async () => {
+    const actual = doc(await e(codeExpressionSchema))
+    const code = actual.getElementsByTagName('code')[0]
+    const output = actual.getElementsByTagName('output')[0]
+
+    expect(actual).toContainElement(code)
+    expect(actual).toContainElement(output)
+  })
+
+  test('decode', async () => {
+    const c = await d(codeExpressionHTML)
+    expect(c).toMatchObject(codeExpressionSchema)
   })
 })
 

--- a/src/codecs/html/html.test.ts
+++ b/src/codecs/html/html.test.ts
@@ -121,7 +121,7 @@ describe('Encode & Decode code-expression nodes', () => {
     programmingLanguage: 'python'
   })
   const codeExpressionHTML =
-    '<stencila-codeexpression programming-language="python"><code slot="code">x * 2</code><output slot="output">42</output></stencila-codeexpression>'
+    '<stencila-code-expression programming-language="python"><code slot="text">x * 2</code><output slot="output">42</output></stencila-code-expression>'
 
   test('encode', async () => {
     const actual = doc(await e(codeExpressionSchema))

--- a/src/codecs/html/index.ts
+++ b/src/codecs/html/index.ts
@@ -1259,13 +1259,12 @@ const decodeCodeOutput = (elem: HTMLElement): stencila.Node => {
 }
 
 /**
- * Encode an output of a `CodeChunk` or `CodeExpression` as
- * a `HTMLElement`.
+ * Encode an output of a `CodeChunk` as an `HTMLElement`.
  */
 const encodeCodeOutput = (node: stencila.Node): Node => {
   switch (nodeType(node)) {
     case 'string':
-      return h('pre', node as string)
+      return h('pre', h('output', node as string))
     default:
       return encodeNode(node)
   }

--- a/src/codecs/html/index.ts
+++ b/src/codecs/html/index.ts
@@ -293,7 +293,7 @@ function decodeNode(node: Node): stencila.Node | stencila.Node[] {
         return decodeCodeBlock(node as HTMLPreElement)
       }
       break
-    case 'stencila-codechunk':
+    case 'stencila-code-chunk':
       return decodeCodeChunk(node as HTMLElement)
     case 'ul':
       return decodeList(node as HTMLUListElement)
@@ -328,7 +328,7 @@ function decodeNode(node: Node): stencila.Node | stencila.Node[] {
       return decodeCite(node as HTMLElement)
     case 'stencila:CiteGroup':
       return decodeCiteGroup(node as HTMLOListElement)
-    case 'stencila-codeexpression':
+    case 'stencila-code-expression':
       return decodeCodeExpression(node as HTMLElement)
     case 'code':
       return decodeCodeFragment(node as HTMLElement)
@@ -1172,10 +1172,10 @@ function encodeCodeBlock(block: stencila.CodeBlock): HTMLPreElement {
 }
 
 /**
- * Decode a `<stencila-codechunk>` element to a Stencila `CodeChunk`.
+ * Decode a `<stencila-code-chunk>` element to a Stencila `CodeChunk`.
  */
 function decodeCodeChunk(chunk: HTMLElement): stencila.CodeChunk {
-  const codeElem = chunk.querySelector('[slot="code"]')
+  const codeElem = chunk.querySelector('[slot="text"]')
   const codeFrag = decodeCodeFragment(codeElem as HTMLElement)
   const { text, programmingLanguage } = codeFrag
 
@@ -1188,7 +1188,7 @@ function decodeCodeChunk(chunk: HTMLElement): stencila.CodeChunk {
 }
 
 /**
- * Encode a Stencila `CodeChunk` to a `<stencila-codechunk>` element.
+ * Encode a Stencila `CodeChunk` to a `<stencila-code-chunk>` element.
  */
 function encodeCodeChunk(chunk: stencila.CodeChunk): HTMLElement {
   const { text = '', meta = {}, programmingLanguage, outputs } = chunk
@@ -1198,7 +1198,7 @@ function encodeCodeChunk(chunk: stencila.CodeChunk): HTMLElement {
   const codeElem = encodeCodeBlock(
     stencila.codeBlock(text, { programmingLanguage })
   )
-  codeElem.setAttribute('slot', 'code')
+  codeElem.setAttribute('slot', 'text')
 
   const outputsElem = encodeMaybe(outputs, outputs =>
     h(
@@ -1212,14 +1212,14 @@ function encodeCodeChunk(chunk: stencila.CodeChunk): HTMLElement {
     )
   )
 
-  return h('stencila-codechunk', attrs, codeElem, outputsElem)
+  return h('stencila-code-chunk', attrs, codeElem, outputsElem)
 }
 
 /**
- * Decode a `<stencila-codeexpression>` element to a Stencila `CodeExpression`.
+ * Decode a `<stencila-code-expression>` element to a Stencila `CodeExpression`.
  */
 function decodeCodeExpression(elem: HTMLElement): stencila.CodeExpression {
-  const codeElem = elem.querySelector('[slot="code"]')
+  const codeElem = elem.querySelector('[slot="text"]')
   const { text, ...codeFragment } = decodeCodeFragment(codeElem as HTMLElement)
   const programmingLanguage =
     elem.getAttribute('programming-language') ||
@@ -1235,22 +1235,30 @@ function decodeCodeExpression(elem: HTMLElement): stencila.CodeExpression {
 }
 
 /**
- * Encode a Stencila `CodeExpression` to a `<stencila-codeexpression>` element.
+ * Encode a Stencila `CodeExpression` to a `<stencila-code-expression>` element.
  */
 function encodeCodeExpression(expr: stencila.CodeExpression): HTMLElement {
   const attrs = encodeDataAttrs(expr.meta || {})
   if (expr.programmingLanguage)
     attrs['programming-language'] = expr.programmingLanguage
 
-  return h('stencila-codeexpression', { attrs }, [
-    h('code', { class: expr.programmingLanguage }, expr.text),
-    h('output', [encodeNode(expr.output || '')].filter(isInlineContent))
+  return h('stencila-code-expression', { attrs }, [
+    h(
+      'code',
+      { class: expr.programmingLanguage, attrs: { slot: 'text' } },
+      expr.text
+    ),
+    h(
+      'output',
+      { attrs: { slot: 'output' } },
+      [encodeNode(expr.output || '')].filter(isInlineContent)
+    )
   ])
 }
 
 /**
- * Decode an output element of a `<stencila-codechunk>` or
- * `<stencila-codeexpression>` to Stencila Node.
+ * Decode an output element of a `<stencila-code-chunk>` or
+ * `<stencila-code-expression>` to Stencila Node.
  */
 const decodeCodeOutput = (elem: HTMLElement): stencila.Node => {
   switch (elem.nodeName.toLowerCase()) {

--- a/src/codecs/rnb/index.ts
+++ b/src/codecs/rnb/index.ts
@@ -138,7 +138,7 @@ export class RnbCodec extends Codec implements Codec {
       const html = container.innerHTML
       container.innerHTML =
         html.slice(0, begin) +
-        `<stencila-codeexpression>
+        `<stencila-codeexpression programming-language="r">
           <code class="language-r" slot="code">${source}</code>
           <span slot="output">${output}</span>
         </stencila-codeexpression>` +

--- a/src/codecs/rnb/index.ts
+++ b/src/codecs/rnb/index.ts
@@ -1,10 +1,10 @@
-import * as stencila from '@stencila/schema'
 import { getLogger } from '@stencila/logga'
+import * as stencila from '@stencila/schema'
 import fs from 'fs-extra'
-import { load, text, first, all, elem } from '../../util/html'
+import { all, elem, first, load, text } from '../../util/html'
 import * as vfile from '../../util/vfile'
-import { Codec } from '../types'
 import { HTMLCodec } from '../html'
+import { Codec } from '../types'
 import { XmdCodec } from '../xmd'
 
 const htmlCodec = new HTMLCodec()
@@ -40,12 +40,12 @@ export class RnbCodec extends Codec implements Codec {
     // Replace delimiting comments with opening and closing HTML tags
     // so that we can handle these below
     const html = rnb
-      .replace(/<!-- rnb-chunk-begin -->/g, '<stencila-codechunk>')
+      .replace(/<!-- rnb-chunk-begin -->/g, '<stencila-code-chunk>')
       .replace(/<!-- rnb-source-begin [\w=]+ -->/g, '<rnb-source>')
       .replace(/<!-- rnb-source-end -->/g, '</rnb-source>')
       .replace(/<!-- rnb-(output|plot|frame)-begin [\w=]+ -->/g, '<rnb-output>')
       .replace(/<!-- rnb-(output|plot|frame)-end -->/g, '</rnb-output>')
-      .replace(/<!-- rnb-chunk-end -->/g, '</stencila-codechunk>')
+      .replace(/<!-- rnb-chunk-end -->/g, '</stencila-code-chunk>')
 
     // Transform the HTML so that it is in the format expected by the `html` codec...
 
@@ -138,16 +138,16 @@ export class RnbCodec extends Codec implements Codec {
       const html = container.innerHTML
       container.innerHTML =
         html.slice(0, begin) +
-        `<stencila-codeexpression programming-language="r">
-          <code class="language-r" slot="code">${source}</code>
+        `<stencila-code-expression programming-language="r">
+          <code class="language-r" slot="text">${source}</code>
           <span slot="output">${output}</span>
-        </stencila-codeexpression>` +
+        </stencila-code-expression>` +
         html.slice(end)
     }
 
     // In R Notebooks, when a code chunk has multiple outputs it is split into multiple
     // <rnb-source> and <rnb-output> elements...
-    for (const chunkElem of all(contentElem, 'stencila-codechunk')) {
+    for (const chunkElem of all(contentElem, 'stencila-code-chunk')) {
       // So join all the source code into one `<pre><code>` element
       const sourceElems = all(chunkElem, 'rnb-source')
       const source = sourceElems
@@ -161,7 +161,7 @@ export class RnbCodec extends Codec implements Codec {
         elem(
           'pre',
           {},
-          elem('code', { slot: 'code', class: 'language-r' }, source)
+          elem('code', { slot: 'text', class: 'language-r' }, source)
         )
       )
 

--- a/src/codecs/rpng/__fixtures__/test.html
+++ b/src/codecs/rpng/__fixtures__/test.html
@@ -27,39 +27,39 @@
     <div>
       Here is a code expressions in some text
       <div id="target">
-        <stencila-codeexpression>
-          <pre slot="code"><code>x * y</code></pre>
+        <stencila-code-expression>
+          <pre slot="text"><code>x * y</code></pre>
           <pre slot="output">42.42</pre>
-        </stencila-codeexpression>
+        </stencila-code-expression>
       </div>
       followed by some more text.
       This one has no output
       <div id="target">
-        <stencila-codeexpression>
-          <pre slot="code"><code>x * y</code></pre>
-        </stencila-codeexpression>
+        <stencila-code-expression>
+          <pre slot="text"><code>x * y</code></pre>
+        </stencila-code-expression>
       </div>. Lorem ipsum
       <div id="target">
-        <stencila-codeexpression>
-          <pre slot="code"><code>x * y</code></pre>
+        <stencila-code-expression>
+          <pre slot="text"><code>x * y</code></pre>
           <pre slot="output">3</pre>
-        </stencila-codeexpression>
+        </stencila-code-expression>
       </div>
       dolor sit amet
       consectetur adipisicing elit. Libero odit
       <div id="target">
-          <stencila-codeexpression>
-            <pre slot="code"><code>x * y</code></pre>
+          <stencila-code-expression>
+            <pre slot="text"><code>x * y</code></pre>
             <pre slot="output">Some longer output</pre>
-          </stencila-codeexpression>
+          </stencila-code-expression>
       </div>
       totam maxime neque?
       Id, alias? In quas veritatis cumque quaerat id
       <div id="target">
-          <stencila-codeexpression>
-            <pre slot="code"><code>x * y</code></pre>
+          <stencila-code-expression>
+            <pre slot="text"><code>x * y</code></pre>
             <pre slot="output">Reaaaaalllyyyyyyyy loooongggggggggggggggggggg output</pre>
-          </stencila-codeexpression>
+          </stencila-code-expression>
       </div>
       iusto neque maiores voluptatibus
       natus iure harum, assumenda explicabo?
@@ -70,17 +70,17 @@
     <p>A code chunk with no output. Lorem, ipsum dolor sit amet consectetur adipisicing elit. Repellendus excepturi aliquam voluptates dolore quo eius, perspiciatis nihil enim dolores saepe, sit, modi aut iusto! Placeat incidunt reiciendis magnam magni eius!</p>
 
     <div id="target">
-      <stencila-codechunk>
-        <pre slot="code"><code>Some code</code></pre>
+      <stencila-code-chunk>
+        <pre slot="text"><code>Some code</code></pre>
         <figure slot="outputs"></figure>
-      </stencila-codechunk>
+      </stencila-code-chunk>
     </div>
 
     <p>A code chunk with a single text output:</p>
 
     <div id="target">
-      <stencila-codechunk>
-        <pre slot="code"><code>print(lorem)</code></pre>
+      <stencila-code-chunk>
+        <pre slot="text"><code>print(lorem)</code></pre>
         <figure slot="outputs">
           <pre>
 Lorem, ipsum dolor sit amet consectetur adipisicing elit. Natus molestias libero
@@ -88,14 +88,14 @@ nostrum id sint sapiente consectetur blanditiis quam perferendis praesentium lab
 quas consequuntur nam modi qui quisquam vel, ab earum?
 </pre>
         </figure>
-      </stencila-codechunk>
+      </stencila-code-chunk>
     </div>
 
     <p>A code chunk with multiple text output. Lorem ipsum dolor sit amet consectetur adipisicing elit. Optio doloribus maxime distinctio tempora reiciendis praesentium delectus, harum nihil dolorum ipsum voluptate odio dicta voluptatibus et minus quaerat porro enim? Velit?</p>
 
     <div id="target">
-      <stencila-codechunk>
-        <pre slot="code"><code>print(lorem)</code></pre>
+      <stencila-code-chunk>
+        <pre slot="text"><code>print(lorem)</code></pre>
         <figure slot="outputs">
             <pre>Optimization terminated successfully.
         Current function value: 2038.118913
@@ -124,25 +124,25 @@ I(dist / 100.)    -0.6219      0.097     -6.383      0.000        -0.813    -0.4
 5       1     1.10  40.874001      1    14
 </pre>
         </figure>
-      </stencila-codechunk>
+      </stencila-code-chunk>
     </div>
 
     <p>A code chunk with an image output. Lorem ipsum dolor sit amet consectetur adipisicing elit. Suscipit, porro? Culpa numquam quam voluptatum beatae quidem harum soluta nobis blanditiis, repellendus placeat voluptate est sed impedit porro. Hic, rerum nemo.</p>
 
     <div id="target">
-      <stencila-codechunk>
-        <pre slot="code"><code>plot</code></pre>
+      <stencila-code-chunk>
+        <pre slot="text"><code>plot</code></pre>
         <figure slot="outputs">
           <img src="test.html.media/c6dc710b61000c08aff3a4b884b4fb86.png" itemprop="image">
       </figure>
-      </stencila-codechunk>
+      </stencila-code-chunk>
     </div>
 
     <p>A code chunk with a table output:</p>
 
     <div id="target">
-      <stencila-codechunk>
-        <pre slot="code"><code>plot</code></pre>
+      <stencila-code-chunk>
+        <pre slot="text"><code>plot</code></pre>
         <figure slot="outputs">
           <table>
             <tbody>
@@ -167,7 +167,7 @@ I(dist / 100.)    -0.6219      0.097     -6.383      0.000        -0.813    -0.4
             </tbody>
           </table>
         </figure>
-      </stencila-codechunk>
+      </stencila-code-chunk>
     </div>
 
     <h1>

--- a/src/codecs/rpng/index.ts
+++ b/src/codecs/rpng/index.ts
@@ -38,38 +38,38 @@ const encodeCss = `
   color: #333;
 }
 
-stencila-codechunk,
-stencila-codeexpression {
+stencila-code-chunk,
+stencila-code-expression {
   display: inline-block;
   border: 1px solid rgb(9, 58, 221);
 }
 
-stencila-codechunk {
+stencila-code-chunk {
   min-width: 2em;
   min-height: 2em;
   border-radius: 3px;
 }
 
-stencila-codeexpression {
+stencila-code-expression {
   min-width: 1em;
   min-height: 1em;
   border-radius: 500px;
 }
 
-stencila-codechunk [slot='code'],
-stencila-codeexpression [slot='code'] {
+stencila-code-chunk [slot='text'],
+stencila-code-expression [slot='text'] {
   display: none;
 }
 
-stencila-codechunk [slot='outputs'] {
+stencila-code-chunk [slot='outputs'] {
   margin: 1em;
 }
 
-stencila-codechunk [slot='outputs'] * {
+stencila-code-chunk [slot='outputs'] * {
   margin: 1em auto;
 }
 
-stencila-codeexpression [slot='output'] {
+stencila-code-expression [slot='output'] {
   display: inline-block;
   margin: 0.1em auto;
 }

--- a/src/codecs/rpng/rpng.css
+++ b/src/codecs/rpng/rpng.css
@@ -6,38 +6,38 @@
   color: #333;
 }
 
-stencila-codechunk,
-stencila-codeexpression {
+stencila-code-chunk,
+stencila-code-expression {
   display: inline-block;
   border: 1px solid rgb(9, 58, 221);
 }
 
-stencila-codechunk {
+stencila-code-chunk {
   min-width: 2em;
   min-height: 2em;
   border-radius: 3px;
 }
 
-stencila-codeexpression {
+stencila-code-expression {
   min-width: 1em;
   min-height: 1em;
   border-radius: 500px;
 }
 
-stencila-codechunk [slot='code'],
-stencila-codeexpression [slot='code'] {
+stencila-code-chunk [slot='text'],
+stencila-code-expression [slot='text'] {
   display: none;
 }
 
-stencila-codechunk [slot='outputs'] {
+stencila-code-chunk [slot='outputs'] {
   margin: 1em;
 }
 
-stencila-codechunk [slot='outputs'] * {
+stencila-code-chunk [slot='outputs'] * {
   margin: 1em auto;
 }
 
-stencila-codeexpression [slot='output'] {
+stencila-code-expression [slot='output'] {
   display: inline-block;
   margin: 0.1em auto;
 }
@@ -49,7 +49,7 @@ table {
 
 table th {
   color: #555;
-  background: rgba(0,0,0,.1);
+  background: rgba(0, 0, 0, 0.1);
 }
 
 table th,


### PR DESCRIPTION
Connects to https://github.com/stencila/designa/pull/17
Once the above PR is merged, we can add `@stencila/components` as a dependency and use the component exposed slot names in here for more resilient HTML generation.

- Wrap CodeOutput in <output> tags 
- Encode CodeExpressions as valid inline HTML elements