### PR TITLE
fix: Using relative paths in zip media creation

### DIFF
--- a/encoda
+++ b/encoda
@@ -2,5 +2,6 @@
 
 # A little script to make it a litle easier to test the CLI 
 # during development of this repo
-
+# change into the current directory of this script so it can be run from anywhere
+cd "$(dirname "$0")"
 npm run cli -- "$@"

--- a/src/index.ts
+++ b/src/index.ts
@@ -373,11 +373,13 @@ export async function convert(
       if (shouldZip === 'yes' || (files.length > 1 && shouldZip === 'maybe')) {
         const first = outputPaths_[0]
         let zipName = 'output.zip'
+        let outputDir = ''
         if (outputPaths_.length === 1 && first !== undefined) {
-          const {dir, name} = path.parse(first)
+          const { dir, name } = path.parse(first)
           zipName = path.join(dir, name + '.zip')
+          outputDir = dir
         }
-        return zip.create(zipName, files, { remove: true })
+        return zip.create(zipName, files, { remove: true, dir: outputDir })
       } else if (outputFile.contents !== undefined)
         return vfile.dump(outputFile)
       else return outputFile.path

--- a/src/util/zip.ts
+++ b/src/util/zip.ts
@@ -18,14 +18,24 @@ import JSZip from 'jszip'
 export const create = async (
   zipPath: string,
   files: string[],
-  options: { remove: boolean }
+  options: { remove: boolean; dir: string }
 ): Promise<string> => {
-  const { remove = false } = options
+  const { remove = false, dir = '' } = options
 
   const zip = new JSZip()
 
   for (const file of files) {
-    zip.file(file, fs.createReadStream(file))
+    let relativePath = file
+
+    if (dir !== '') {
+      let fullDir = dir
+      if (!fullDir.endsWith('/')) fullDir += '/'
+      if (file.startsWith(fullDir)) {
+        relativePath = file.substring(fullDir.length)
+      }
+    }
+
+    zip.file(relativePath, fs.createReadStream(file))
   }
 
   return new Promise(resolve => {

--- a/src/util/zip.ts
+++ b/src/util/zip.ts
@@ -6,6 +6,7 @@
 
 import fs from 'fs-extra'
 import JSZip from 'jszip'
+import * as path from 'path'
 
 /**
  * Create a Zip file
@@ -14,6 +15,7 @@ import JSZip from 'jszip'
  * @param files A list of file paths to include in the zip archive
  * @param options
  * @param options.remove Remove files after creating the zip archive?
+ * @param options.dir The directory being zipped, filenames will be relative to this.
  */
 export const create = async (
   zipPath: string,
@@ -25,17 +27,7 @@ export const create = async (
   const zip = new JSZip()
 
   for (const file of files) {
-    let relativePath = file
-
-    if (dir !== '') {
-      let fullDir = dir
-      if (!fullDir.endsWith('/')) fullDir += '/'
-      if (file.startsWith(fullDir)) {
-        relativePath = file.substring(fullDir.length)
-      }
-    }
-
-    zip.file(relativePath, fs.createReadStream(file))
+    zip.file(path.relative(dir, file), fs.createReadStream(file))
   }
 
   return new Promise(resolve => {


### PR DESCRIPTION
The full paths were getting pulled into the Zip file when it was created. This strips out the parent dir so only relative paths are in the zip.

Before:

```bash
$ unzip -l /Users/ben/Downloads/example.zip 
Archive:  /Users/ben/Downloads/example.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  09-17-2019 18:57   /Users/
        0  09-17-2019 18:57   /Users/ben/
        0  09-17-2019 18:57   /Users/ben/stencila_checkouts/
        0  09-17-2019 18:57   /Users/ben/stencila_checkouts/conversions/
        0  09-17-2019 18:57   /Users/ben/stencila_checkouts/conversions/b/
        0  09-17-2019 18:57   /Users/ben/stencila_checkouts/conversions/b/C/
        0  09-17-2019 18:57   /Users/ben/stencila_checkouts/conversions/b/C/bC3RYXonEUv/
     4590  09-17-2019 18:57   /Users/ben/stencila_checkouts/conversions/b/C/bC3RYXonEUv/example.html
        0  09-17-2019 18:57   /Users/ben/stencila_checkouts/conversions/b/C/bC3RYXonEUv/example.html.media/
   143891  09-17-2019 18:57   /Users/ben/stencila_checkouts/conversions/b/C/bC3RYXonEUv/example.html.media/image1.jpeg
     7110  09-17-2019 18:57   /Users/ben/stencila_checkouts/conversions/b/C/bC3RYXonEUv/example.html.media/image2.png
    13282  09-17-2019 18:57   /Users/ben/stencila_checkouts/conversions/b/C/bC3RYXonEUv/example.html.media/image3.png
```

After
```bash
$ unzip -l /Users/ben/Downloads/example-2.zip 
Archive:  /Users/ben/Downloads/example-2.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
     4590  09-17-2019 19:20   example.html
        0  09-17-2019 19:20   example.html.media/
   143891  09-17-2019 19:20   example.html.media/image1.jpeg
     7110  09-17-2019 19:20   example.html.media/image2.png
    13282  09-17-2019 19:20   example.html.media/image3.png
```