### PR TITLE
fix(JATS): Fixes to encoding to JATS XML

### DIFF
--- a/src/codecs/__mocks__/crypto.js
+++ b/src/codecs/__mocks__/crypto.js
@@ -1,0 +1,7 @@
+const crypto = jest.genMockFromModule('crypto')
+
+crypto.randomBytes = function(size) {
+  return new Buffer(size).fill(0)
+}
+
+module.exports = crypto

--- a/src/codecs/jats/__file_snapshots__/elife-30274-v1.jats.xml
+++ b/src/codecs/jats/__file_snapshots__/elife-30274-v1.jats.xml
@@ -11,21 +11,21 @@
                     <surname>Lewis</surname>
                     <given-names>L Michelle</given-names>
                 </name>
-                <xref ref-type="aff" rid="f69418855a0b26ba9f73ae0f7bac0058"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Edwards</surname>
                     <given-names>Meredith C</given-names>
                 </name>
-                <xref ref-type="aff" rid="03652a29f075f8e2855b2fcb687ca5ab"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Meyers</surname>
                     <given-names>Zachary R</given-names>
                 </name>
-                <xref ref-type="aff" rid="36b3229d5be5364609d88a55b9dfe27c"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
@@ -33,21 +33,21 @@
                     <given-names>C Conover</given-names>
                     <suffix>Jr</suffix>
                 </name>
-                <xref ref-type="aff" rid="c1bf07c3d1cebc7e80242f1371a9bd5d"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Hao</surname>
                     <given-names>Haiping</given-names>
                 </name>
-                <xref ref-type="aff" rid="211e40670305750c935a465176829daa"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Blum</surname>
                     <given-names>David</given-names>
                 </name>
-                <xref ref-type="aff" rid="781c05c350496f0f760359edaac36bbc"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <string-name/>
@@ -82,22 +82,22 @@
                     <given-names>Timothy M</given-names>
                 </name>
             </contrib>
-            <aff id="f69418855a0b26ba9f73ae0f7bac0058">
+            <aff id="00000000000000000000000000000000">
                 <institution>University of Georgia, Bioexpression and Fermentation Facility</institution>
             </aff>
-            <aff id="03652a29f075f8e2855b2fcb687ca5ab">
+            <aff id="00000000000000000000000000000000">
                 <institution>University of Georgia, Bioexpression and Fermentation Facility</institution>
             </aff>
-            <aff id="36b3229d5be5364609d88a55b9dfe27c">
+            <aff id="00000000000000000000000000000000">
                 <institution>University of Georgia, Bioexpression and Fermentation Facility</institution>
             </aff>
-            <aff id="c1bf07c3d1cebc7e80242f1371a9bd5d">
+            <aff id="00000000000000000000000000000000">
                 <institution>Johns Hopkins University, Deep Sequencing and Microarray Core Facility</institution>
             </aff>
-            <aff id="211e40670305750c935a465176829daa">
+            <aff id="00000000000000000000000000000000">
                 <institution>Johns Hopkins University, Deep Sequencing and Microarray Core Facility</institution>
             </aff>
-            <aff id="781c05c350496f0f760359edaac36bbc">
+            <aff id="00000000000000000000000000000000">
                 <institution>University of Georgia, Bioexpression and Fermentation Facility</institution>
             </aff>
         </contrib-group>

--- a/src/codecs/jats/__file_snapshots__/elife-30274-v1.jats.xml
+++ b/src/codecs/jats/__file_snapshots__/elife-30274-v1.jats.xml
@@ -11,21 +11,21 @@
                     <surname>Lewis</surname>
                     <given-names>L Michelle</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="f69418855a0b26ba9f73ae0f7bac0058"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Edwards</surname>
                     <given-names>Meredith C</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="03652a29f075f8e2855b2fcb687ca5ab"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Meyers</surname>
                     <given-names>Zachary R</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="36b3229d5be5364609d88a55b9dfe27c"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
@@ -33,21 +33,21 @@
                     <given-names>C Conover</given-names>
                     <suffix>Jr</suffix>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="c1bf07c3d1cebc7e80242f1371a9bd5d"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Hao</surname>
                     <given-names>Haiping</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="211e40670305750c935a465176829daa"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Blum</surname>
                     <given-names>David</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="781c05c350496f0f760359edaac36bbc"/>
             </contrib>
             <contrib contrib-type="author">
                 <string-name/>
@@ -82,22 +82,22 @@
                     <given-names>Timothy M</given-names>
                 </name>
             </contrib>
-            <aff id="unique">
+            <aff id="f69418855a0b26ba9f73ae0f7bac0058">
                 <institution>University of Georgia, Bioexpression and Fermentation Facility</institution>
             </aff>
-            <aff id="unique">
+            <aff id="03652a29f075f8e2855b2fcb687ca5ab">
                 <institution>University of Georgia, Bioexpression and Fermentation Facility</institution>
             </aff>
-            <aff id="unique">
+            <aff id="36b3229d5be5364609d88a55b9dfe27c">
                 <institution>University of Georgia, Bioexpression and Fermentation Facility</institution>
             </aff>
-            <aff id="unique">
+            <aff id="c1bf07c3d1cebc7e80242f1371a9bd5d">
                 <institution>Johns Hopkins University, Deep Sequencing and Microarray Core Facility</institution>
             </aff>
-            <aff id="unique">
+            <aff id="211e40670305750c935a465176829daa">
                 <institution>Johns Hopkins University, Deep Sequencing and Microarray Core Facility</institution>
             </aff>
-            <aff id="unique">
+            <aff id="781c05c350496f0f760359edaac36bbc">
                 <institution>University of Georgia, Bioexpression and Fermentation Facility</institution>
             </aff>
         </contrib-group>

--- a/src/codecs/jats/__file_snapshots__/elife-46472-v3.jats.xml
+++ b/src/codecs/jats/__file_snapshots__/elife-46472-v3.jats.xml
@@ -14,115 +14,115 @@
                     <surname>Stafford</surname>
                     <given-names>Alexandra M</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="4fe9e14a12592dd432ee2e22cbccd96f"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Reed</surname>
                     <given-names>Cheryl</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="7d3125a4bcaa41a190d0a2782ebd6305"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Baba</surname>
                     <given-names>Harue</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="252f1fe010f87ebe5064778e62fbbc01"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Walter</surname>
                     <given-names>Nicole AR</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="011a7df021796f17ccfbea9e47cb9f89"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Mootz</surname>
                     <given-names>John RK</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="a4b6723c57aa893fe7a04da4a80242ae"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Williams</surname>
                     <given-names>Robert W</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="2cd686a2938cee2ee67ffb8bdf1de866"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Neve</surname>
                     <given-names>Kim A</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="17bbdb57cc3e043958a02610f99e99d9"/>
+                <xref ref-type="aff" rid="b4c4adfc598bf141e62ed102e48500a5"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Fedorov</surname>
                     <given-names>Lev M</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="5dd27d1d1b68e38cbc2575740e464cd3"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Janowsky</surname>
                     <given-names>Aaron J</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
-                <xref ref-type="aff" rid="unique"/>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="25a4d47333f3c36ab282bd47fe569012"/>
+                <xref ref-type="aff" rid="cf35676580f8d6bd35ee48959426773e"/>
+                <xref ref-type="aff" rid="0baf6823bdfdfc6efe68f2418eb3bf5d"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Phillips</surname>
                     <given-names>Tamara J</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="6832aa9bbca024786af8c2718adba027"/>
+                <xref ref-type="aff" rid="e71d4651658bf21ac114725896cc11fc"/>
             </contrib>
-            <aff id="unique">
+            <aff id="4fe9e14a12592dd432ee2e22cbccd96f">
                 <institution>Department of Behavioral Neuroscience and Methamphetamine Abuse Research Center</institution>
             </aff>
-            <aff id="unique">
+            <aff id="7d3125a4bcaa41a190d0a2782ebd6305">
                 <institution>Department of Behavioral Neuroscience and Methamphetamine Abuse Research Center</institution>
             </aff>
-            <aff id="unique">
+            <aff id="252f1fe010f87ebe5064778e62fbbc01">
                 <institution>Department of Behavioral Neuroscience and Methamphetamine Abuse Research Center</institution>
             </aff>
-            <aff id="unique">
+            <aff id="011a7df021796f17ccfbea9e47cb9f89">
                 <institution>Division of Neuroscience</institution>
             </aff>
-            <aff id="unique">
+            <aff id="a4b6723c57aa893fe7a04da4a80242ae">
                 <institution>Department of Behavioral Neuroscience and Methamphetamine Abuse Research Center</institution>
             </aff>
-            <aff id="unique">
+            <aff id="2cd686a2938cee2ee67ffb8bdf1de866">
                 <institution>Department of Genetics, Genomics and Informatics</institution>
             </aff>
-            <aff id="unique">
+            <aff id="17bbdb57cc3e043958a02610f99e99d9">
                 <institution>Department of Behavioral Neuroscience and Methamphetamine Abuse Research Center</institution>
             </aff>
-            <aff id="unique">
+            <aff id="b4c4adfc598bf141e62ed102e48500a5">
                 <institution>Veterans Affairs Portland Health Care System</institution>
             </aff>
-            <aff id="unique">
+            <aff id="5dd27d1d1b68e38cbc2575740e464cd3">
                 <institution>Transgenic Mouse Models Shared Resource, Knight Cancer Institute</institution>
             </aff>
-            <aff id="unique">
+            <aff id="25a4d47333f3c36ab282bd47fe569012">
                 <institution>Department of Behavioral Neuroscience and Methamphetamine Abuse Research Center</institution>
             </aff>
-            <aff id="unique">
+            <aff id="cf35676580f8d6bd35ee48959426773e">
                 <institution>Veterans Affairs Portland Health Care System</institution>
             </aff>
-            <aff id="unique">
+            <aff id="0baf6823bdfdfc6efe68f2418eb3bf5d">
                 <institution>Department of Psychiatry</institution>
             </aff>
-            <aff id="unique">
+            <aff id="6832aa9bbca024786af8c2718adba027">
                 <institution>Department of Behavioral Neuroscience and Methamphetamine Abuse Research Center</institution>
             </aff>
-            <aff id="unique">
+            <aff id="e71d4651658bf21ac114725896cc11fc">
                 <institution>Veterans Affairs Portland Health Care System</institution>
             </aff>
         </contrib-group>

--- a/src/codecs/jats/__file_snapshots__/elife-46472-v3.jats.xml
+++ b/src/codecs/jats/__file_snapshots__/elife-46472-v3.jats.xml
@@ -14,115 +14,115 @@
                     <surname>Stafford</surname>
                     <given-names>Alexandra M</given-names>
                 </name>
-                <xref ref-type="aff" rid="4fe9e14a12592dd432ee2e22cbccd96f"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Reed</surname>
                     <given-names>Cheryl</given-names>
                 </name>
-                <xref ref-type="aff" rid="7d3125a4bcaa41a190d0a2782ebd6305"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Baba</surname>
                     <given-names>Harue</given-names>
                 </name>
-                <xref ref-type="aff" rid="252f1fe010f87ebe5064778e62fbbc01"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Walter</surname>
                     <given-names>Nicole AR</given-names>
                 </name>
-                <xref ref-type="aff" rid="011a7df021796f17ccfbea9e47cb9f89"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Mootz</surname>
                     <given-names>John RK</given-names>
                 </name>
-                <xref ref-type="aff" rid="a4b6723c57aa893fe7a04da4a80242ae"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Williams</surname>
                     <given-names>Robert W</given-names>
                 </name>
-                <xref ref-type="aff" rid="2cd686a2938cee2ee67ffb8bdf1de866"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Neve</surname>
                     <given-names>Kim A</given-names>
                 </name>
-                <xref ref-type="aff" rid="17bbdb57cc3e043958a02610f99e99d9"/>
-                <xref ref-type="aff" rid="b4c4adfc598bf141e62ed102e48500a5"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Fedorov</surname>
                     <given-names>Lev M</given-names>
                 </name>
-                <xref ref-type="aff" rid="5dd27d1d1b68e38cbc2575740e464cd3"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Janowsky</surname>
                     <given-names>Aaron J</given-names>
                 </name>
-                <xref ref-type="aff" rid="25a4d47333f3c36ab282bd47fe569012"/>
-                <xref ref-type="aff" rid="cf35676580f8d6bd35ee48959426773e"/>
-                <xref ref-type="aff" rid="0baf6823bdfdfc6efe68f2418eb3bf5d"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Phillips</surname>
                     <given-names>Tamara J</given-names>
                 </name>
-                <xref ref-type="aff" rid="6832aa9bbca024786af8c2718adba027"/>
-                <xref ref-type="aff" rid="e71d4651658bf21ac114725896cc11fc"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
-            <aff id="4fe9e14a12592dd432ee2e22cbccd96f">
+            <aff id="00000000000000000000000000000000">
                 <institution>Department of Behavioral Neuroscience and Methamphetamine Abuse Research Center</institution>
             </aff>
-            <aff id="7d3125a4bcaa41a190d0a2782ebd6305">
+            <aff id="00000000000000000000000000000000">
                 <institution>Department of Behavioral Neuroscience and Methamphetamine Abuse Research Center</institution>
             </aff>
-            <aff id="252f1fe010f87ebe5064778e62fbbc01">
+            <aff id="00000000000000000000000000000000">
                 <institution>Department of Behavioral Neuroscience and Methamphetamine Abuse Research Center</institution>
             </aff>
-            <aff id="011a7df021796f17ccfbea9e47cb9f89">
+            <aff id="00000000000000000000000000000000">
                 <institution>Division of Neuroscience</institution>
             </aff>
-            <aff id="a4b6723c57aa893fe7a04da4a80242ae">
+            <aff id="00000000000000000000000000000000">
                 <institution>Department of Behavioral Neuroscience and Methamphetamine Abuse Research Center</institution>
             </aff>
-            <aff id="2cd686a2938cee2ee67ffb8bdf1de866">
+            <aff id="00000000000000000000000000000000">
                 <institution>Department of Genetics, Genomics and Informatics</institution>
             </aff>
-            <aff id="17bbdb57cc3e043958a02610f99e99d9">
+            <aff id="00000000000000000000000000000000">
                 <institution>Department of Behavioral Neuroscience and Methamphetamine Abuse Research Center</institution>
             </aff>
-            <aff id="b4c4adfc598bf141e62ed102e48500a5">
+            <aff id="00000000000000000000000000000000">
                 <institution>Veterans Affairs Portland Health Care System</institution>
             </aff>
-            <aff id="5dd27d1d1b68e38cbc2575740e464cd3">
+            <aff id="00000000000000000000000000000000">
                 <institution>Transgenic Mouse Models Shared Resource, Knight Cancer Institute</institution>
             </aff>
-            <aff id="25a4d47333f3c36ab282bd47fe569012">
+            <aff id="00000000000000000000000000000000">
                 <institution>Department of Behavioral Neuroscience and Methamphetamine Abuse Research Center</institution>
             </aff>
-            <aff id="cf35676580f8d6bd35ee48959426773e">
+            <aff id="00000000000000000000000000000000">
                 <institution>Veterans Affairs Portland Health Care System</institution>
             </aff>
-            <aff id="0baf6823bdfdfc6efe68f2418eb3bf5d">
+            <aff id="00000000000000000000000000000000">
                 <institution>Department of Psychiatry</institution>
             </aff>
-            <aff id="6832aa9bbca024786af8c2718adba027">
+            <aff id="00000000000000000000000000000000">
                 <institution>Department of Behavioral Neuroscience and Methamphetamine Abuse Research Center</institution>
             </aff>
-            <aff id="e71d4651658bf21ac114725896cc11fc">
+            <aff id="00000000000000000000000000000000">
                 <institution>Veterans Affairs Portland Health Care System</institution>
             </aff>
         </contrib-group>

--- a/src/codecs/jats/__file_snapshots__/elife-46793-v1.jats.xml
+++ b/src/codecs/jats/__file_snapshots__/elife-46793-v1.jats.xml
@@ -11,97 +11,97 @@
                     <surname>Zyner</surname>
                     <given-names>Katherine G</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="cceab9ff33f2e529196ee232d61b69eb"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Mulhearn</surname>
                     <given-names>Darcie S</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="e9593a403e098da3a5df680672427757"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Adhikari</surname>
                     <given-names>Santosh</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="89bf4fff8fb09eeff77bf4ad1aa68d5b"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Martínez Cuesta</surname>
                     <given-names>Sergio</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="7f227d6864e5ef6879efbf76fb5044f8"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Di Antonio</surname>
                     <given-names>Marco</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="0b68b04a9cc4d2ff198750f8afc81ab1"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Erard</surname>
                     <given-names>Nicolas</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="7798ac9ace7afaa90ef1c6079687dcb2"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Hannon</surname>
                     <given-names>Gregory J</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="0b54c8e3624d73a92f7921ad6592ca99"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Tannahill</surname>
                     <given-names>David</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="89448adca7e4690743915f905574c532"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Balasubramanian</surname>
                     <given-names>Shankar</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
-                <xref ref-type="aff" rid="unique"/>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="584a14655022ebfc1f0c5f7c81efaf0c"/>
+                <xref ref-type="aff" rid="4abbd375acb16afc68d3ac0498ada34c"/>
+                <xref ref-type="aff" rid="fc566d6ac7ba9854f7627132fcd1ec78"/>
             </contrib>
-            <aff id="unique">
+            <aff id="cceab9ff33f2e529196ee232d61b69eb">
                 <institution>Cancer Research United Kingdom Cambridge Institute</institution>
             </aff>
-            <aff id="unique">
+            <aff id="e9593a403e098da3a5df680672427757">
                 <institution>Cancer Research United Kingdom Cambridge Institute</institution>
             </aff>
-            <aff id="unique">
+            <aff id="89bf4fff8fb09eeff77bf4ad1aa68d5b">
                 <institution>Department of Chemistry</institution>
             </aff>
-            <aff id="unique">
+            <aff id="7f227d6864e5ef6879efbf76fb5044f8">
                 <institution>Cancer Research United Kingdom Cambridge Institute</institution>
             </aff>
-            <aff id="unique">
+            <aff id="0b68b04a9cc4d2ff198750f8afc81ab1">
                 <institution>Department of Chemistry</institution>
             </aff>
-            <aff id="unique">
+            <aff id="7798ac9ace7afaa90ef1c6079687dcb2">
                 <institution>Cancer Research United Kingdom Cambridge Institute</institution>
             </aff>
-            <aff id="unique">
+            <aff id="0b54c8e3624d73a92f7921ad6592ca99">
                 <institution>Cancer Research United Kingdom Cambridge Institute</institution>
             </aff>
-            <aff id="unique">
+            <aff id="89448adca7e4690743915f905574c532">
                 <institution>Cancer Research United Kingdom Cambridge Institute</institution>
             </aff>
-            <aff id="unique">
+            <aff id="584a14655022ebfc1f0c5f7c81efaf0c">
                 <institution>Cancer Research United Kingdom Cambridge Institute</institution>
             </aff>
-            <aff id="unique">
+            <aff id="4abbd375acb16afc68d3ac0498ada34c">
                 <institution>Department of Chemistry</institution>
             </aff>
-            <aff id="unique">
+            <aff id="fc566d6ac7ba9854f7627132fcd1ec78">
                 <institution>School of Clinical Medicine</institution>
             </aff>
         </contrib-group>

--- a/src/codecs/jats/__file_snapshots__/elife-46793-v1.jats.xml
+++ b/src/codecs/jats/__file_snapshots__/elife-46793-v1.jats.xml
@@ -11,97 +11,97 @@
                     <surname>Zyner</surname>
                     <given-names>Katherine G</given-names>
                 </name>
-                <xref ref-type="aff" rid="cceab9ff33f2e529196ee232d61b69eb"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Mulhearn</surname>
                     <given-names>Darcie S</given-names>
                 </name>
-                <xref ref-type="aff" rid="e9593a403e098da3a5df680672427757"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Adhikari</surname>
                     <given-names>Santosh</given-names>
                 </name>
-                <xref ref-type="aff" rid="89bf4fff8fb09eeff77bf4ad1aa68d5b"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Martínez Cuesta</surname>
                     <given-names>Sergio</given-names>
                 </name>
-                <xref ref-type="aff" rid="7f227d6864e5ef6879efbf76fb5044f8"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Di Antonio</surname>
                     <given-names>Marco</given-names>
                 </name>
-                <xref ref-type="aff" rid="0b68b04a9cc4d2ff198750f8afc81ab1"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Erard</surname>
                     <given-names>Nicolas</given-names>
                 </name>
-                <xref ref-type="aff" rid="7798ac9ace7afaa90ef1c6079687dcb2"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Hannon</surname>
                     <given-names>Gregory J</given-names>
                 </name>
-                <xref ref-type="aff" rid="0b54c8e3624d73a92f7921ad6592ca99"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Tannahill</surname>
                     <given-names>David</given-names>
                 </name>
-                <xref ref-type="aff" rid="89448adca7e4690743915f905574c532"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Balasubramanian</surname>
                     <given-names>Shankar</given-names>
                 </name>
-                <xref ref-type="aff" rid="584a14655022ebfc1f0c5f7c81efaf0c"/>
-                <xref ref-type="aff" rid="4abbd375acb16afc68d3ac0498ada34c"/>
-                <xref ref-type="aff" rid="fc566d6ac7ba9854f7627132fcd1ec78"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
-            <aff id="cceab9ff33f2e529196ee232d61b69eb">
+            <aff id="00000000000000000000000000000000">
                 <institution>Cancer Research United Kingdom Cambridge Institute</institution>
             </aff>
-            <aff id="e9593a403e098da3a5df680672427757">
+            <aff id="00000000000000000000000000000000">
                 <institution>Cancer Research United Kingdom Cambridge Institute</institution>
             </aff>
-            <aff id="89bf4fff8fb09eeff77bf4ad1aa68d5b">
+            <aff id="00000000000000000000000000000000">
                 <institution>Department of Chemistry</institution>
             </aff>
-            <aff id="7f227d6864e5ef6879efbf76fb5044f8">
+            <aff id="00000000000000000000000000000000">
                 <institution>Cancer Research United Kingdom Cambridge Institute</institution>
             </aff>
-            <aff id="0b68b04a9cc4d2ff198750f8afc81ab1">
+            <aff id="00000000000000000000000000000000">
                 <institution>Department of Chemistry</institution>
             </aff>
-            <aff id="7798ac9ace7afaa90ef1c6079687dcb2">
+            <aff id="00000000000000000000000000000000">
                 <institution>Cancer Research United Kingdom Cambridge Institute</institution>
             </aff>
-            <aff id="0b54c8e3624d73a92f7921ad6592ca99">
+            <aff id="00000000000000000000000000000000">
                 <institution>Cancer Research United Kingdom Cambridge Institute</institution>
             </aff>
-            <aff id="89448adca7e4690743915f905574c532">
+            <aff id="00000000000000000000000000000000">
                 <institution>Cancer Research United Kingdom Cambridge Institute</institution>
             </aff>
-            <aff id="584a14655022ebfc1f0c5f7c81efaf0c">
+            <aff id="00000000000000000000000000000000">
                 <institution>Cancer Research United Kingdom Cambridge Institute</institution>
             </aff>
-            <aff id="4abbd375acb16afc68d3ac0498ada34c">
+            <aff id="00000000000000000000000000000000">
                 <institution>Department of Chemistry</institution>
             </aff>
-            <aff id="fc566d6ac7ba9854f7627132fcd1ec78">
+            <aff id="00000000000000000000000000000000">
                 <institution>School of Clinical Medicine</institution>
             </aff>
         </contrib-group>

--- a/src/codecs/jats/__file_snapshots__/f1000-7-1655-v1.jats.xml
+++ b/src/codecs/jats/__file_snapshots__/f1000-7-1655-v1.jats.xml
@@ -11,189 +11,189 @@
                     <surname>Beck</surname>
                     <given-names>Jeffrey</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="aeedc91686391faa126cadb9dfed10c4"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Funk</surname>
                     <given-names>Kathryn</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="f5ef0b14af32fb023ce965cbe8ec697c"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Harrison</surname>
                     <given-names>Melissa</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="1bd38509d135d5a9c33676c3aee2f44e"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>McEntyre</surname>
                     <given-names>Jo</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="64b3a94924d90b02039bb2b8254af6a6"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Breen</surname>
                     <given-names>Josie</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="bdef8d48cf4688a576b1d6fe83bf3959"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Collings</surname>
                     <given-names>Andy</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="22f4b097d1e3e6362f267aaeaa2fc3ed"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Donohoe</surname>
                     <given-names>Paul</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="07c47cb008f99398262925f6a1a335e0"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Evans</surname>
                     <given-names>Michael</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="e61c5fbe67dfe7adbd5cdf559cac1845"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Flintoft</surname>
                     <given-names>Louisa</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="dbff76bd109b417b50e1cdb3543cb645"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Hamelers</surname>
                     <given-names>Audrey</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="00fe94db9b2493f1c56efa366f99e6fa"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Hurst</surname>
                     <given-names>Phil</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="d256565f756b6642ff8da1b357e2192c"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Lemberger</surname>
                     <given-names>Thomas</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="ad8a503def1842871a0d42f38619bb88"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Lin</surname>
                     <given-names>Jennifer</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="0c4e8da92a7ed28ad2d697fec402f452"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>O'Connor</surname>
                     <given-names>Niamh</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="569b05fd789dd8aed9499ab698dc39a5"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Parkin</surname>
                     <given-names>Michael</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="2c6b7ad8f2965ee5b652f3064a36fc59"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Parker</surname>
                     <given-names>Sam</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="7cb4fc71e795cd2602103c70b64b4d07"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Rodgers</surname>
                     <given-names>Peter</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="55848b277ece87bd6dfb912ed8e3fdd1"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Skipper</surname>
                     <given-names>Magdalena</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="7f92a21835415bd07ced5941aeffd2c3"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Stoner</surname>
                     <given-names>Michael</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="7b7f7cde58027e79a7fd959fae3ce1c3"/>
             </contrib>
-            <aff id="unique">
+            <aff id="aeedc91686391faa126cadb9dfed10c4">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="f5ef0b14af32fb023ce965cbe8ec697c">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="1bd38509d135d5a9c33676c3aee2f44e">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="64b3a94924d90b02039bb2b8254af6a6">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="bdef8d48cf4688a576b1d6fe83bf3959">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="22f4b097d1e3e6362f267aaeaa2fc3ed">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="07c47cb008f99398262925f6a1a335e0">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="e61c5fbe67dfe7adbd5cdf559cac1845">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="dbff76bd109b417b50e1cdb3543cb645">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="00fe94db9b2493f1c56efa366f99e6fa">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="d256565f756b6642ff8da1b357e2192c">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="ad8a503def1842871a0d42f38619bb88">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="0c4e8da92a7ed28ad2d697fec402f452">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="569b05fd789dd8aed9499ab698dc39a5">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="2c6b7ad8f2965ee5b652f3064a36fc59">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="7cb4fc71e795cd2602103c70b64b4d07">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="55848b277ece87bd6dfb912ed8e3fdd1">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="7f92a21835415bd07ced5941aeffd2c3">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="7b7f7cde58027e79a7fd959fae3ce1c3">
                 <institution/>
             </aff>
         </contrib-group>

--- a/src/codecs/jats/__file_snapshots__/f1000-7-1655-v1.jats.xml
+++ b/src/codecs/jats/__file_snapshots__/f1000-7-1655-v1.jats.xml
@@ -11,189 +11,189 @@
                     <surname>Beck</surname>
                     <given-names>Jeffrey</given-names>
                 </name>
-                <xref ref-type="aff" rid="aeedc91686391faa126cadb9dfed10c4"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Funk</surname>
                     <given-names>Kathryn</given-names>
                 </name>
-                <xref ref-type="aff" rid="f5ef0b14af32fb023ce965cbe8ec697c"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Harrison</surname>
                     <given-names>Melissa</given-names>
                 </name>
-                <xref ref-type="aff" rid="1bd38509d135d5a9c33676c3aee2f44e"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>McEntyre</surname>
                     <given-names>Jo</given-names>
                 </name>
-                <xref ref-type="aff" rid="64b3a94924d90b02039bb2b8254af6a6"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Breen</surname>
                     <given-names>Josie</given-names>
                 </name>
-                <xref ref-type="aff" rid="bdef8d48cf4688a576b1d6fe83bf3959"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Collings</surname>
                     <given-names>Andy</given-names>
                 </name>
-                <xref ref-type="aff" rid="22f4b097d1e3e6362f267aaeaa2fc3ed"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Donohoe</surname>
                     <given-names>Paul</given-names>
                 </name>
-                <xref ref-type="aff" rid="07c47cb008f99398262925f6a1a335e0"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Evans</surname>
                     <given-names>Michael</given-names>
                 </name>
-                <xref ref-type="aff" rid="e61c5fbe67dfe7adbd5cdf559cac1845"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Flintoft</surname>
                     <given-names>Louisa</given-names>
                 </name>
-                <xref ref-type="aff" rid="dbff76bd109b417b50e1cdb3543cb645"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Hamelers</surname>
                     <given-names>Audrey</given-names>
                 </name>
-                <xref ref-type="aff" rid="00fe94db9b2493f1c56efa366f99e6fa"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Hurst</surname>
                     <given-names>Phil</given-names>
                 </name>
-                <xref ref-type="aff" rid="d256565f756b6642ff8da1b357e2192c"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Lemberger</surname>
                     <given-names>Thomas</given-names>
                 </name>
-                <xref ref-type="aff" rid="ad8a503def1842871a0d42f38619bb88"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Lin</surname>
                     <given-names>Jennifer</given-names>
                 </name>
-                <xref ref-type="aff" rid="0c4e8da92a7ed28ad2d697fec402f452"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>O'Connor</surname>
                     <given-names>Niamh</given-names>
                 </name>
-                <xref ref-type="aff" rid="569b05fd789dd8aed9499ab698dc39a5"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Parkin</surname>
                     <given-names>Michael</given-names>
                 </name>
-                <xref ref-type="aff" rid="2c6b7ad8f2965ee5b652f3064a36fc59"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Parker</surname>
                     <given-names>Sam</given-names>
                 </name>
-                <xref ref-type="aff" rid="7cb4fc71e795cd2602103c70b64b4d07"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Rodgers</surname>
                     <given-names>Peter</given-names>
                 </name>
-                <xref ref-type="aff" rid="55848b277ece87bd6dfb912ed8e3fdd1"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Skipper</surname>
                     <given-names>Magdalena</given-names>
                 </name>
-                <xref ref-type="aff" rid="7f92a21835415bd07ced5941aeffd2c3"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Stoner</surname>
                     <given-names>Michael</given-names>
                 </name>
-                <xref ref-type="aff" rid="7b7f7cde58027e79a7fd959fae3ce1c3"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
-            <aff id="aeedc91686391faa126cadb9dfed10c4">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="f5ef0b14af32fb023ce965cbe8ec697c">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="1bd38509d135d5a9c33676c3aee2f44e">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="64b3a94924d90b02039bb2b8254af6a6">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="bdef8d48cf4688a576b1d6fe83bf3959">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="22f4b097d1e3e6362f267aaeaa2fc3ed">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="07c47cb008f99398262925f6a1a335e0">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="e61c5fbe67dfe7adbd5cdf559cac1845">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="dbff76bd109b417b50e1cdb3543cb645">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="00fe94db9b2493f1c56efa366f99e6fa">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="d256565f756b6642ff8da1b357e2192c">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="ad8a503def1842871a0d42f38619bb88">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="0c4e8da92a7ed28ad2d697fec402f452">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="569b05fd789dd8aed9499ab698dc39a5">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="2c6b7ad8f2965ee5b652f3064a36fc59">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="7cb4fc71e795cd2602103c70b64b4d07">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="55848b277ece87bd6dfb912ed8e3fdd1">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="7f92a21835415bd07ced5941aeffd2c3">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="7b7f7cde58027e79a7fd959fae3ce1c3">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
         </contrib-group>

--- a/src/codecs/jats/__file_snapshots__/f1000-8-1394-v1.jats.xml
+++ b/src/codecs/jats/__file_snapshots__/f1000-8-1394-v1.jats.xml
@@ -11,89 +11,89 @@
                     <surname>Lachenmeier</surname>
                     <given-names>Dirk W.</given-names>
                 </name>
-                <xref ref-type="aff" rid="05e63aae2e518a1e38a73a57731f4a99"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Habel</surname>
                     <given-names>Stephanie</given-names>
                 </name>
-                <xref ref-type="aff" rid="3f6141de16ac55bf90b09a582a79eefd"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Fischer</surname>
                     <given-names>Berit</given-names>
                 </name>
-                <xref ref-type="aff" rid="c9a2e3e8b264c2ddb6c3c90b4a5794c6"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Herbi</surname>
                     <given-names>Frauke</given-names>
                 </name>
-                <xref ref-type="aff" rid="b60b8ab0f673dba978d657081a007ba7"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Zerbe</surname>
                     <given-names>Yvonne</given-names>
                 </name>
-                <xref ref-type="aff" rid="0edba7ed7098129d7c0f5ebe0315ffbd"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Bock</surname>
                     <given-names>Verena</given-names>
                 </name>
-                <xref ref-type="aff" rid="4713483e018f4531dad88b7f9c758bab"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Rajcic de Rezende</surname>
                     <given-names>Tabata</given-names>
                 </name>
-                <xref ref-type="aff" rid="4450aaf30b9ce32a7788a8137e056ca8"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Walch</surname>
                     <given-names>Stephan G.</given-names>
                 </name>
-                <xref ref-type="aff" rid="fa50c8dcdd74e3ed0efd71c9f1014584"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Sproll</surname>
                     <given-names>Constanze</given-names>
                 </name>
-                <xref ref-type="aff" rid="4c3a96e9ed921b49b4db6bb295b0192b"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
-            <aff id="05e63aae2e518a1e38a73a57731f4a99">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="3f6141de16ac55bf90b09a582a79eefd">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="c9a2e3e8b264c2ddb6c3c90b4a5794c6">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="b60b8ab0f673dba978d657081a007ba7">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="0edba7ed7098129d7c0f5ebe0315ffbd">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="4713483e018f4531dad88b7f9c758bab">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="4450aaf30b9ce32a7788a8137e056ca8">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="fa50c8dcdd74e3ed0efd71c9f1014584">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="4c3a96e9ed921b49b4db6bb295b0192b">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
         </contrib-group>

--- a/src/codecs/jats/__file_snapshots__/f1000-8-1394-v1.jats.xml
+++ b/src/codecs/jats/__file_snapshots__/f1000-8-1394-v1.jats.xml
@@ -11,89 +11,89 @@
                     <surname>Lachenmeier</surname>
                     <given-names>Dirk W.</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="05e63aae2e518a1e38a73a57731f4a99"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Habel</surname>
                     <given-names>Stephanie</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="3f6141de16ac55bf90b09a582a79eefd"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Fischer</surname>
                     <given-names>Berit</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="c9a2e3e8b264c2ddb6c3c90b4a5794c6"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Herbi</surname>
                     <given-names>Frauke</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="b60b8ab0f673dba978d657081a007ba7"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Zerbe</surname>
                     <given-names>Yvonne</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="0edba7ed7098129d7c0f5ebe0315ffbd"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Bock</surname>
                     <given-names>Verena</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="4713483e018f4531dad88b7f9c758bab"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Rajcic de Rezende</surname>
                     <given-names>Tabata</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="4450aaf30b9ce32a7788a8137e056ca8"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Walch</surname>
                     <given-names>Stephan G.</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="fa50c8dcdd74e3ed0efd71c9f1014584"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Sproll</surname>
                     <given-names>Constanze</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="4c3a96e9ed921b49b4db6bb295b0192b"/>
             </contrib>
-            <aff id="unique">
+            <aff id="05e63aae2e518a1e38a73a57731f4a99">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="3f6141de16ac55bf90b09a582a79eefd">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="c9a2e3e8b264c2ddb6c3c90b4a5794c6">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="b60b8ab0f673dba978d657081a007ba7">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="0edba7ed7098129d7c0f5ebe0315ffbd">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="4713483e018f4531dad88b7f9c758bab">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="4450aaf30b9ce32a7788a8137e056ca8">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="fa50c8dcdd74e3ed0efd71c9f1014584">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="4c3a96e9ed921b49b4db6bb295b0192b">
                 <institution/>
             </aff>
         </contrib-group>

--- a/src/codecs/jats/__file_snapshots__/f1000-8-978-v1.jats.xml
+++ b/src/codecs/jats/__file_snapshots__/f1000-8-978-v1.jats.xml
@@ -11,79 +11,79 @@
                     <surname>Ksiksi</surname>
                     <given-names>Taoufik Saleh</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="e732fc24d75fbf2e2dfc7ffd7a54f313"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>K.</surname>
                     <given-names>Remya</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="94773425e8e7d70006ef11fddc223270"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Mousa</surname>
                     <given-names>Mohamed T.</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="6f30f9cd41686bedc174976ff81a0840"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Al-Badi</surname>
                     <given-names>Shima K.</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="1024c2e05bbceaa0758acbc3370d7e7a"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Al Kaabi</surname>
                     <given-names>Salama K.</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="df0951b89f3065232fa98529d55cfce5"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Alameemi</surname>
                     <given-names>Shamsa M.</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="6303a2a64a628ce1ab37d3d3ae33a47d"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Fereaa</surname>
                     <given-names>Sanad M.</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="22c51d2003e79daf6756fb84ef83e5e4"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Hassan</surname>
                     <given-names>Fatima E.</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="669eb7ed28b72c551906100d188a407f"/>
             </contrib>
-            <aff id="unique">
+            <aff id="e732fc24d75fbf2e2dfc7ffd7a54f313">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="94773425e8e7d70006ef11fddc223270">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="6f30f9cd41686bedc174976ff81a0840">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="1024c2e05bbceaa0758acbc3370d7e7a">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="df0951b89f3065232fa98529d55cfce5">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="6303a2a64a628ce1ab37d3d3ae33a47d">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="22c51d2003e79daf6756fb84ef83e5e4">
                 <institution/>
             </aff>
-            <aff id="unique">
+            <aff id="669eb7ed28b72c551906100d188a407f">
                 <institution/>
             </aff>
         </contrib-group>

--- a/src/codecs/jats/__file_snapshots__/f1000-8-978-v1.jats.xml
+++ b/src/codecs/jats/__file_snapshots__/f1000-8-978-v1.jats.xml
@@ -11,79 +11,79 @@
                     <surname>Ksiksi</surname>
                     <given-names>Taoufik Saleh</given-names>
                 </name>
-                <xref ref-type="aff" rid="e732fc24d75fbf2e2dfc7ffd7a54f313"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>K.</surname>
                     <given-names>Remya</given-names>
                 </name>
-                <xref ref-type="aff" rid="94773425e8e7d70006ef11fddc223270"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Mousa</surname>
                     <given-names>Mohamed T.</given-names>
                 </name>
-                <xref ref-type="aff" rid="6f30f9cd41686bedc174976ff81a0840"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Al-Badi</surname>
                     <given-names>Shima K.</given-names>
                 </name>
-                <xref ref-type="aff" rid="1024c2e05bbceaa0758acbc3370d7e7a"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Al Kaabi</surname>
                     <given-names>Salama K.</given-names>
                 </name>
-                <xref ref-type="aff" rid="df0951b89f3065232fa98529d55cfce5"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Alameemi</surname>
                     <given-names>Shamsa M.</given-names>
                 </name>
-                <xref ref-type="aff" rid="6303a2a64a628ce1ab37d3d3ae33a47d"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Fereaa</surname>
                     <given-names>Sanad M.</given-names>
                 </name>
-                <xref ref-type="aff" rid="22c51d2003e79daf6756fb84ef83e5e4"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Hassan</surname>
                     <given-names>Fatima E.</given-names>
                 </name>
-                <xref ref-type="aff" rid="669eb7ed28b72c551906100d188a407f"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
-            <aff id="e732fc24d75fbf2e2dfc7ffd7a54f313">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="94773425e8e7d70006ef11fddc223270">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="6f30f9cd41686bedc174976ff81a0840">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="1024c2e05bbceaa0758acbc3370d7e7a">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="df0951b89f3065232fa98529d55cfce5">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="6303a2a64a628ce1ab37d3d3ae33a47d">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="22c51d2003e79daf6756fb84ef83e5e4">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
-            <aff id="669eb7ed28b72c551906100d188a407f">
+            <aff id="00000000000000000000000000000000">
                 <institution/>
             </aff>
         </contrib-group>

--- a/src/codecs/jats/__file_snapshots__/plosone-0091296.jats.xml
+++ b/src/codecs/jats/__file_snapshots__/plosone-0091296.jats.xml
@@ -11,29 +11,29 @@
                     <surname>Robinson</surname>
                     <given-names>Jan</given-names>
                 </name>
-                <xref ref-type="aff" rid="39d61abe9fb9ebcde8571452286fdaf3"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Cinner</surname>
                     <given-names>Joshua E.</given-names>
                 </name>
-                <xref ref-type="aff" rid="559b22e26f1d66e23b0dc258c1f278e9"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Graham</surname>
                     <given-names>Nicholas A. J.</given-names>
                 </name>
-                <xref ref-type="aff" rid="6a4381225e85a0da2edea01411623b1f"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
-            <aff id="39d61abe9fb9ebcde8571452286fdaf3">
+            <aff id="00000000000000000000000000000000">
                 <institution>ARC Center of Excellence for Coral Reef Studies, James Cook University, Townsville, Queensland, Australia</institution>
             </aff>
-            <aff id="559b22e26f1d66e23b0dc258c1f278e9">
+            <aff id="00000000000000000000000000000000">
                 <institution>ARC Center of Excellence for Coral Reef Studies, James Cook University, Townsville, Queensland, Australia</institution>
             </aff>
-            <aff id="6a4381225e85a0da2edea01411623b1f">
+            <aff id="00000000000000000000000000000000">
                 <institution>ARC Center of Excellence for Coral Reef Studies, James Cook University, Townsville, Queensland, Australia</institution>
             </aff>
         </contrib-group>

--- a/src/codecs/jats/__file_snapshots__/plosone-0091296.jats.xml
+++ b/src/codecs/jats/__file_snapshots__/plosone-0091296.jats.xml
@@ -11,29 +11,29 @@
                     <surname>Robinson</surname>
                     <given-names>Jan</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="39d61abe9fb9ebcde8571452286fdaf3"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Cinner</surname>
                     <given-names>Joshua E.</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="559b22e26f1d66e23b0dc258c1f278e9"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Graham</surname>
                     <given-names>Nicholas A. J.</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="6a4381225e85a0da2edea01411623b1f"/>
             </contrib>
-            <aff id="unique">
+            <aff id="39d61abe9fb9ebcde8571452286fdaf3">
                 <institution>ARC Center of Excellence for Coral Reef Studies, James Cook University, Townsville, Queensland, Australia</institution>
             </aff>
-            <aff id="unique">
+            <aff id="559b22e26f1d66e23b0dc258c1f278e9">
                 <institution>ARC Center of Excellence for Coral Reef Studies, James Cook University, Townsville, Queensland, Australia</institution>
             </aff>
-            <aff id="unique">
+            <aff id="6a4381225e85a0da2edea01411623b1f">
                 <institution>ARC Center of Excellence for Coral Reef Studies, James Cook University, Townsville, Queensland, Australia</institution>
             </aff>
         </contrib-group>

--- a/src/codecs/jats/__file_snapshots__/plosone-0093988.jats.xml
+++ b/src/codecs/jats/__file_snapshots__/plosone-0093988.jats.xml
@@ -11,29 +11,29 @@
                     <surname>Iyer</surname>
                     <given-names>Swami</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="297701249f9aa9ce027e53cce2852cb5"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Reyes</surname>
                     <given-names>Joshua</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="cf39fbd2666a01fe876397db29d7faa5"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Killingback</surname>
                     <given-names>Timothy</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="f5fe4bd06f55f316d40900d4e20b7472"/>
             </contrib>
-            <aff id="unique">
+            <aff id="297701249f9aa9ce027e53cce2852cb5">
                 <institution>Computer Science Department, University of Massachusetts, Boston, Massachusetts, United States of America</institution>
             </aff>
-            <aff id="unique">
+            <aff id="cf39fbd2666a01fe876397db29d7faa5">
                 <institution>Department of Systems Biology, Harvard Medical School, Boston, Massachusetts, United States of America</institution>
             </aff>
-            <aff id="unique">
+            <aff id="f5fe4bd06f55f316d40900d4e20b7472">
                 <institution>Mathematics Department, University of Massachusetts, Boston, Massachusetts, United States of America</institution>
             </aff>
         </contrib-group>

--- a/src/codecs/jats/__file_snapshots__/plosone-0093988.jats.xml
+++ b/src/codecs/jats/__file_snapshots__/plosone-0093988.jats.xml
@@ -11,29 +11,29 @@
                     <surname>Iyer</surname>
                     <given-names>Swami</given-names>
                 </name>
-                <xref ref-type="aff" rid="297701249f9aa9ce027e53cce2852cb5"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Reyes</surname>
                     <given-names>Joshua</given-names>
                 </name>
-                <xref ref-type="aff" rid="cf39fbd2666a01fe876397db29d7faa5"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Killingback</surname>
                     <given-names>Timothy</given-names>
                 </name>
-                <xref ref-type="aff" rid="f5fe4bd06f55f316d40900d4e20b7472"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
-            <aff id="297701249f9aa9ce027e53cce2852cb5">
+            <aff id="00000000000000000000000000000000">
                 <institution>Computer Science Department, University of Massachusetts, Boston, Massachusetts, United States of America</institution>
             </aff>
-            <aff id="cf39fbd2666a01fe876397db29d7faa5">
+            <aff id="00000000000000000000000000000000">
                 <institution>Department of Systems Biology, Harvard Medical School, Boston, Massachusetts, United States of America</institution>
             </aff>
-            <aff id="f5fe4bd06f55f316d40900d4e20b7472">
+            <aff id="00000000000000000000000000000000">
                 <institution>Mathematics Department, University of Massachusetts, Boston, Massachusetts, United States of America</institution>
             </aff>
         </contrib-group>

--- a/src/codecs/jats/__file_snapshots__/plosone-0178565.jats.xml
+++ b/src/codecs/jats/__file_snapshots__/plosone-0178565.jats.xml
@@ -11,31 +11,31 @@
                     <surname>Tiruveedula</surname>
                     <given-names>Gopi Siva Sai</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="4e5cea3404e0245cc66251aa3d9db939"/>
+                <xref ref-type="aff" rid="7d4a6c3341d752317db2de6aa14a566a"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Wangikar</surname>
                     <given-names>Pramod P.</given-names>
                 </name>
-                <xref ref-type="aff" rid="unique"/>
-                <xref ref-type="aff" rid="unique"/>
-                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="84bcf1cfffcc94e09e39a58aaba0f771"/>
+                <xref ref-type="aff" rid="c3d42ce651a1ea8e20a040854ef47205"/>
+                <xref ref-type="aff" rid="6862952b3e68ce5adb7fec728db2e8c3"/>
             </contrib>
-            <aff id="unique">
+            <aff id="4e5cea3404e0245cc66251aa3d9db939">
                 <institution>Department of Chemical Engineering, National Institute of Technology Karnataka, Surathkal, Mangalore, India</institution>
             </aff>
-            <aff id="unique">
+            <aff id="7d4a6c3341d752317db2de6aa14a566a">
                 <institution>Department of Chemical Engineering, Indian Institute of Technology Bombay, Powai, Mumbai, India</institution>
             </aff>
-            <aff id="unique">
+            <aff id="84bcf1cfffcc94e09e39a58aaba0f771">
                 <institution>Department of Chemical Engineering, Indian Institute of Technology Bombay, Powai, Mumbai, India</institution>
             </aff>
-            <aff id="unique">
+            <aff id="c3d42ce651a1ea8e20a040854ef47205">
                 <institution>DBT-Pan IIT Center for Bioenergy, Indian Institute of Technology Bombay, Powai, Mumbai, India</institution>
             </aff>
-            <aff id="unique">
+            <aff id="6862952b3e68ce5adb7fec728db2e8c3">
                 <institution>Wadhwani Research Center for Bioengineering, Indian Institute of Technology Bombay, Powai, Mumbai, India</institution>
             </aff>
         </contrib-group>

--- a/src/codecs/jats/__file_snapshots__/plosone-0178565.jats.xml
+++ b/src/codecs/jats/__file_snapshots__/plosone-0178565.jats.xml
@@ -11,31 +11,31 @@
                     <surname>Tiruveedula</surname>
                     <given-names>Gopi Siva Sai</given-names>
                 </name>
-                <xref ref-type="aff" rid="4e5cea3404e0245cc66251aa3d9db939"/>
-                <xref ref-type="aff" rid="7d4a6c3341d752317db2de6aa14a566a"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Wangikar</surname>
                     <given-names>Pramod P.</given-names>
                 </name>
-                <xref ref-type="aff" rid="84bcf1cfffcc94e09e39a58aaba0f771"/>
-                <xref ref-type="aff" rid="c3d42ce651a1ea8e20a040854ef47205"/>
-                <xref ref-type="aff" rid="6862952b3e68ce5adb7fec728db2e8c3"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
+                <xref ref-type="aff" rid="00000000000000000000000000000000"/>
             </contrib>
-            <aff id="4e5cea3404e0245cc66251aa3d9db939">
+            <aff id="00000000000000000000000000000000">
                 <institution>Department of Chemical Engineering, National Institute of Technology Karnataka, Surathkal, Mangalore, India</institution>
             </aff>
-            <aff id="7d4a6c3341d752317db2de6aa14a566a">
+            <aff id="00000000000000000000000000000000">
                 <institution>Department of Chemical Engineering, Indian Institute of Technology Bombay, Powai, Mumbai, India</institution>
             </aff>
-            <aff id="84bcf1cfffcc94e09e39a58aaba0f771">
+            <aff id="00000000000000000000000000000000">
                 <institution>Department of Chemical Engineering, Indian Institute of Technology Bombay, Powai, Mumbai, India</institution>
             </aff>
-            <aff id="c3d42ce651a1ea8e20a040854ef47205">
+            <aff id="00000000000000000000000000000000">
                 <institution>DBT-Pan IIT Center for Bioenergy, Indian Institute of Technology Bombay, Powai, Mumbai, India</institution>
             </aff>
-            <aff id="6862952b3e68ce5adb7fec728db2e8c3">
+            <aff id="00000000000000000000000000000000">
                 <institution>Wadhwani Research Center for Bioengineering, Indian Institute of Technology Bombay, Powai, Mumbai, India</institution>
             </aff>
         </contrib-group>

--- a/src/codecs/jats/index.ts
+++ b/src/codecs/jats/index.ts
@@ -4,6 +4,7 @@
 
 import { getLogger } from '@stencila/logga'
 import * as stencila from '@stencila/schema'
+import crypto from 'crypto'
 import fs from 'fs-extra'
 import * as vfile from '../../util/vfile'
 /* eslint-disable import/no-duplicates */
@@ -407,13 +408,13 @@ function encodeAuthor(
   if (author.type === 'Person') {
     name = encodeName(author)
     if (author.affiliations) {
-      affs = author.affiliations.map(org => {
-        return elem(
+      affs = author.affiliations.map(org =>
+        elem(
           'aff',
-          { id: 'unique' },
+          { id: crypto.randomBytes(16).toString('hex') },
           elem('institution', org.name || '')
         )
-      })
+      )
     }
   } else {
     name = elem('string-name', author.legalName || author.name || '')

--- a/src/codecs/jats/jats.test.ts
+++ b/src/codecs/jats/jats.test.ts
@@ -15,6 +15,8 @@ const { sniff } = new JatsCodec()
  * ```
  */
 
+jest.mock('crypto')
+
 const fixture = (name: string) =>
   path.join(__dirname, '__fixtures__', name, 'main.jats.xml')
 


### PR DESCRIPTION
This PR address some issues with the `encode` method of the [`jats`](https://github.com/stencila/encoda/blob/master/src/codecs/jats/index.ts#L88) codec. In particular @FAtherden-eLife noted that when doing:

```bash
encoda convert https://elifesciences.org/articles/53535v2 elife-53535.xml --to jats
```

The resulting JATS XML has ~330 validation errors, most due to the following four issues. Although encoding to JATS is not a high priority at right now, some of these are low hanging fruit ( or have already been addressed) towards ensuring that the generated JATS is at least valid.

- [x] Numerous elements output with the same id, the string "unique", which fails because the ids are not actually unique. Fixed by fd7521db789ce52c84f13bc2bfbdd514db8dbe4b in this PR.

- [ ] Table data and headers and output as table rows (td and th as tr).

- [x] `label` elements are output after `caption` which is not allowed in jats (needs to be before caption). Already fixed in 9a3e4ef63453c196a46469376e8ae444ef172a27.

- [x] `title-group`, `contrib-group` and `abstract` placed in `front` instead of in `article-meta`.

Ideally, this PR should also add a test that validates generated JATS against a DTD.
