### PR TITLE
fix(HTML): Use a major version of Thema styles

### DIFF
--- a/src/codecs/html/html.test.ts
+++ b/src/codecs/html/html.test.ts
@@ -404,18 +404,18 @@ test('encode with different themes', async () => {
 
   let html = await e({ theme: 'stencila' })
   expect(html).toMatch(
-    /<script src="https:\/\/unpkg\.com\/@stencila\/thema@\d\.\d\.\d\/dist\/themes\/stencila\/index\.js/
+    /<script src="https:\/\/unpkg\.com\/@stencila\/thema@\d\/dist\/themes\/stencila\/index\.js/
   )
   expect(html).toMatch(
-    /<link href="https:\/\/unpkg\.com\/@stencila\/thema@\d\.\d\.\d\/dist\/themes\/stencila\/styles\.css/
+    /<link href="https:\/\/unpkg\.com\/@stencila\/thema@\d\/dist\/themes\/stencila\/styles\.css/
   )
 
   html = await e({ theme: 'eLife' })
   expect(html).toMatch(
-    /<script src="https:\/\/unpkg\.com\/@stencila\/thema@\d\.\d\.\d\/dist\/themes\/eLife\/index\.js/
+    /<script src="https:\/\/unpkg\.com\/@stencila\/thema@\d\/dist\/themes\/eLife\/index\.js/
   )
   expect(html).toMatch(
-    /<link href="https:\/\/unpkg\.com\/@stencila\/thema@\d\.\d\.\d\/dist\/themes\/eLife\/styles\.css/
+    /<link href="https:\/\/unpkg\.com\/@stencila\/thema@\d\/dist\/themes\/eLife\/styles\.css/
   )
 })
 

--- a/src/codecs/html/index.ts
+++ b/src/codecs/html/index.ts
@@ -505,8 +505,9 @@ function generateHtmlElement(
       '..',
       'package.json'
     )).version
+    const themaMajor = themaVersion.split('.')[0]
 
-    const themeBaseUrl = `https://unpkg.com/@stencila/thema@${themaVersion}/${themePath}/${theme}`
+    const themeBaseUrl = `https://unpkg.com/@stencila/thema@${themaMajor}/${themePath}/${theme}`
     themeCss = h('link', {
       href: `${themeBaseUrl}/styles.css`,
       rel: 'stylesheet'


### PR DESCRIPTION
Takes a similar approach to that used for `@stencila/components`: uses major version for links to style sheets. This allows for non-breaking Thema fixes and features to be available, without a release of Encoda.
