### PR TITLE
feat(Coerce): Allow for variants of property names and aliases

### DIFF
--- a/src/util/coerce.test.ts
+++ b/src/util/coerce.test.ts
@@ -60,6 +60,28 @@ describe('coerce', () => {
     })
   })
 
+  it('will rename property name and alias variants', async () => {
+    expect(
+      await coerce({
+        type: 'Person',
+        // A variant of a property alias `first-name` -> `firstName` -> `givenNames`
+        'first-name': 'John',
+        // A variant of a property name `family_names` -> `familyNames`
+        family_names: ['Jones'],
+        // A variant of a property alias `alternate name` -> `alternateName` -> `alternateNames`
+        'alternate name': 'Jono',
+        // A variant of a property alias
+        'telephone-number': '939393'
+      })
+    ).toEqual({
+      type: 'Person',
+      givenNames: ['John'],
+      familyNames: ['Jones'],
+      alternateNames: ['Jono'],
+      telephoneNumbers: ['939393']
+    })
+  })
+
   it('will remove additional properties', async () => {
     expect(
       await coerce({


### PR DESCRIPTION
In the JSON Schema we allow for property names to have aliases. However, it is laborious  to cover all the possible aliases that arise from using alternative conventions for word separation e.g camel case, snake case, kebab case, spaces. This allows for those alternative conventions.

The primary reason for this feature is to give users more flexibility when adding meta-data to documents. e.g. in YAML frontmatter in R Markdown. The need for flexibility was highlighted when creating examples for https://hub.stenci.la/open/
