### PR TITLE
feat(JATS): Improve decoding of article front matter

### DIFF
--- a/src/codecs/elife/__file_snapshots__/45123.yaml
+++ b/src/codecs/elife/__file_snapshots__/45123.yaml
@@ -46,6 +46,15 @@ isPartOf:
       name: 'eLife Sciences Publications, Ltd'
     title: eLife
   volumeNumber: '8'
+keywords:
+  - long non-coding RNA
+  - intellectual disabilities
+  - autism
+  - genomics
+  - gene regulation
+  - neuronal development
+  - Human
+  - Mouse
 licenses:
   - type: CreativeWork
     url: 'http://creativecommons.org/licenses/by/4.0/'

--- a/src/codecs/elife/__file_snapshots__/45123.yaml
+++ b/src/codecs/elife/__file_snapshots__/45123.yaml
@@ -24,6 +24,9 @@ authors:
     givenNames:
       - Sacri
       - R
+datePublished:
+  type: Date
+  value: '2019-02-19'
 description:
   - type: Paragraph
     content:

--- a/src/codecs/elife/__file_snapshots__/45123.yaml
+++ b/src/codecs/elife/__file_snapshots__/45123.yaml
@@ -32,6 +32,17 @@ description:
         content:
           - lnc-NR2F1
       - ' regulates several neuronal genes, including some involved in autism and intellectual disabilities.'
+isPartOf:
+  type: PublicationVolume
+  isPartOf:
+    type: Periodical
+    issn:
+      - 2050-084X
+    publisher:
+      type: Organization
+      name: 'eLife Sciences Publications, Ltd'
+    title: eLife
+  volumeNumber: '8'
 references:
   - type: Article
     id: bib1

--- a/src/codecs/elife/__file_snapshots__/45123.yaml
+++ b/src/codecs/elife/__file_snapshots__/45123.yaml
@@ -46,6 +46,20 @@ isPartOf:
       name: 'eLife Sciences Publications, Ltd'
     title: eLife
   volumeNumber: '8'
+licenses:
+  - type: CreativeWork
+    url: 'http://creativecommons.org/licenses/by/4.0/'
+    content:
+      - type: Paragraph
+        content:
+          - 'This article is distributed under the terms of the '
+          - type: Link
+            target: 'http://creativecommons.org/licenses/by/4.0/'
+            content:
+              - Creative Commons Attribution License
+          - >-
+            , which permits unrestricted use and redistribution provided that
+            the original author and source are credited.
 references:
   - type: Article
     id: bib1

--- a/src/codecs/elife/__file_snapshots__/46793.yaml
+++ b/src/codecs/elife/__file_snapshots__/46793.yaml
@@ -127,6 +127,15 @@ editors:
       - Heyer
     givenNames:
       - Wolf-Dietrich
+funders:
+  - type: Organization
+    name: Cancer Research UK
+  - type: Organization
+    name: Royal Society
+  - type: Organization
+    name: Pew Charitable Trusts
+  - type: Organization
+    name: Wellcome
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/elife/__file_snapshots__/46793.yaml
+++ b/src/codecs/elife/__file_snapshots__/46793.yaml
@@ -114,6 +114,17 @@ description:
         killing. We also identify new genes and pathways regulating or
         interacting with G4s and demonstrate that the DDX42 DEAD-box helicase is
         a newly discovered G4-binding protein.
+isPartOf:
+  type: PublicationVolume
+  isPartOf:
+    type: Periodical
+    issn:
+      - 2050-084X
+    publisher:
+      type: Organization
+      name: 'eLife Sciences Publications, Ltd'
+    title: eLife
+  volumeNumber: '8'
 references:
   - type: Article
     id: bib1

--- a/src/codecs/elife/__file_snapshots__/46793.yaml
+++ b/src/codecs/elife/__file_snapshots__/46793.yaml
@@ -117,6 +117,16 @@ description:
         killing. We also identify new genes and pathways regulating or
         interacting with G4s and demonstrate that the DDX42 DEAD-box helicase is
         a newly discovered G4-binding protein.
+editors:
+  - type: Person
+    affiliations:
+      - type: Organization
+        address: United States
+        name: 'University of California, Davis'
+    familyNames:
+      - Heyer
+    givenNames:
+      - Wolf-Dietrich
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/elife/__file_snapshots__/46793.yaml
+++ b/src/codecs/elife/__file_snapshots__/46793.yaml
@@ -138,6 +138,14 @@ isPartOf:
       name: 'eLife Sciences Publications, Ltd'
     title: eLife
   volumeNumber: '8'
+keywords:
+  - G-quadruplex
+  - G4
+  - G-quadruplex ligands
+  - genetic vulnerability
+  - nucleic acid structure
+  - cancer
+  - Human
 licenses:
   - type: CreativeWork
     url: 'http://creativecommons.org/licenses/by/4.0/'

--- a/src/codecs/elife/__file_snapshots__/46793.yaml
+++ b/src/codecs/elife/__file_snapshots__/46793.yaml
@@ -94,6 +94,9 @@ authors:
       - Balasubramanian
     givenNames:
       - Shankar
+datePublished:
+  type: Date
+  value: '2019-07-09'
 description:
   - type: Paragraph
     content:

--- a/src/codecs/elife/__file_snapshots__/46793.yaml
+++ b/src/codecs/elife/__file_snapshots__/46793.yaml
@@ -138,6 +138,20 @@ isPartOf:
       name: 'eLife Sciences Publications, Ltd'
     title: eLife
   volumeNumber: '8'
+licenses:
+  - type: CreativeWork
+    url: 'http://creativecommons.org/licenses/by/4.0/'
+    content:
+      - type: Paragraph
+        content:
+          - 'This article is distributed under the terms of the '
+          - type: Link
+            target: 'http://creativecommons.org/licenses/by/4.0/'
+            content:
+              - Creative Commons Attribution License
+          - >-
+            , which permits unrestricted use and redistribution provided that
+            the original author and source are credited.
 references:
   - type: Article
     id: bib1

--- a/src/codecs/jats/__file_snapshots__/elife-30274-v1.jats.xml
+++ b/src/codecs/jats/__file_snapshots__/elife-30274-v1.jats.xml
@@ -51,36 +51,46 @@
             </contrib>
             <contrib contrib-type="author">
                 <string-name/>
+                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="unique"/>
+                <xref ref-type="aff" rid="unique"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Iorns</surname>
                     <given-names>Elizabeth</given-names>
                 </name>
+                <xref ref-type="aff" rid="unique"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Tsui</surname>
                     <given-names>Rachel</given-names>
                 </name>
+                <xref ref-type="aff" rid="unique"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Denis</surname>
                     <given-names>Alexandria</given-names>
                 </name>
+                <xref ref-type="aff" rid="unique"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Perfito</surname>
                     <given-names>Nicole</given-names>
                 </name>
+                <xref ref-type="aff" rid="unique"/>
             </contrib>
             <contrib contrib-type="author">
                 <name>
                     <surname>Errington</surname>
                     <given-names>Timothy M</given-names>
                 </name>
+                <xref ref-type="aff" rid="unique"/>
             </contrib>
             <aff id="unique">
                 <institution>University of Georgia, Bioexpression and Fermentation Facility</institution>
@@ -99,6 +109,36 @@
             </aff>
             <aff id="unique">
                 <institution>University of Georgia, Bioexpression and Fermentation Facility</institution>
+            </aff>
+            <aff id="unique">
+                <institution>Science Exchange</institution>
+            </aff>
+            <aff id="unique">
+                <institution>Science Exchange</institution>
+            </aff>
+            <aff id="unique">
+                <institution>Center for Open Science</institution>
+            </aff>
+            <aff id="unique">
+                <institution>Science Exchange</institution>
+            </aff>
+            <aff id="unique">
+                <institution>Center for Open Science</institution>
+            </aff>
+            <aff id="unique">
+                <institution>Science Exchange</institution>
+            </aff>
+            <aff id="unique">
+                <institution>Science Exchange</institution>
+            </aff>
+            <aff id="unique">
+                <institution>Center for Open Science</institution>
+            </aff>
+            <aff id="unique">
+                <institution>Science Exchange</institution>
+            </aff>
+            <aff id="unique">
+                <institution>Center for Open Science</institution>
             </aff>
         </contrib-group>
         <abstract>

--- a/src/codecs/jats/__file_snapshots__/elife-30274-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-30274-v1.yaml
@@ -188,6 +188,14 @@ isPartOf:
       name: 'eLife Sciences Publications, Ltd'
     title: eLife
   volumeNumber: '7'
+keywords:
+  - 'Reproducibility Project: Cancer Biology'
+  - replication
+  - metascience
+  - reproducibility
+  - c-Myc
+  - gene expression
+  - Human
 licenses:
   - type: CreativeWork
     url: 'http://creativecommons.org/licenses/by/4.0/'

--- a/src/codecs/jats/__file_snapshots__/elife-30274-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-30274-v1.yaml
@@ -95,6 +95,9 @@ authors:
     givenNames:
       - Timothy
       - M
+datePublished:
+  type: Date
+  value: '2018-01-09'
 description:
   - type: Paragraph
     content:

--- a/src/codecs/jats/__file_snapshots__/elife-30274-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-30274-v1.yaml
@@ -177,6 +177,9 @@ editors:
     givenNames:
       - Michael
       - R
+funders:
+  - type: Organization
+    name: Laura and John Arnold Foundation
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/jats/__file_snapshots__/elife-30274-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-30274-v1.yaml
@@ -66,30 +66,66 @@ authors:
     givenNames:
       - David
   - type: Person
+    affiliations:
+      - type: Organization
+        address: 'Palo Alto, United States'
+        name: Science Exchange
+      - type: Organization
+        address: 'Palo Alto, United States'
+        name: Science Exchange
+      - type: Organization
+        address: 'Charlottesville, United States'
+        name: Center for Open Science
+      - type: Organization
+        address: 'Palo Alto, United States'
+        name: Science Exchange
+      - type: Organization
+        address: 'Charlottesville, United States'
+        name: Center for Open Science
     emails:
       - tim@cos.io
       - nicole@scienceexchange.com
   - type: Person
+    affiliations:
+      - type: Organization
+        address: 'Palo Alto, United States'
+        name: Science Exchange
     familyNames:
       - Iorns
     givenNames:
       - Elizabeth
   - type: Person
+    affiliations:
+      - type: Organization
+        address: 'Palo Alto, United States'
+        name: Science Exchange
     familyNames:
       - Tsui
     givenNames:
       - Rachel
   - type: Person
+    affiliations:
+      - type: Organization
+        address: 'Charlottesville, United States'
+        name: Center for Open Science
     familyNames:
       - Denis
     givenNames:
       - Alexandria
   - type: Person
+    affiliations:
+      - type: Organization
+        address: 'Palo Alto, United States'
+        name: Science Exchange
     familyNames:
       - Perfito
     givenNames:
       - Nicole
   - type: Person
+    affiliations:
+      - type: Organization
+        address: 'Charlottesville, United States'
+        name: Center for Open Science
     familyNames:
       - Errington
     givenNames:
@@ -128,6 +164,19 @@ description:
         both active and silent genes upon c-Myc induction, with the change in
         gene expression greater for active genes compared to silent genes.
         Finally, we report meta-analyses for each result.
+editors:
+  - type: Person
+    affiliations:
+      - type: Organization
+        address: United States
+        name: >-
+          Howard Hughes Medical Institute, University of Massachusetts Medical
+          School
+    familyNames:
+      - Green
+    givenNames:
+      - Michael
+      - R
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/jats/__file_snapshots__/elife-30274-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-30274-v1.yaml
@@ -188,6 +188,20 @@ isPartOf:
       name: 'eLife Sciences Publications, Ltd'
     title: eLife
   volumeNumber: '7'
+licenses:
+  - type: CreativeWork
+    url: 'http://creativecommons.org/licenses/by/4.0/'
+    content:
+      - type: Paragraph
+        content:
+          - 'This article is distributed under the terms of the '
+          - type: Link
+            target: 'http://creativecommons.org/licenses/by/4.0/'
+            content:
+              - Creative Commons Attribution License
+          - >-
+            , which permits unrestricted use and redistribution provided that
+            the original author and source are credited.
 references:
   - type: Article
     id: bib1

--- a/src/codecs/jats/__file_snapshots__/elife-30274-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-30274-v1.yaml
@@ -125,6 +125,17 @@ description:
         both active and silent genes upon c-Myc induction, with the change in
         gene expression greater for active genes compared to silent genes.
         Finally, we report meta-analyses for each result.
+isPartOf:
+  type: PublicationVolume
+  isPartOf:
+    type: Periodical
+    issn:
+      - 2050-084X
+    publisher:
+      type: Organization
+      name: 'eLife Sciences Publications, Ltd'
+    title: eLife
+  volumeNumber: '7'
 references:
   - type: Article
     id: bib1

--- a/src/codecs/jats/__file_snapshots__/elife-46472-v3.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-46472-v3.yaml
@@ -178,6 +178,17 @@ description:
         content:
           - Oprm1
       - ' variants to human methamphetamine addiction.'
+isPartOf:
+  type: PublicationVolume
+  isPartOf:
+    type: Periodical
+    issn:
+      - 2050-084X
+    publisher:
+      type: Organization
+      name: 'eLife Sciences Publications, Ltd'
+    title: eLife
+  volumeNumber: '8'
 references:
   - type: Article
     id: bib1

--- a/src/codecs/jats/__file_snapshots__/elife-46472-v3.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-46472-v3.yaml
@@ -202,6 +202,14 @@ isPartOf:
       name: 'eLife Sciences Publications, Ltd'
     title: eLife
   volumeNumber: '8'
+keywords:
+  - trace amine-associated receptor 1
+  - mu-opioid receptor
+  - CRISPR-Cas9
+  - self administration
+  - hypothermia
+  - addiction
+  - Mouse
 licenses:
   - type: CreativeWork
     url: 'http://creativecommons.org/publicdomain/zero/1.0/'

--- a/src/codecs/jats/__file_snapshots__/elife-46472-v3.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-46472-v3.yaml
@@ -181,6 +181,16 @@ description:
         content:
           - Oprm1
       - ' variants to human methamphetamine addiction.'
+editors:
+  - type: Person
+    affiliations:
+      - type: Organization
+        address: United States
+        name: 'University of California, Los Angeles'
+    familyNames:
+      - Flint
+    givenNames:
+      - Jonathan
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/jats/__file_snapshots__/elife-46472-v3.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-46472-v3.yaml
@@ -126,6 +126,9 @@ authors:
     givenNames:
       - Tamara
       - J
+datePublished:
+  type: Date
+  value: '2019-07-09'
 description:
   - type: Paragraph
     content:

--- a/src/codecs/jats/__file_snapshots__/elife-46472-v3.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-46472-v3.yaml
@@ -191,6 +191,17 @@ editors:
       - Flint
     givenNames:
       - Jonathan
+funders:
+  - type: Organization
+    name: National Institute on Drug Abuse
+  - type: Organization
+    name: Department of Veterans Affairs
+  - type: Organization
+    name: Oregon Health & Science University
+  - type: Organization
+    name: U.S. Department of Veterans Affairs
+  - type: Organization
+    name: University of Tennessee Center for Integrative and Translational Science
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/jats/__file_snapshots__/elife-46472-v3.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-46472-v3.yaml
@@ -202,6 +202,22 @@ isPartOf:
       name: 'eLife Sciences Publications, Ltd'
     title: eLife
   volumeNumber: '8'
+licenses:
+  - type: CreativeWork
+    url: 'http://creativecommons.org/publicdomain/zero/1.0/'
+    content:
+      - type: Paragraph
+        content:
+          - >-
+            This is an open-access article, free of all copyright, and may be
+            freely reproduced, distributed, transmitted, modified, built upon,
+            or otherwise used by anyone for any lawful purpose. The work is made
+            available under the 
+          - type: Link
+            target: 'http://creativecommons.org/publicdomain/zero/1.0/'
+            content:
+              - Creative Commons CC0 public domain dedication
+          - .
 references:
   - type: Article
     id: bib1

--- a/src/codecs/jats/__file_snapshots__/elife-46793-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-46793-v1.yaml
@@ -127,6 +127,15 @@ editors:
       - Heyer
     givenNames:
       - Wolf-Dietrich
+funders:
+  - type: Organization
+    name: Cancer Research UK
+  - type: Organization
+    name: Royal Society
+  - type: Organization
+    name: Pew Charitable Trusts
+  - type: Organization
+    name: Wellcome
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/jats/__file_snapshots__/elife-46793-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-46793-v1.yaml
@@ -114,6 +114,17 @@ description:
         killing. We also identify new genes and pathways regulating or
         interacting with G4s and demonstrate that the DDX42 DEAD-box helicase is
         a newly discovered G4-binding protein.
+isPartOf:
+  type: PublicationVolume
+  isPartOf:
+    type: Periodical
+    issn:
+      - 2050-084X
+    publisher:
+      type: Organization
+      name: 'eLife Sciences Publications, Ltd'
+    title: eLife
+  volumeNumber: '8'
 references:
   - type: Article
     id: bib1

--- a/src/codecs/jats/__file_snapshots__/elife-46793-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-46793-v1.yaml
@@ -117,6 +117,16 @@ description:
         killing. We also identify new genes and pathways regulating or
         interacting with G4s and demonstrate that the DDX42 DEAD-box helicase is
         a newly discovered G4-binding protein.
+editors:
+  - type: Person
+    affiliations:
+      - type: Organization
+        address: United States
+        name: 'University of California, Davis'
+    familyNames:
+      - Heyer
+    givenNames:
+      - Wolf-Dietrich
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/jats/__file_snapshots__/elife-46793-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-46793-v1.yaml
@@ -138,6 +138,14 @@ isPartOf:
       name: 'eLife Sciences Publications, Ltd'
     title: eLife
   volumeNumber: '8'
+keywords:
+  - G-quadruplex
+  - G4
+  - G-quadruplex ligands
+  - genetic vulnerability
+  - nucleic acid structure
+  - cancer
+  - Human
 licenses:
   - type: CreativeWork
     url: 'http://creativecommons.org/licenses/by/4.0/'

--- a/src/codecs/jats/__file_snapshots__/elife-46793-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-46793-v1.yaml
@@ -94,6 +94,9 @@ authors:
       - Balasubramanian
     givenNames:
       - Shankar
+datePublished:
+  type: Date
+  value: '2019-07-09'
 description:
   - type: Paragraph
     content:

--- a/src/codecs/jats/__file_snapshots__/elife-46793-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-46793-v1.yaml
@@ -138,6 +138,20 @@ isPartOf:
       name: 'eLife Sciences Publications, Ltd'
     title: eLife
   volumeNumber: '8'
+licenses:
+  - type: CreativeWork
+    url: 'http://creativecommons.org/licenses/by/4.0/'
+    content:
+      - type: Paragraph
+        content:
+          - 'This article is distributed under the terms of the '
+          - type: Link
+            target: 'http://creativecommons.org/licenses/by/4.0/'
+            content:
+              - Creative Commons Attribution License
+          - >-
+            , which permits unrestricted use and redistribution provided that
+            the original author and source are credited.
 references:
   - type: Article
     id: bib1

--- a/src/codecs/jats/__file_snapshots__/f1000-7-1655-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/f1000-7-1655-v1.yaml
@@ -167,6 +167,12 @@ isPartOf:
       name: F1000 Research Limited
     title: F1000Research
   volumeNumber: '7'
+keywords:
+  - peer review
+  - scholarly publishing
+  - JATS
+  - JATS4R
+  - Crossref
 licenses:
   - type: CreativeWork
     url: 'http://creativecommons.org/licenses/by/4.0/'

--- a/src/codecs/jats/__file_snapshots__/f1000-7-1655-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/f1000-7-1655-v1.yaml
@@ -156,6 +156,11 @@ description:
         draft as to how to represent these materials in the JATS and Crossref
         data models to facilitate the coordination and discoverability of peer
         review materials, and seek feedback on these initial recommendations.
+funders:
+  - type: Organization
+    name: U.S. National Library of Medicine
+  - type: Organization
+    name: Wellcome Trust
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/jats/__file_snapshots__/f1000-7-1655-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/f1000-7-1655-v1.yaml
@@ -133,6 +133,9 @@ authors:
       - Stoner
     givenNames:
       - Michael
+datePublished:
+  type: Date
+  value: '2018-10-17'
 description:
   - type: Paragraph
     content:

--- a/src/codecs/jats/__file_snapshots__/f1000-7-1655-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/f1000-7-1655-v1.yaml
@@ -153,6 +153,17 @@ description:
         draft as to how to represent these materials in the JATS and Crossref
         data models to facilitate the coordination and discoverability of peer
         review materials, and seek feedback on these initial recommendations.
+isPartOf:
+  type: PublicationVolume
+  isPartOf:
+    type: Periodical
+    issn:
+      - 2046-1402
+    publisher:
+      type: Organization
+      name: F1000 Research Limited
+    title: F1000Research
+  volumeNumber: '7'
 references:
   - type: Article
     id: ref-1

--- a/src/codecs/jats/__file_snapshots__/f1000-7-1655-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/f1000-7-1655-v1.yaml
@@ -167,6 +167,17 @@ isPartOf:
       name: F1000 Research Limited
     title: F1000Research
   volumeNumber: '7'
+licenses:
+  - type: CreativeWork
+    url: 'http://creativecommons.org/licenses/by/4.0/'
+    content:
+      - type: Paragraph
+        content:
+          - >-
+            This is an open access article distributed under the terms of the
+            Creative Commons Attribution Licence, which permits unrestricted
+            use, distribution, and reproduction in any medium, provided the
+            original work is properly cited.
 references:
   - type: Article
     id: ref-1

--- a/src/codecs/jats/__file_snapshots__/f1000-8-1394-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/f1000-8-1394-v1.yaml
@@ -106,6 +106,17 @@ description:
         products, the effectiveness of the instrument of food business
         operators' own responsibility for product safety must obviously be
         challenged.
+isPartOf:
+  type: PublicationVolume
+  isPartOf:
+    type: Periodical
+    issn:
+      - 2046-1402
+    publisher:
+      type: Organization
+      name: F1000 Research Limited
+    title: F1000Research
+  volumeNumber: '8'
 references:
   - type: Article
     id: ref-1

--- a/src/codecs/jats/__file_snapshots__/f1000-8-1394-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/f1000-8-1394-v1.yaml
@@ -120,6 +120,14 @@ isPartOf:
       name: F1000 Research Limited
     title: F1000Research
   volumeNumber: '8'
+keywords:
+  - Tetrahydrocannabinol
+  - cannabidiol
+  - Cannabis sativa
+  - hemp
+  - food supplements
+  - risk assessment
+  - drug effects
 licenses:
   - type: CreativeWork
     url: 'http://creativecommons.org/licenses/by/4.0/'

--- a/src/codecs/jats/__file_snapshots__/f1000-8-1394-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/f1000-8-1394-v1.yaml
@@ -67,6 +67,9 @@ authors:
       - Sproll
     givenNames:
       - Constanze
+datePublished:
+  type: Date
+  value: '2019-08-08'
 description:
   - type: Paragraph
     content:

--- a/src/codecs/jats/__file_snapshots__/f1000-8-1394-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/f1000-8-1394-v1.yaml
@@ -120,6 +120,17 @@ isPartOf:
       name: F1000 Research Limited
     title: F1000Research
   volumeNumber: '8'
+licenses:
+  - type: CreativeWork
+    url: 'http://creativecommons.org/licenses/by/4.0/'
+    content:
+      - type: Paragraph
+        content:
+          - >-
+            This is an open access article distributed under the terms of the
+            Creative Commons Attribution Licence, which permits unrestricted
+            use, distribution, and reproduction in any medium, provided the
+            original work is properly cited.
 references:
   - type: Article
     id: ref-1

--- a/src/codecs/jats/__file_snapshots__/f1000-8-978-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/f1000-8-978-v1.yaml
@@ -154,6 +154,17 @@ description:
       - >-
         Precipitation of coldest quarter (BIO19) had the maximum contribution
         for all the three species under investigation.
+isPartOf:
+  type: PublicationVolume
+  isPartOf:
+    type: Periodical
+    issn:
+      - 2046-1402
+    publisher:
+      type: Organization
+      name: F1000 Research Limited
+    title: F1000Research
+  volumeNumber: '8'
 references:
   - type: Article
     id: ref-1

--- a/src/codecs/jats/__file_snapshots__/f1000-8-978-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/f1000-8-978-v1.yaml
@@ -157,6 +157,9 @@ description:
       - >-
         Precipitation of coldest quarter (BIO19) had the maximum contribution
         for all the three species under investigation.
+funders:
+  - type: Organization
+    name: United Arab Emirates University
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/jats/__file_snapshots__/f1000-8-978-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/f1000-8-978-v1.yaml
@@ -168,6 +168,10 @@ isPartOf:
       name: F1000 Research Limited
     title: F1000Research
   volumeNumber: '8'
+keywords:
+  - MaxEnt Model
+  - Niche Assessment
+  - Species Distribution Models
 licenses:
   - type: CreativeWork
     url: 'http://creativecommons.org/licenses/by/4.0/'

--- a/src/codecs/jats/__file_snapshots__/f1000-8-978-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/f1000-8-978-v1.yaml
@@ -168,6 +168,17 @@ isPartOf:
       name: F1000 Research Limited
     title: F1000Research
   volumeNumber: '8'
+licenses:
+  - type: CreativeWork
+    url: 'http://creativecommons.org/licenses/by/4.0/'
+    content:
+      - type: Paragraph
+        content:
+          - >-
+            This is an open access article distributed under the terms of the
+            Creative Commons Attribution Licence, which permits unrestricted
+            use, distribution, and reproduction in any medium, provided the
+            original work is properly cited.
 references:
   - type: Article
     id: ref-1

--- a/src/codecs/jats/__file_snapshots__/f1000-8-978-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/f1000-8-978-v1.yaml
@@ -64,6 +64,9 @@ authors:
     givenNames:
       - Fatima
       - E.
+datePublished:
+  type: Date
+  value: '2019-06-27'
 description:
   - type: Paragraph
     content:

--- a/src/codecs/jats/__file_snapshots__/plosone-0091296.yaml
+++ b/src/codecs/jats/__file_snapshots__/plosone-0091296.yaml
@@ -92,6 +92,19 @@ isPartOf:
       name: Public Library of Science
     title: PLoS ONE
   volumeNumber: '9'
+licenses:
+  - type: CreativeWork
+    content:
+      - type: Paragraph
+        content:
+          - 'This is an open-access article distributed under the terms of the '
+          - type: Link
+            target: 'http://creativecommons.org/licenses/by/4.0/'
+            content:
+              - Creative Commons Attribution License
+          - >-
+            , which permits unrestricted use, distribution, and reproduction in
+            any medium, provided the original author and source are credited.
 references:
   - type: Article
     id: pone.0091296-Mora1

--- a/src/codecs/jats/__file_snapshots__/plosone-0091296.yaml
+++ b/src/codecs/jats/__file_snapshots__/plosone-0091296.yaml
@@ -68,6 +68,17 @@ description:
         content:
           - tambu
       - ' areas, are to be supported. The findings of this study call for a holistic approach to assessing the risks posed to reef fish aggregations by fishing, grounded in the principals of fisheries science and emerging social-ecological thinking.'
+isPartOf:
+  type: PublicationVolume
+  isPartOf:
+    type: Periodical
+    issn:
+      - 1932-6203
+    publisher:
+      type: Organization
+      name: Public Library of Science
+    title: PLoS ONE
+  volumeNumber: '9'
 references:
   - type: Article
     id: pone.0091296-Mora1

--- a/src/codecs/jats/__file_snapshots__/plosone-0091296.yaml
+++ b/src/codecs/jats/__file_snapshots__/plosone-0091296.yaml
@@ -33,6 +33,9 @@ authors:
       - Nicholas
       - A.
       - J.
+datePublished:
+  type: Date
+  value: '2014-03-19'
 description:
   - type: Paragraph
     content:

--- a/src/codecs/jats/__file_snapshots__/plosone-0091296.yaml
+++ b/src/codecs/jats/__file_snapshots__/plosone-0091296.yaml
@@ -71,6 +71,16 @@ description:
         content:
           - tambu
       - ' areas, are to be supported. The findings of this study call for a holistic approach to assessing the risks posed to reef fish aggregations by fishing, grounded in the principals of fisheries science and emerging social-ecological thinking.'
+editors:
+  - type: Person
+    affiliations:
+      - type: Organization
+        name: 'The Australian National University, Australia'
+    familyNames:
+      - Fulton
+    givenNames:
+      - Christopher
+      - J.
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/jats/__file_snapshots__/plosone-0093988.yaml
+++ b/src/codecs/jats/__file_snapshots__/plosone-0093988.yaml
@@ -71,6 +71,19 @@ isPartOf:
       name: Public Library of Science
     title: PLoS ONE
   volumeNumber: '9'
+licenses:
+  - type: CreativeWork
+    content:
+      - type: Paragraph
+        content:
+          - 'This is an open-access article distributed under the terms of the '
+          - type: Link
+            target: 'http://creativecommons.org/licenses/by/4.0/'
+            content:
+              - Creative Commons Attribution License
+          - >-
+            , which permits unrestricted use, distribution, and reproduction in
+            any medium, provided the original author and source are credited.
 references:
   - type: Article
     id: pone.0093988-Kollock1

--- a/src/codecs/jats/__file_snapshots__/plosone-0093988.yaml
+++ b/src/codecs/jats/__file_snapshots__/plosone-0093988.yaml
@@ -30,6 +30,9 @@ authors:
       - Killingback
     givenNames:
       - Timothy
+datePublished:
+  type: Date
+  value: '2014-04-07'
 description:
   - type: Paragraph
     content:

--- a/src/codecs/jats/__file_snapshots__/plosone-0093988.yaml
+++ b/src/codecs/jats/__file_snapshots__/plosone-0093988.yaml
@@ -48,6 +48,17 @@ description:
         experimentally. Thus, these variants of the Traveler's Dilemma and the
         Minimum Effort Coordination games provide a simple resolution of the
         paradoxical behavior associated with the original games.
+isPartOf:
+  type: PublicationVolume
+  isPartOf:
+    type: Periodical
+    issn:
+      - 1932-6203
+    publisher:
+      type: Organization
+      name: Public Library of Science
+    title: PLoS ONE
+  volumeNumber: '9'
 references:
   - type: Article
     id: pone.0093988-Kollock1

--- a/src/codecs/jats/__file_snapshots__/plosone-0093988.yaml
+++ b/src/codecs/jats/__file_snapshots__/plosone-0093988.yaml
@@ -51,6 +51,15 @@ description:
         experimentally. Thus, these variants of the Traveler's Dilemma and the
         Minimum Effort Coordination games provide a simple resolution of the
         paradoxical behavior associated with the original games.
+editors:
+  - type: Person
+    affiliations:
+      - type: Organization
+        name: 'University of Maribor, Slovenia'
+    familyNames:
+      - Perc
+    givenNames:
+      - Matjaž
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/jats/__file_snapshots__/plosone-0178565.yaml
+++ b/src/codecs/jats/__file_snapshots__/plosone-0178565.yaml
@@ -82,6 +82,9 @@ editors:
     givenNames:
       - Igor
       - B.
+funders:
+  - type: Organization
+    name: 'Department of Biotechnology, Ministry of Science and Technology'
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/jats/__file_snapshots__/plosone-0178565.yaml
+++ b/src/codecs/jats/__file_snapshots__/plosone-0178565.yaml
@@ -72,6 +72,16 @@ description:
         cyanobacterial genes. We believe that the data and the analysis
         presented here will be a great resource to the scientific community
         interested in cyanobacteria.
+editors:
+  - type: Person
+    affiliations:
+      - type: Organization
+        name: 'National Center for Biotechnology Information, UNITED STATES'
+    familyNames:
+      - Rogozin
+    givenNames:
+      - Igor
+      - B.
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/jats/__file_snapshots__/plosone-0178565.yaml
+++ b/src/codecs/jats/__file_snapshots__/plosone-0178565.yaml
@@ -35,6 +35,9 @@ authors:
     givenNames:
       - Pramod
       - P.
+datePublished:
+  type: Date
+  value: '2017-06-08'
 description:
   - type: Paragraph
     content:

--- a/src/codecs/jats/__file_snapshots__/plosone-0178565.yaml
+++ b/src/codecs/jats/__file_snapshots__/plosone-0178565.yaml
@@ -93,6 +93,20 @@ isPartOf:
       name: Public Library of Science
     title: PLOS ONE
   volumeNumber: '12'
+licenses:
+  - type: CreativeWork
+    url: 'http://creativecommons.org/licenses/by/4.0/'
+    content:
+      - type: Paragraph
+        content:
+          - 'This is an open access article distributed under the terms of the '
+          - type: Link
+            target: 'http://creativecommons.org/licenses/by/4.0/'
+            content:
+              - Creative Commons Attribution License
+          - >-
+            , which permits unrestricted use, distribution, and reproduction in
+            any medium, provided the original author and source are credited.
 references:
   - type: Article
     id: pone.0178565.ref001

--- a/src/codecs/jats/__file_snapshots__/plosone-0178565.yaml
+++ b/src/codecs/jats/__file_snapshots__/plosone-0178565.yaml
@@ -69,6 +69,17 @@ description:
         cyanobacterial genes. We believe that the data and the analysis
         presented here will be a great resource to the scientific community
         interested in cyanobacteria.
+isPartOf:
+  type: PublicationVolume
+  isPartOf:
+    type: Periodical
+    issn:
+      - 1932-6203
+    publisher:
+      type: Organization
+      name: Public Library of Science
+    title: PLOS ONE
+  volumeNumber: '12'
 references:
   - type: Article
     id: pone.0178565.ref001

--- a/src/codecs/jats/index.ts
+++ b/src/codecs/jats/index.ts
@@ -294,6 +294,7 @@ function decodeFront(
   | 'description'
   | 'isPartOf'
   | 'licenses'
+  | 'keywords'
 > {
   return front === null
     ? {}
@@ -304,7 +305,8 @@ function decodeFront(
         title: decodeTitle(first(front, 'article-title'), state),
         description: decodeAbstract(first(front, 'abstract'), state),
         isPartOf: decodeIsPartOf(front),
-        licenses: decodeLicenses(front, state)
+        licenses: decodeLicenses(front, state),
+        keywords: decodeKeywords(front)
       }
 }
 
@@ -449,6 +451,18 @@ function decodeLicenses(
     const p = first(license, 'license-p')
     const content = p !== null ? decodeParagraph(p, state) : undefined
     return [...prev, stencila.creativeWork({ url, content })]
+  }, [])
+}
+
+/**
+ * Decode JATS `<kwd>` elements into a Stencila `Article.keywords` property.
+ */
+function decodeKeywords(front: xml.Element): stencila.Article['keywords'] {
+  const kwds = all(front, 'kwd')
+  if (kwds.length === 0) return undefined
+  return kwds.reduce((prev: string[], curr) => {
+    const kwd = textOrUndefined(curr)
+    return kwd !== undefined ? [...prev, kwd] : prev
   }, [])
 }
 

--- a/src/codecs/plos/__file_snapshots__/pbio-3000349.yaml
+++ b/src/codecs/plos/__file_snapshots__/pbio-3000349.yaml
@@ -114,6 +114,15 @@ description:
         providing metrics aimed at unifying the psychology and the
         neurophysiology of chronic pain applicable across diverse clinical
         conditions.
+editors:
+  - type: Person
+    affiliations:
+      - type: Organization
+        name: 'University of Cambridge, UNITED KINGDOM'
+    familyNames:
+      - Seymour
+    givenNames:
+      - Ben
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/plos/__file_snapshots__/pbio-3000349.yaml
+++ b/src/codecs/plos/__file_snapshots__/pbio-3000349.yaml
@@ -89,6 +89,9 @@ authors:
     givenNames:
       - A.
       - Vania
+datePublished:
+  type: Date
+  value: '2019-08-20'
 description:
   - type: Paragraph
     content:

--- a/src/codecs/plos/__file_snapshots__/pbio-3000349.yaml
+++ b/src/codecs/plos/__file_snapshots__/pbio-3000349.yaml
@@ -111,6 +111,18 @@ description:
         providing metrics aimed at unifying the psychology and the
         neurophysiology of chronic pain applicable across diverse clinical
         conditions.
+isPartOf:
+  type: PublicationVolume
+  isPartOf:
+    type: Periodical
+    issn:
+      - 1544-9173
+      - 1545-7885
+    publisher:
+      type: Organization
+      name: Public Library of Science
+    title: PLOS Biology
+  volumeNumber: '17'
 references:
   - type: Article
     id: pbio.3000349.ref001

--- a/src/codecs/plos/__file_snapshots__/pbio-3000349.yaml
+++ b/src/codecs/plos/__file_snapshots__/pbio-3000349.yaml
@@ -135,6 +135,20 @@ isPartOf:
       name: Public Library of Science
     title: PLOS Biology
   volumeNumber: '17'
+licenses:
+  - type: CreativeWork
+    url: 'http://creativecommons.org/licenses/by/4.0/'
+    content:
+      - type: Paragraph
+        content:
+          - 'This is an open access article distributed under the terms of the '
+          - type: Link
+            target: 'http://creativecommons.org/licenses/by/4.0/'
+            content:
+              - Creative Commons Attribution License
+          - >-
+            , which permits unrestricted use, distribution, and reproduction in
+            any medium, provided the original author and source are credited.
 references:
   - type: Article
     id: pbio.3000349.ref001

--- a/src/codecs/plos/__file_snapshots__/pcbi-1007273.yaml
+++ b/src/codecs/plos/__file_snapshots__/pcbi-1007273.yaml
@@ -87,6 +87,9 @@ authors:
       - Koren
     givenNames:
       - Sergey
+datePublished:
+  type: Date
+  value: '2019-08-21'
 description:
   - type: Paragraph
     content:

--- a/src/codecs/plos/__file_snapshots__/pcbi-1007273.yaml
+++ b/src/codecs/plos/__file_snapshots__/pcbi-1007273.yaml
@@ -128,6 +128,22 @@ isPartOf:
       name: Public Library of Science
     title: PLOS Computational Biology
   volumeNumber: '15'
+licenses:
+  - type: CreativeWork
+    url: 'https://creativecommons.org/publicdomain/zero/1.0/'
+    content:
+      - type: Paragraph
+        content:
+          - >-
+            This is an open access article, free of all copyright, and may be
+            freely reproduced, distributed, transmitted, modified, built upon,
+            or otherwise used by anyone for any lawful purpose. The work is made
+            available under the 
+          - type: Link
+            target: 'https://creativecommons.org/publicdomain/zero/1.0/'
+            content:
+              - Creative Commons CC0
+          - ' public domain dedication.'
 references:
   - type: Article
     id: pcbi.1007273.ref001

--- a/src/codecs/plos/__file_snapshots__/pcbi-1007273.yaml
+++ b/src/codecs/plos/__file_snapshots__/pcbi-1007273.yaml
@@ -107,6 +107,15 @@ description:
         content:
           - 'https://github.com/machinegun/SALSA'
       - .
+editors:
+  - type: Person
+    affiliations:
+      - type: Organization
+        name: 'Ottawa University, CANADA'
+    familyNames:
+      - Ioshikhes
+    givenNames:
+      - Ilya
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/plos/__file_snapshots__/pcbi-1007273.yaml
+++ b/src/codecs/plos/__file_snapshots__/pcbi-1007273.yaml
@@ -104,6 +104,18 @@ description:
         content:
           - 'https://github.com/machinegun/SALSA'
       - .
+isPartOf:
+  type: PublicationVolume
+  isPartOf:
+    type: Periodical
+    issn:
+      - 1553-734X
+      - 1553-7358
+    publisher:
+      type: Organization
+      name: Public Library of Science
+    title: PLOS Computational Biology
+  volumeNumber: '15'
 references:
   - type: Article
     id: pcbi.1007273.ref001

--- a/src/codecs/plos/__file_snapshots__/pgen-1008133.yaml
+++ b/src/codecs/plos/__file_snapshots__/pgen-1008133.yaml
@@ -74,6 +74,9 @@ authors:
       - Dekanty
     givenNames:
       - Andrés
+datePublished:
+  type: Date
+  value: '2019-08-19'
 description:
   - type: Paragraph
     content:

--- a/src/codecs/plos/__file_snapshots__/pgen-1008133.yaml
+++ b/src/codecs/plos/__file_snapshots__/pgen-1008133.yaml
@@ -96,6 +96,15 @@ editors:
       - Perrimon
     givenNames:
       - Norbert
+funders:
+  - type: Organization
+    name: Ministerio de Ciencia e Innovación
+  - type: Organization
+    name: 'Ministry of Science, Innovation and Universities'
+  - type: Organization
+    name: Agencia Nacional de Promoción Científica y Tecnológica
+  - type: Organization
+    name: Universidad Nacional del Litoral
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/plos/__file_snapshots__/pgen-1008133.yaml
+++ b/src/codecs/plos/__file_snapshots__/pgen-1008133.yaml
@@ -108,6 +108,20 @@ isPartOf:
       name: Public Library of Science
     title: PLOS Genetics
   volumeNumber: '15'
+licenses:
+  - type: CreativeWork
+    url: 'http://creativecommons.org/licenses/by/4.0/'
+    content:
+      - type: Paragraph
+        content:
+          - 'This is an open access article distributed under the terms of the '
+          - type: Link
+            target: 'http://creativecommons.org/licenses/by/4.0/'
+            content:
+              - Creative Commons Attribution License
+          - >-
+            , which permits unrestricted use, distribution, and reproduction in
+            any medium, provided the original author and source are credited.
 references:
   - type: Article
     id: pgen.1008133.ref001

--- a/src/codecs/plos/__file_snapshots__/pgen-1008133.yaml
+++ b/src/codecs/plos/__file_snapshots__/pgen-1008133.yaml
@@ -87,6 +87,15 @@ description:
         content:
           - Drosophila
       - ' wing has been a valuable model system to reveal the existence of a stress response mechanism involved in the coordination of growth between adjacent cell populations and to identify a role of the fly orthologue of p53 (Dmp53) in this process. Here we identify the molecular mechanisms used by Dmp53 to regulate growth and proliferation in a non-autonomous manner. First, Dmp53-mediated transcriptional induction of Eiger, the fly orthologue of TNFα ligand, leads to the cell-autonomous activation of JNK. Second, two distinct signaling events downstream of the Eiger/JNK axis are induced in order to independently regulate tissue size and cell number in adjacent cell populations. Whereas expression of the hormone dILP8 acts systemically to reduce growth rates and tissue size of adjacent cell populations, the production of Reactive Oxygen Species—downstream of Eiger/JNK and as a consequence of apoptosis induction—acts in a non-cell-autonomous manner to reduce proliferation rates. Our results unravel how local and systemic signals act concertedly within a tissue to coordinate growth and proliferation, thereby generating well-proportioned organs and functionally integrated adults.'
+editors:
+  - type: Person
+    affiliations:
+      - type: Organization
+        name: 'Harvard Medical School, Howard Hughes Medical Institute, UNITED STATES'
+    familyNames:
+      - Perrimon
+    givenNames:
+      - Norbert
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/plos/__file_snapshots__/pgen-1008133.yaml
+++ b/src/codecs/plos/__file_snapshots__/pgen-1008133.yaml
@@ -84,6 +84,18 @@ description:
         content:
           - Drosophila
       - ' wing has been a valuable model system to reveal the existence of a stress response mechanism involved in the coordination of growth between adjacent cell populations and to identify a role of the fly orthologue of p53 (Dmp53) in this process. Here we identify the molecular mechanisms used by Dmp53 to regulate growth and proliferation in a non-autonomous manner. First, Dmp53-mediated transcriptional induction of Eiger, the fly orthologue of TNFα ligand, leads to the cell-autonomous activation of JNK. Second, two distinct signaling events downstream of the Eiger/JNK axis are induced in order to independently regulate tissue size and cell number in adjacent cell populations. Whereas expression of the hormone dILP8 acts systemically to reduce growth rates and tissue size of adjacent cell populations, the production of Reactive Oxygen Species—downstream of Eiger/JNK and as a consequence of apoptosis induction—acts in a non-cell-autonomous manner to reduce proliferation rates. Our results unravel how local and systemic signals act concertedly within a tissue to coordinate growth and proliferation, thereby generating well-proportioned organs and functionally integrated adults.'
+isPartOf:
+  type: PublicationVolume
+  isPartOf:
+    type: Periodical
+    issn:
+      - 1553-7390
+      - 1553-7404
+    publisher:
+      type: Organization
+      name: Public Library of Science
+    title: PLOS Genetics
+  volumeNumber: '15'
 references:
   - type: Article
     id: pgen.1008133.ref001

--- a/src/codecs/plos/__file_snapshots__/pmed-1002858.yaml
+++ b/src/codecs/plos/__file_snapshots__/pmed-1002858.yaml
@@ -159,6 +159,16 @@ description:
         risk of death in severe falciparum malaria. This is possibly a direct
         causal association. The severe anaemia threshold criteria for a
         definition of severe falciparum malaria should be reconsidered.
+editors:
+  - type: Person
+    affiliations:
+      - type: Organization
+        name: 'Burnet Institute, AUSTRALIA'
+    familyNames:
+      - Beeson
+    givenNames:
+      - James
+      - G.
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/plos/__file_snapshots__/pmed-1002858.yaml
+++ b/src/codecs/plos/__file_snapshots__/pmed-1002858.yaml
@@ -181,6 +181,20 @@ isPartOf:
       name: Public Library of Science
     title: PLOS Medicine
   volumeNumber: '16'
+licenses:
+  - type: CreativeWork
+    url: 'http://creativecommons.org/licenses/by/4.0/'
+    content:
+      - type: Paragraph
+        content:
+          - 'This is an open access article distributed under the terms of the '
+          - type: Link
+            target: 'http://creativecommons.org/licenses/by/4.0/'
+            content:
+              - Creative Commons Attribution License
+          - >-
+            , which permits unrestricted use, distribution, and reproduction in
+            any medium, provided the original author and source are credited.
 references:
   - type: Article
     id: pmed.1002858.ref001

--- a/src/codecs/plos/__file_snapshots__/pmed-1002858.yaml
+++ b/src/codecs/plos/__file_snapshots__/pmed-1002858.yaml
@@ -120,6 +120,9 @@ authors:
     givenNames:
       - Nicholas
       - J.
+datePublished:
+  type: Date
+  value: '2019-08-23'
 description:
   - type: Paragraph
     content:

--- a/src/codecs/plos/__file_snapshots__/pmed-1002858.yaml
+++ b/src/codecs/plos/__file_snapshots__/pmed-1002858.yaml
@@ -156,6 +156,18 @@ description:
         risk of death in severe falciparum malaria. This is possibly a direct
         causal association. The severe anaemia threshold criteria for a
         definition of severe falciparum malaria should be reconsidered.
+isPartOf:
+  type: PublicationVolume
+  isPartOf:
+    type: Periodical
+    issn:
+      - 1549-1277
+      - 1549-1676
+    publisher:
+      type: Organization
+      name: Public Library of Science
+    title: PLOS Medicine
+  volumeNumber: '16'
 references:
   - type: Article
     id: pmed.1002858.ref001

--- a/src/codecs/plos/__file_snapshots__/pntd-0007469.yaml
+++ b/src/codecs/plos/__file_snapshots__/pntd-0007469.yaml
@@ -84,6 +84,20 @@ isPartOf:
       name: Public Library of Science
     title: PLOS Neglected Tropical Diseases
   volumeNumber: '13'
+licenses:
+  - type: CreativeWork
+    url: 'http://creativecommons.org/licenses/by/4.0/'
+    content:
+      - type: Paragraph
+        content:
+          - 'This is an open access article distributed under the terms of the '
+          - type: Link
+            target: 'http://creativecommons.org/licenses/by/4.0/'
+            content:
+              - Creative Commons Attribution License
+          - >-
+            , which permits unrestricted use, distribution, and reproduction in
+            any medium, provided the original author and source are credited.
 references:
   - type: Article
     id: pntd.0007469.ref001

--- a/src/codecs/plos/__file_snapshots__/pntd-0007469.yaml
+++ b/src/codecs/plos/__file_snapshots__/pntd-0007469.yaml
@@ -45,6 +45,9 @@ authors:
     givenNames:
       - Pierre
       - Edouard
+datePublished:
+  type: Date
+  value: '2019-08-29'
 description:
   - type: Paragraph
     content:

--- a/src/codecs/plos/__file_snapshots__/pntd-0007469.yaml
+++ b/src/codecs/plos/__file_snapshots__/pntd-0007469.yaml
@@ -60,6 +60,17 @@ description:
         content:
           - Rickettsia-
       - related microorganisms.
+isPartOf:
+  type: PublicationVolume
+  isPartOf:
+    type: Periodical
+    issn:
+      - 1935-2735
+    publisher:
+      type: Organization
+      name: Public Library of Science
+    title: PLOS Neglected Tropical Diseases
+  volumeNumber: '13'
 references:
   - type: Article
     id: pntd.0007469.ref001

--- a/src/codecs/plos/__file_snapshots__/pntd-0007469.yaml
+++ b/src/codecs/plos/__file_snapshots__/pntd-0007469.yaml
@@ -63,6 +63,16 @@ description:
         content:
           - Rickettsia-
       - related microorganisms.
+editors:
+  - type: Person
+    affiliations:
+      - type: Organization
+        name: 'Faculty of Science, Ain Shams University (ASU), EGYPT'
+    familyNames:
+      - Samy
+    givenNames:
+      - Abdallah
+      - M.
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/plos/__file_snapshots__/pone-0216012.yaml
+++ b/src/codecs/plos/__file_snapshots__/pone-0216012.yaml
@@ -72,6 +72,9 @@ authors:
       - Guidoboni
     givenNames:
       - Giovanna
+datePublished:
+  type: Date
+  value: '2019-08-14'
 description:
   - type: Paragraph
     content:

--- a/src/codecs/plos/__file_snapshots__/pone-0216012.yaml
+++ b/src/codecs/plos/__file_snapshots__/pone-0216012.yaml
@@ -110,6 +110,15 @@ editors:
     givenNames:
       - Sakamuri
       - V.
+funders:
+  - type: Organization
+    name: National Science Foundation (USA)
+  - type: Organization
+    name: Cercle Gutenberg (France)
+  - type: Organization
+    name: 'University of Strasbourg, France'
+  - type: Organization
+    name: Université de Strasbourg (FR)
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/plos/__file_snapshots__/pone-0216012.yaml
+++ b/src/codecs/plos/__file_snapshots__/pone-0216012.yaml
@@ -98,6 +98,18 @@ description:
         content:
           - (iii)
       - ' their interactions. The model is used to simulate variations in intraocular pressure, intracranial pressure and blood flow due to microgravity conditions, which are thought to be critical factors in SANS. Specifically, the model predicts that both intracranial and intraocular pressures increase in microgravity, even though their respective trends may be different. In such conditions, ocular blood flow is predicted to decrease in the choroid and ciliary body circulations, whereas retinal circulation is found to be less susceptible to microgravity-induced alterations, owing to a purely mechanical component in perfusion control associated with the venous segments. These findings indicate that the particular anatomical architecture of venous drainage in the retina may be one of the reasons why most of the SANS alterations are not observed in the retina but, rather, in other vascular beds, particularly the choroid. Thus, clinical assessment of ocular venous function may be considered as a determinant SANS factor, for which astronauts could be screened on earth and in-flight.'
+editors:
+  - type: Person
+    affiliations:
+      - type: Organization
+        name: >-
+          Charles P. Darby Children’s Research Institute, Charleston, SC, UNITED
+          STATES
+    familyNames:
+      - Reddy
+    givenNames:
+      - Sakamuri
+      - V.
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/plos/__file_snapshots__/pone-0216012.yaml
+++ b/src/codecs/plos/__file_snapshots__/pone-0216012.yaml
@@ -95,6 +95,17 @@ description:
         content:
           - (iii)
       - ' their interactions. The model is used to simulate variations in intraocular pressure, intracranial pressure and blood flow due to microgravity conditions, which are thought to be critical factors in SANS. Specifically, the model predicts that both intracranial and intraocular pressures increase in microgravity, even though their respective trends may be different. In such conditions, ocular blood flow is predicted to decrease in the choroid and ciliary body circulations, whereas retinal circulation is found to be less susceptible to microgravity-induced alterations, owing to a purely mechanical component in perfusion control associated with the venous segments. These findings indicate that the particular anatomical architecture of venous drainage in the retina may be one of the reasons why most of the SANS alterations are not observed in the retina but, rather, in other vascular beds, particularly the choroid. Thus, clinical assessment of ocular venous function may be considered as a determinant SANS factor, for which astronauts could be screened on earth and in-flight.'
+isPartOf:
+  type: PublicationVolume
+  isPartOf:
+    type: Periodical
+    issn:
+      - 1932-6203
+    publisher:
+      type: Organization
+      name: Public Library of Science
+    title: PLOS ONE
+  volumeNumber: '14'
 references:
   - type: Article
     id: pone.0216012.ref001

--- a/src/codecs/plos/__file_snapshots__/pone-0216012.yaml
+++ b/src/codecs/plos/__file_snapshots__/pone-0216012.yaml
@@ -121,6 +121,20 @@ isPartOf:
       name: Public Library of Science
     title: PLOS ONE
   volumeNumber: '14'
+licenses:
+  - type: CreativeWork
+    url: 'http://creativecommons.org/licenses/by/4.0/'
+    content:
+      - type: Paragraph
+        content:
+          - 'This is an open access article distributed under the terms of the '
+          - type: Link
+            target: 'http://creativecommons.org/licenses/by/4.0/'
+            content:
+              - Creative Commons Attribution License
+          - >-
+            , which permits unrestricted use, distribution, and reproduction in
+            any medium, provided the original author and source are credited.
 references:
   - type: Article
     id: pone.0216012.ref001

--- a/src/codecs/plos/__file_snapshots__/ppat-1007958.yaml
+++ b/src/codecs/plos/__file_snapshots__/ppat-1007958.yaml
@@ -203,6 +203,20 @@ isPartOf:
       name: Public Library of Science
     title: PLOS Pathogens
   volumeNumber: '15'
+licenses:
+  - type: CreativeWork
+    url: 'http://creativecommons.org/licenses/by/4.0/'
+    content:
+      - type: Paragraph
+        content:
+          - 'This is an open access article distributed under the terms of the '
+          - type: Link
+            target: 'http://creativecommons.org/licenses/by/4.0/'
+            content:
+              - Creative Commons Attribution License
+          - >-
+            , which permits unrestricted use, distribution, and reproduction in
+            any medium, provided the original author and source are credited.
 references:
   - type: Article
     id: ppat.1007958.ref001

--- a/src/codecs/plos/__file_snapshots__/ppat-1007958.yaml
+++ b/src/codecs/plos/__file_snapshots__/ppat-1007958.yaml
@@ -182,6 +182,15 @@ description:
         episomal 2-LTR circles were observed suggesting that the integration of
         HIV-1 genome was restricted. This is the second genetic defect described
         after CCR5Δ32 that shows strong resistance against HIV-1 infection.
+editors:
+  - type: Person
+    affiliations:
+      - type: Organization
+        name: 'Fred Hutchinson Cancer Research Center, UNITED STATES'
+    familyNames:
+      - Emerman
+    givenNames:
+      - Michael
 isPartOf:
   type: PublicationVolume
   isPartOf:

--- a/src/codecs/plos/__file_snapshots__/ppat-1007958.yaml
+++ b/src/codecs/plos/__file_snapshots__/ppat-1007958.yaml
@@ -179,6 +179,18 @@ description:
         episomal 2-LTR circles were observed suggesting that the integration of
         HIV-1 genome was restricted. This is the second genetic defect described
         after CCR5Δ32 that shows strong resistance against HIV-1 infection.
+isPartOf:
+  type: PublicationVolume
+  isPartOf:
+    type: Periodical
+    issn:
+      - 1553-7366
+      - 1553-7374
+    publisher:
+      type: Organization
+      name: Public Library of Science
+    title: PLOS Pathogens
+  volumeNumber: '15'
 references:
   - type: Article
     id: ppat.1007958.ref001

--- a/src/codecs/plos/__file_snapshots__/ppat-1007958.yaml
+++ b/src/codecs/plos/__file_snapshots__/ppat-1007958.yaml
@@ -156,6 +156,9 @@ authors:
       - Alcamí
     givenNames:
       - José
+datePublished:
+  type: Date
+  value: '2019-08-29'
 description:
   - type: Paragraph
     content:


### PR DESCRIPTION
Addresses most of #395. The remaining unaddressed items are, IMO, lower priority and this would be useful merged as is.

See the test snapshot diffs to gauge the additional article meta-data being 'decoded' to in-memory data e.g https://github.com/stencila/encoda/pull/396/files#diff-f1d2c7910e700f5b4ed2c16abfcc03fc

See note regarding potential improvements to capturing funding information when the `Grant` type is added to the schema:
https://github.com/stencila/encoda/blob/684d234110b15a78738fa73a5d3330dfb2bf0c9a/src/codecs/jats/index.ts#L474-L479