### PR TITLE
fix(MD): Don't coerce decoded MD AST, avoiding false null values

### DIFF
--- a/src/codecs/md/index.ts
+++ b/src/codecs/md/index.ts
@@ -5,11 +5,11 @@
 import { getLogger } from '@stencila/logga'
 import stencila, {
   isBlockContent,
+  isInlineContent,
   isListItem,
   nodeIs,
   nodeType,
-  TypeMapGeneric,
-  isInlineContent
+  TypeMapGeneric
 } from '@stencila/schema'
 import * as yaml from 'js-yaml'
 import JSON5 from 'json5'
@@ -36,12 +36,11 @@ import filter from 'unist-util-filter'
 import map from 'unist-util-map'
 // @ts-ignore
 import { selectAll } from 'unist-util-select'
-import * as vfile from '../../util/vfile'
 import { stringifyContent } from '../../util/content/stringifyContent'
-import { Codec } from '../types'
+import * as vfile from '../../util/vfile'
 import { HTMLCodec } from '../html'
+import { Codec } from '../types'
 import { stringifyHTML } from './stringifyHtml'
-import { coerce } from '../../util/coerce'
 
 export const log = getLogger('encoda:md')
 
@@ -58,8 +57,7 @@ export class MdCodec extends Codec implements Codec {
     file: vfile.VFile
   ): Promise<stencila.Node> => {
     const md = await vfile.dump(file)
-    const node = decodeMarkdown(md)
-    return coerce(node)
+    return decodeMarkdown(md)
   }
 
   /**

--- a/src/codecs/md/md.test.ts
+++ b/src/codecs/md/md.test.ts
@@ -40,6 +40,7 @@ describe('decode', () => {
 
 some paragraphs
 
+<!-- A comment which should not be included -->
 <a href="#">My link</a>
 
 followed by more paragraphs`)
@@ -49,6 +50,7 @@ followed by more paragraphs`)
         content: [
           heading({ content: ['Heading 1'], depth: 1 }),
           paragraph({ content: ['some paragraphs'] }),
+          '',
           paragraph({ content: [link({ content: ['My link'], target: '#' })] }),
           paragraph({ content: ['followed by more paragraphs'] })
         ]

--- a/src/codecs/rnb/__file_snapshots__/kitchensink.json
+++ b/src/codecs/rnb/__file_snapshots__/kitchensink.json
@@ -1,5 +1,10 @@
 {
   "title": "Kitchensink R Notebook",
+  "output": "html_notebook",
+  "author": [
+    "Peter Pan",
+    "Captain Hook"
+  ],
   "content": [
     {
       "type": "Paragraph",
@@ -156,23 +161,5 @@
       "type": "CodeChunk"
     }
   ],
-  "type": "Article",
-  "authors": [
-    {
-      "givenNames": [
-        "Peter"
-      ],
-      "familyNames": [
-        "Pan"
-      ],
-      "type": "Person"
-    },
-    {
-      "familyNames": [
-        "Hook"
-      ],
-      "honorificPrefix": "Captain",
-      "type": "Person"
-    }
-  ]
+  "type": "Article"
 }

--- a/src/codecs/xmd/__file_snapshots__/basic.json
+++ b/src/codecs/xmd/__file_snapshots__/basic.json
@@ -1,5 +1,6 @@
 {
   "title": "Untitled",
+  "output": "html_document",
   "content": [
     {
       "text": "knitr::opts_chunk$set(echo = TRUE)",

--- a/src/codecs/xmd/__file_snapshots__/kitchensink.json
+++ b/src/codecs/xmd/__file_snapshots__/kitchensink.json
@@ -1,15 +1,7 @@
 {
   "title": "Kitchen sink XMarkdown example",
   "authors": [
-    {
-      "givenNames": [
-        "Nokome"
-      ],
-      "familyNames": [
-        "Bentley"
-      ],
-      "type": "Person"
-    }
+    "Nokome Bentley"
   ],
   "description": "This example is intended to have a variety of different XMarkdown elements in it.\n",
   "content": [


### PR DESCRIPTION
As discussed over video, this removes the `coerce` call on the decoded MD schema, closes #307 
Down the road we might look into reinstating coercion in a single top-level place in the `index.ts` file.