### PR TITLE
Pandoc update

### DIFF
--- a/src/codecs/docx/index.ts
+++ b/src/codecs/docx/index.ts
@@ -52,17 +52,17 @@ export class DocxCodec extends Codec<EncodeOptions>
       .defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const article = ensureArticle(node)
-    const { references, ...rest } = article
+    const { references } = article
 
     const referenceDoc =
       codecOptions.templatePath || DocxCodec.defaultTemplatePath
 
-    let bibliographyFlags: string[] = []
+    let flags: string[] = [`--reference-doc=${referenceDoc}`]
+
     if (references !== undefined) {
       // Currently the style is fixed, but in the future will be an encoding option.
       const cslStyle = path.join(stylesDir, 'apa.csl')
-      bibliographyFlags = [
-        '--filter=pandoc-citeproc',
+      flags = [
         `--metadata=csl:${cslStyle}`,
         '--metadata=reference-section-title:References'
       ]
@@ -73,8 +73,9 @@ export class DocxCodec extends Codec<EncodeOptions>
       format: Pandoc.OutputFormat.docx,
       theme: getTheme(),
       codecOptions: {
-        flags: [`--reference-doc=${referenceDoc}`, ...bibliographyFlags],
-        ensureFile: true
+        flags,
+        ensureFile: true,
+        useCiteproc: references !== undefined
       }
     })
   }

--- a/src/codecs/pandoc/__file_snapshots__/cite-bib-file.json
+++ b/src/codecs/pandoc/__file_snapshots__/cite-bib-file.json
@@ -1,0 +1,28 @@
+{
+  "type": "Article",
+  "authors": [],
+  "bibliography": {
+    "type": "Paragraph",
+    "content": [
+      "cite-bib-file.bib"
+    ]
+  },
+  "title": "Untitled",
+  "content": [
+    {
+      "type": "Paragraph",
+      "content": [
+        "Bibliography in a file ",
+        {
+          "type": "Cite",
+          "citationMode": "normal",
+          "target": "WatsonCrick1953",
+          "content": [
+            "@WatsonCrick1953"
+          ]
+        },
+        "."
+      ]
+    }
+  ]
+}

--- a/src/codecs/pandoc/__file_snapshots__/cite-refs.html
+++ b/src/codecs/pandoc/__file_snapshots__/cite-refs.html
@@ -1,0 +1,7 @@
+<p>An example with references in YAML metadata. Example from https://pandoc.org/MANUAL.html. <span class="citation" data-cites="WatsonCrick1953">Watson and Crick (1953)</span>.</p>
+<h1 class="unnumbered" id="references" class="unnumbered">References</h1>
+<div id="refs" class="references hanging-indent" role="doc-bibliography">
+<div id="ref-WatsonCrick1953">
+<p>Watson, J. D., and F. H. C. Crick. 1953. “Molecular Structure of Nucleic Acids: A Structure for Deoxyribose Nucleic Acid.” <em>Nature</em> 171 (4356): 737–38. <a href="https://doi.org/10.1038/171737a0">https://doi.org/10.1038/171737a0</a>.</p>
+</div>
+</div>

--- a/src/codecs/pandoc/__file_snapshots__/cite.json
+++ b/src/codecs/pandoc/__file_snapshots__/cite.json
@@ -1,0 +1,81 @@
+{
+  "type": "Article",
+  "authors": [],
+  "bibliography": [
+    {
+      "author": [
+        {
+          "family": {
+            "type": "Paragraph",
+            "content": [
+              "Watson"
+            ]
+          },
+          "given": {
+            "type": "Paragraph",
+            "content": [
+              "J. D."
+            ]
+          }
+        },
+        {
+          "family": {
+            "type": "Paragraph",
+            "content": [
+              "Crick"
+            ]
+          },
+          "given": {
+            "type": "Paragraph",
+            "content": [
+              "F. H. C."
+            ]
+          }
+        }
+      ],
+      "id": {
+        "type": "Paragraph",
+        "content": [
+          "WatsonCrick1953"
+        ]
+      }
+    }
+  ],
+  "title": "Untitled",
+  "content": [
+    {
+      "type": "Paragraph",
+      "content": [
+        "Citations in line ",
+        {
+          "type": "Cite",
+          "citationMode": "normal",
+          "target": "WatsonCrick1953",
+          "content": [
+            "@WatsonCrick1953"
+          ]
+        },
+        " or grouped in brackets ",
+        {
+          "type": "CiteGroup",
+          "items": [
+            {
+              "type": "Cite",
+              "citationMode": "normal",
+              "target": "WatsonCrick1953",
+              "content": [
+                "[@WatsonCrick1953; @WatsonCrick1953]"
+              ]
+            },
+            {
+              "type": "Cite",
+              "citationMode": "normal",
+              "target": "WatsonCrick1953"
+            }
+          ]
+        },
+        "."
+      ]
+    }
+  ]
+}

--- a/src/codecs/pandoc/__fixtures__/Makefile
+++ b/src/codecs/pandoc/__fixtures__/Makefile
@@ -1,0 +1,6 @@
+all: $(patsubst %.md,%.pandoc.json,$(filter-out README.md,$(wildcard *.md)))
+
+%.pandoc.json: %.md FORCE
+	./pandoc-json.sh $< > $@
+
+FORCE:

--- a/src/codecs/pandoc/__fixtures__/README.md
+++ b/src/codecs/pandoc/__fixtures__/README.md
@@ -1,6 +1,6 @@
 # Test fixtures for Pandoc
 
-These tests fixtures are intended to be used with the `pandoc` codec, which by default imports and exports Pandoc JSON. But because no one wants to write Pandoc JSON by hand, this folder contains files in other formats from which Pandoc JSON is generated using `pandoc-json.sh` e.g.
+These tests fixtures are intended to be used with the `pandoc` codec, which by default imports and exports Pandoc JSON. But Pandoc JSON is painful to write by hand. So, this folder contains fixture files in other formats, from which Pandoc JSON is generated using `pandoc-json.sh` e.g.
 
 ```bash
 ./pandoc-json.sh cite.md > cite.pandoc.json
@@ -9,3 +9,9 @@ These tests fixtures are intended to be used with the `pandoc` codec, which by d
 This provides an easy way to quickly see the structure of the Pandoc JSON that needs to be decoded/encoded by this codec.
 
 Please don't use these "other format" files e.g. `*.md` in the Pandoc tests. Instead prefer adding fixtures to the codec for the "other format" e.g. `md` codec.
+
+To rebuild all these fixtures do,
+
+```bash
+make
+```

--- a/src/codecs/pandoc/__fixtures__/cite-bib-file.pandoc.json
+++ b/src/codecs/pandoc/__fixtures__/cite-bib-file.pandoc.json
@@ -63,9 +63,7 @@
   ],
   "pandoc-api-version": [
     1,
-    17,
-    5,
-    4
+    20
   ],
   "meta": {
     "bibliography": {

--- a/src/codecs/pandoc/__fixtures__/cite-refs.md
+++ b/src/codecs/pandoc/__fixtures__/cite-refs.md
@@ -1,0 +1,29 @@
+---
+references:
+- type: article-journal
+  id: WatsonCrick1953
+  author:
+  - family: Watson
+    given: J. D.
+  - family: Crick
+    given: F. H. C.
+  issued:
+    date-parts:
+    - - 1953
+      - 4
+      - 25
+  title: 'Molecular structure of nucleic acids: a structure for deoxyribose
+    nucleic acid'
+  title-short: Molecular structure of nucleic acids
+  container-title: Nature
+  volume: 171
+  issue: 4356
+  page: 737-738
+  DOI: 10.1038/171737a0
+  URL: http://www.nature.com/nature/journal/v171/n4356/abs/171737a0.html
+  language: en-GB
+---
+
+An example with references in YAML metadata. Example from https://pandoc.org/MANUAL.html. @WatsonCrick1953.
+
+# References

--- a/src/codecs/pandoc/__fixtures__/cite-refs.pandoc.json
+++ b/src/codecs/pandoc/__fixtures__/cite-refs.pandoc.json
@@ -1,0 +1,450 @@
+{
+  "blocks": [
+    {
+      "t": "Para",
+      "c": [
+        {
+          "t": "Str",
+          "c": "An"
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Str",
+          "c": "example"
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Str",
+          "c": "with"
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Str",
+          "c": "references"
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Str",
+          "c": "in"
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Str",
+          "c": "YAML"
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Str",
+          "c": "metadata."
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Str",
+          "c": "Example"
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Str",
+          "c": "from"
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Str",
+          "c": "https://pandoc.org/MANUAL.html."
+        },
+        {
+          "t": "Space"
+        },
+        {
+          "t": "Cite",
+          "c": [
+            [
+              {
+                "citationSuffix": [],
+                "citationNoteNum": 0,
+                "citationMode": {
+                  "t": "AuthorInText"
+                },
+                "citationPrefix": [],
+                "citationId": "WatsonCrick1953",
+                "citationHash": 0
+              }
+            ],
+            [
+              {
+                "t": "Str",
+                "c": "@WatsonCrick1953"
+              }
+            ]
+          ]
+        },
+        {
+          "t": "Str",
+          "c": "."
+        }
+      ]
+    },
+    {
+      "t": "Header",
+      "c": [
+        1,
+        [
+          "references",
+          [],
+          []
+        ],
+        [
+          {
+            "t": "Str",
+            "c": "References"
+          }
+        ]
+      ]
+    }
+  ],
+  "pandoc-api-version": [
+    1,
+    20
+  ],
+  "meta": {
+    "references": {
+      "t": "MetaList",
+      "c": [
+        {
+          "t": "MetaMap",
+          "c": {
+            "DOI": {
+              "t": "MetaInlines",
+              "c": [
+                {
+                  "t": "Str",
+                  "c": "10.1038/171737a0"
+                }
+              ]
+            },
+            "volume": {
+              "t": "MetaInlines",
+              "c": [
+                {
+                  "t": "Str",
+                  "c": "171"
+                }
+              ]
+            },
+            "URL": {
+              "t": "MetaInlines",
+              "c": [
+                {
+                  "t": "Str",
+                  "c": "http://www.nature.com/nature/journal/v171/n4356/abs/171737a0.html"
+                }
+              ]
+            },
+            "page": {
+              "t": "MetaInlines",
+              "c": [
+                {
+                  "t": "Str",
+                  "c": "737-738"
+                }
+              ]
+            },
+            "title-short": {
+              "t": "MetaInlines",
+              "c": [
+                {
+                  "t": "Str",
+                  "c": "Molecular"
+                },
+                {
+                  "t": "Space"
+                },
+                {
+                  "t": "Str",
+                  "c": "structure"
+                },
+                {
+                  "t": "Space"
+                },
+                {
+                  "t": "Str",
+                  "c": "of"
+                },
+                {
+                  "t": "Space"
+                },
+                {
+                  "t": "Str",
+                  "c": "nucleic"
+                },
+                {
+                  "t": "Space"
+                },
+                {
+                  "t": "Str",
+                  "c": "acids"
+                }
+              ]
+            },
+            "container-title": {
+              "t": "MetaInlines",
+              "c": [
+                {
+                  "t": "Str",
+                  "c": "Nature"
+                }
+              ]
+            },
+            "language": {
+              "t": "MetaInlines",
+              "c": [
+                {
+                  "t": "Str",
+                  "c": "en-GB"
+                }
+              ]
+            },
+            "author": {
+              "t": "MetaList",
+              "c": [
+                {
+                  "t": "MetaMap",
+                  "c": {
+                    "family": {
+                      "t": "MetaInlines",
+                      "c": [
+                        {
+                          "t": "Str",
+                          "c": "Watson"
+                        }
+                      ]
+                    },
+                    "given": {
+                      "t": "MetaInlines",
+                      "c": [
+                        {
+                          "t": "Str",
+                          "c": "J."
+                        },
+                        {
+                          "t": "Space"
+                        },
+                        {
+                          "t": "Str",
+                          "c": "D."
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "t": "MetaMap",
+                  "c": {
+                    "family": {
+                      "t": "MetaInlines",
+                      "c": [
+                        {
+                          "t": "Str",
+                          "c": "Crick"
+                        }
+                      ]
+                    },
+                    "given": {
+                      "t": "MetaInlines",
+                      "c": [
+                        {
+                          "t": "Str",
+                          "c": "F."
+                        },
+                        {
+                          "t": "Space"
+                        },
+                        {
+                          "t": "Str",
+                          "c": "H."
+                        },
+                        {
+                          "t": "Space"
+                        },
+                        {
+                          "t": "Str",
+                          "c": "C."
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            "id": {
+              "t": "MetaInlines",
+              "c": [
+                {
+                  "t": "Str",
+                  "c": "WatsonCrick1953"
+                }
+              ]
+            },
+            "issued": {
+              "t": "MetaMap",
+              "c": {
+                "date-parts": {
+                  "t": "MetaList",
+                  "c": [
+                    {
+                      "t": "MetaList",
+                      "c": [
+                        {
+                          "t": "MetaInlines",
+                          "c": [
+                            {
+                              "t": "Str",
+                              "c": "1953"
+                            }
+                          ]
+                        },
+                        {
+                          "t": "MetaInlines",
+                          "c": [
+                            {
+                              "t": "Str",
+                              "c": "4"
+                            }
+                          ]
+                        },
+                        {
+                          "t": "MetaInlines",
+                          "c": [
+                            {
+                              "t": "Str",
+                              "c": "25"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            },
+            "title": {
+              "t": "MetaInlines",
+              "c": [
+                {
+                  "t": "Str",
+                  "c": "Molecular"
+                },
+                {
+                  "t": "Space"
+                },
+                {
+                  "t": "Str",
+                  "c": "structure"
+                },
+                {
+                  "t": "Space"
+                },
+                {
+                  "t": "Str",
+                  "c": "of"
+                },
+                {
+                  "t": "Space"
+                },
+                {
+                  "t": "Str",
+                  "c": "nucleic"
+                },
+                {
+                  "t": "Space"
+                },
+                {
+                  "t": "Str",
+                  "c": "acids:"
+                },
+                {
+                  "t": "Space"
+                },
+                {
+                  "t": "Str",
+                  "c": "a"
+                },
+                {
+                  "t": "Space"
+                },
+                {
+                  "t": "Str",
+                  "c": "structure"
+                },
+                {
+                  "t": "Space"
+                },
+                {
+                  "t": "Str",
+                  "c": "for"
+                },
+                {
+                  "t": "Space"
+                },
+                {
+                  "t": "Str",
+                  "c": "deoxyribose"
+                },
+                {
+                  "t": "Space"
+                },
+                {
+                  "t": "Str",
+                  "c": "nucleic"
+                },
+                {
+                  "t": "Space"
+                },
+                {
+                  "t": "Str",
+                  "c": "acid"
+                }
+              ]
+            },
+            "type": {
+              "t": "MetaInlines",
+              "c": [
+                {
+                  "t": "Str",
+                  "c": "article-journal"
+                }
+              ]
+            },
+            "issue": {
+              "t": "MetaInlines",
+              "c": [
+                {
+                  "t": "Str",
+                  "c": "4356"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/codecs/pandoc/__fixtures__/cite.pandoc.json
+++ b/src/codecs/pandoc/__fixtures__/cite.pandoc.json
@@ -127,9 +127,7 @@
   ],
   "pandoc-api-version": [
     1,
-    17,
-    5,
-    4
+    20
   ],
   "meta": {
     "bibliography": {

--- a/src/codecs/pandoc/__fixtures__/pandoc-json.sh
+++ b/src/codecs/pandoc/__fixtures__/pandoc-json.sh
@@ -3,5 +3,5 @@
 # A little script for generating test fixture in Pandoc JSON
 # from files in other formats which are eiseir to author
 
-../../../../vendor/pandoc/bin/pandoc $1 --to json | jq .
+../../../../dist/codecs/pandoc/binary/bin/pandoc $1 --to json | jq .
 

--- a/src/codecs/pandoc/binary.ts
+++ b/src/codecs/pandoc/binary.ts
@@ -12,7 +12,7 @@ import appHome from '../../util/app/home'
 import isPackaged from '../../util/app/isPackaged'
 import isCompiled from '../../util/app/isCompiled'
 
-const version = '2.7.3'
+const version = '2.9.1'
 const base = `https://github.com/jgm/pandoc/releases/download/${version}/pandoc-${version}`
 
 const home = path.join(
@@ -21,7 +21,7 @@ const home = path.join(
 )
 
 export const binary = new BinWrapper()
-  .src(`${base}-linux.tar.gz`, 'linux', 'x64')
+  .src(`${base}-linux-amd64.tar.gz`, 'linux', 'x64')
   .src(`${base}-macOS.zip`, 'darwin')
   .src(`${base}-windows-i386.zip`, 'win32', 'x32')
   .src(`${base}-windows-x86_64.zip`, 'win32', 'x64')

--- a/src/codecs/pandoc/binary.ts
+++ b/src/codecs/pandoc/binary.ts
@@ -29,6 +29,11 @@ export const binary = new BinWrapper()
   .use(process.platform === 'win32' ? 'pandoc.exe' : 'bin/pandoc')
   .version(version)
 
+export const citeprocBinaryPath = path.join(
+  binary.dest(),
+  process.platform === 'win32' ? 'pandoc-citeproc.exe' : 'bin/pandoc-citeproc'
+)
+
 /**
  * Equivalent to the Pandoc `--data-dir` flag.
  * Instructs Pandoc where to find templates and other assets.

--- a/src/codecs/pandoc/pandoc.test.ts
+++ b/src/codecs/pandoc/pandoc.test.ts
@@ -125,7 +125,7 @@ const space = (): Pandoc.Space => ({ t: 'Space', c: undefined })
 // Pandoc element type (we'll add them over time :)
 const kitchenSink: testCase = {
   pdoc: {
-    'pandoc-api-version': [1, 17, 5, 4],
+    'pandoc-api-version': [1, 20],
     meta: {
       title: {
         t: 'MetaString',

--- a/src/codecs/pandoc/pandoc.test.ts
+++ b/src/codecs/pandoc/pandoc.test.ts
@@ -19,7 +19,8 @@ jest.setTimeout(60 * 1000)
 const pdoc2node = async (pdoc: any) => await decode(load(JSON.stringify(pdoc)))
 const node2pdoc = async (node: any) =>
   JSON.parse(await dump(await encode(node)))
-const decodeFixture = async (name: string) => await decode(await vfile.read(fixture(name)))
+const decodeFixture = async (name: string) =>
+  await decode(await vfile.read(fixture(name)))
 
 const json = new JsonCodec()
 
@@ -113,12 +114,12 @@ describe('citations and references', () => {
    * as expected.
    */
   test('decoding', async () => {
-    expect(await json.dump(await decodeFixture('cite.pandoc.json'))).toMatchFile(
-      snapshot('cite.json')
-    )
-    expect(await json.dump(await decodeFixture('cite-bib-file.pandoc.json'))).toMatchFile(
-      snapshot('cite-bib-file.json')
-    )
+    expect(
+      await json.dump(await decodeFixture('cite.pandoc.json'))
+    ).toMatchFile(snapshot('cite.json'))
+    expect(
+      await json.dump(await decodeFixture('cite-bib-file.pandoc.json'))
+    ).toMatchFile(snapshot('cite-bib-file.json'))
   })
 
   /**
@@ -127,10 +128,7 @@ describe('citations and references', () => {
    */
   test('encoding', async () => {
     const pandocJson = await fs.readFile(fixture('cite-refs.pandoc.json'))
-    const html = await run(pandocJson, [
-      '--from=json',
-      '--to=html'
-    ], true)
+    const html = await run(pandocJson, ['--from=json', '--to=html'], true)
     expect(html).toMatchFile(snapshot('cite-refs.html'))
   })
 })

--- a/src/codecs/pandoc/pandoc.test.ts
+++ b/src/codecs/pandoc/pandoc.test.ts
@@ -6,8 +6,8 @@ import { dump, load } from '../../util/vfile'
 import { fixture, snapshot } from '../../__tests__/helpers'
 import { RPNGCodec } from '../rpng'
 import { defaultEncodeOptions } from '../types'
-import { YamlCodec } from '../yaml'
-import { decodeMeta, emptyAttrs, encodeMeta, PandocCodec } from './'
+import { JsonCodec } from '../json'
+import { decodeMeta, emptyAttrs, encodeMeta, PandocCodec, run } from './'
 import * as Pandoc from './types'
 
 const { decode, encode } = new PandocCodec()
@@ -19,10 +19,9 @@ jest.setTimeout(60 * 1000)
 const pdoc2node = async (pdoc: any) => await decode(load(JSON.stringify(pdoc)))
 const node2pdoc = async (node: any) =>
   JSON.parse(await dump(await encode(node)))
-const yaml = new YamlCodec()
+const decodeFixture = async (name: string) => await decode(await vfile.read(fixture(name)))
 
-const pjson2yaml = async (pjson: string) =>
-  vfile.dump(await yaml.encode(await decode(await vfile.read(fixture(pjson)))))
+const json = new JsonCodec()
 
 test('decode', async () => {
   let got = await pdoc2node(kitchenSink.pdoc)
@@ -31,10 +30,6 @@ test('decode', async () => {
   expect(await pdoc2node(collapseSpaces.pdoc)).toEqual(collapseSpaces.node)
   expect(await pdoc2node(imageInlinesToString.pdoc)).toEqual(
     imageInlinesToString.node
-  )
-
-  expect(await pjson2yaml('cite.pandoc.json')).toMatchFile(
-    snapshot('cite.yaml')
   )
 })
 
@@ -110,6 +105,34 @@ test('metadata', async () => {
 
   expect(encoded).toEqual(pmeta)
   expect(decoded).toEqual(meta)
+})
+
+describe('citations and references', () => {
+  /**
+   * Simple tests that decoding from Pandoc JSON works
+   * as expected.
+   */
+  test('decoding', async () => {
+    expect(await json.dump(await decodeFixture('cite.pandoc.json'))).toMatchFile(
+      snapshot('cite.json')
+    )
+    expect(await json.dump(await decodeFixture('cite-bib-file.pandoc.json'))).toMatchFile(
+      snapshot('cite-bib-file.json')
+    )
+  })
+
+  /**
+   * Test that `useCiteproc` works eg. that `pandoc-citeproc`
+   * binary is found. Expects the references section to be populated.
+   */
+  test('encoding', async () => {
+    const pandocJson = await fs.readFile(fixture('cite-refs.pandoc.json'))
+    const html = await run(pandocJson, [
+      '--from=json',
+      '--to=html'
+    ], true)
+    expect(html).toMatchFile(snapshot('cite-refs.html'))
+  })
 })
 
 interface testCase {

--- a/src/codecs/pandoc/pandoc.test.ts
+++ b/src/codecs/pandoc/pandoc.test.ts
@@ -125,10 +125,11 @@ describe('citations and references', () => {
   /**
    * Test that `useCiteproc` works eg. that `pandoc-citeproc`
    * binary is found. Expects the references section to be populated.
+   * Use `--eol=lf` to avoid difference to snapshot on Windows.
    */
   test('encoding', async () => {
     const pandocJson = await fs.readFile(fixture('cite-refs.pandoc.json'))
-    const html = await run(pandocJson, ['--from=json', '--to=html'], true)
+    const html = await run(pandocJson, ['--from=json', '--to=html', '--eol=lf'], true)
     expect(html).toMatchFile(snapshot('cite-refs.html'))
   })
 })

--- a/src/codecs/pandoc/types.ts
+++ b/src/codecs/pandoc/types.ts
@@ -4,9 +4,18 @@
  * @module pandoc/types
  */
 
-type VersionNumber = [number, number, number, number]
-
-export const Version: VersionNumber = [1, 17, 5, 4]
+/**
+ * The `pandoc-types` version number. This must be consistent
+ * with the version used by the Pandoc binary version specified
+ * in `./binary.ts` (tests will error if they are not).
+ *
+ * When changing the types version (due to upgrades in the binary version),
+ * check for any changes in the `pandoc-types` `Definition.hs` file
+ * that may need to be ported to these Typescript types e.g.
+ *    https://github.com/jgm/pandoc-types/compare/1.17.5.4...1.20
+ */
+type VersionNumber = [number, number]
+export const Version: VersionNumber = [1, 20]
 
 export interface Document {
   /**


### PR DESCRIPTION
- Updates `pandoc` to 2.9.1
- Ensures that the `pandoc-citeproc` binary used is the one distributed with `pandoc`