### PR TITLE
fix(RPNG Style): Update rPNG styling

### DIFF
--- a/src/codecs/rpng/__fixtures__/test.html
+++ b/src/codecs/rpng/__fixtures__/test.html
@@ -6,7 +6,7 @@
     <style>
       body {
         /* Microsoft Word-like styling. Beware what leeaks into rPNG style! */
-        font-family: Cambria, Cochin, Georgia, Times, 'Times New Roman', serif;
+        font-family: Lato, Cambria, Cochin, Georgia, Times, 'Times New Roman', serif;
         font-size: 12pt;
         line-height: 150%;
         max-width: 50rem;

--- a/src/codecs/rpng/index.ts
+++ b/src/codecs/rpng/index.ts
@@ -30,30 +30,33 @@ import { Codec, GlobalEncodeOptions } from '../types'
  * we just copy and paste this file in here.
  */
 const encodeCss = `
+:root {
+  /* --color-neutral: ; */
+  --color-neutral-100: #f7fafc;
+  --color-neutral-300: #e2e8f0;
+}
+
 #target {
   display: inline-block;
   font-family: monospace;
   font-size: 11pt;
   line-height: 150%;
   color: #333;
+  padding: 1px;
 }
 
 stencila-code-chunk,
 stencila-code-expression {
   display: inline-block;
-  border: 1px solid rgb(9, 58, 221);
+  background: var(--color-neutral-100);
+  border: 1px solid var(--color-neutral-300);
+  border-radius: 0.25rem;
 }
 
-stencila-code-chunk {
-  min-width: 2em;
-  min-height: 2em;
-  border-radius: 3px;
-}
-
+stencila-code-chunk,
 stencila-code-expression {
   min-width: 1em;
   min-height: 1em;
-  border-radius: 500px;
 }
 
 stencila-code-chunk [slot='text'],
@@ -69,9 +72,30 @@ stencila-code-chunk [slot='outputs'] * {
   margin: 1em auto;
 }
 
+stencila-code-chunk::before,
+stencila-code-expression::before {
+  content: 'code';
+  color: transparent;
+  height: 2em;
+  position: relative;
+  left: 0.5em;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  text-transform: uppercase;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgb(29, 100, 243)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' class='feather feather-code'%3E%3Cpolyline points='16 18 22 12 16 6'/%3E%3Cpolyline points='8 6 2 12 8 18'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+
+stencila-code-chunk::before {
+  top: 0.5em;
+  left: 1em;
+  padding-right: 0.5rem;
+}
+
 stencila-code-expression [slot='output'] {
   display: inline-block;
-  margin: 0.1em auto;
+  margin: 0.1em 0.5em 0.1em auto;
 }
 
 table {
@@ -81,7 +105,7 @@ table {
 
 table th {
   color: #555;
-  background: rgba(0,0,0,.1);
+  background: rgba(0, 0, 0, 0.1);
 }
 
 table th,

--- a/src/codecs/rpng/rpng.css
+++ b/src/codecs/rpng/rpng.css
@@ -1,3 +1,9 @@
+:root {
+  /* --color-neutral: ; */
+  --color-neutral-100: #f7fafc;
+  --color-neutral-300: #e2e8f0;
+}
+
 #target {
   display: inline-block;
   font-family: monospace;
@@ -9,19 +15,15 @@
 stencila-code-chunk,
 stencila-code-expression {
   display: inline-block;
-  border: 1px solid rgb(9, 58, 221);
+  background: var(--color-neutral-100);
+  border: 1px solid var(--color-neutral-300);
+  border-radius: 0.25rem;
 }
 
-stencila-code-chunk {
-  min-width: 2em;
-  min-height: 2em;
-  border-radius: 3px;
-}
-
+stencila-code-chunk,
 stencila-code-expression {
   min-width: 1em;
   min-height: 1em;
-  border-radius: 500px;
 }
 
 stencila-code-chunk [slot='text'],
@@ -37,9 +39,30 @@ stencila-code-chunk [slot='outputs'] * {
   margin: 1em auto;
 }
 
+stencila-code-chunk::before,
+stencila-code-expression::before {
+  content: 'code';
+  color: transparent;
+  height: 2em;
+  position: relative;
+  left: 0.5em;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  text-transform: uppercase;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgb(29, 100, 243)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' class='feather feather-code'%3E%3Cpolyline points='16 18 22 12 16 6'/%3E%3Cpolyline points='8 6 2 12 8 18'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+
+stencila-code-chunk::before {
+  top: 0.5em;
+  left: 1em;
+  padding-right: 0.5rem;
+}
+
 stencila-code-expression [slot='output'] {
   display: inline-block;
-  margin: 0.1em auto;
+  margin: 0.1em 0.5em 0.1em auto;
 }
 
 table {

--- a/src/codecs/rpng/rpng.css
+++ b/src/codecs/rpng/rpng.css
@@ -10,6 +10,7 @@
   font-size: 11pt;
   line-height: 150%;
   color: #333;
+  padding: 1px;
 }
 
 stencila-code-chunk,


### PR DESCRIPTION
Updating rPNG styles to look closer to CodeChunks and CodeExpressions in Thema previews, and using SVG code icon from feather icon set.

![Screen Shot 2019-09-24 at 5 17 52 PM](https://user-images.githubusercontent.com/10161095/65559730-aa2b6a00-def0-11e9-8d96-d32dd7504c7d.png)
