### PR TITLE
feat(Theme): Add ability to pass URLs as theme argument

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,7 @@ import * as puppeteer from './util/puppeteer'
 import { coerce } from './util/coerce'
 import { validate } from './util/validate'
 import { getTheme, themes } from '@stencila/thema'
+import { isTheme } from './util/html'
 
 const { _, ...options } = minimist(process.argv.slice(2), {
   boolean: ['standalone', 'bundle', 'debug'],
@@ -66,7 +67,9 @@ configure(options.debug)
   try {
     if (command === 'convert') {
       const { to, from, standalone, bundle, zip, ...rest } = options
-      const theme = getTheme(options.theme)
+      const theme = isTheme(options.theme)
+        ? getTheme(options.theme)
+        : options.theme
 
       await convert(args[0], args.slice(1), {
         to,

--- a/src/codecs/types.ts
+++ b/src/codecs/types.ts
@@ -1,5 +1,5 @@
 import * as stencila from '@stencila/schema'
-import { getTheme, ThemeNames } from '@stencila/thema'
+import { getTheme } from '@stencila/thema'
 import * as vfile from '../util/vfile'
 
 export interface GlobalEncodeOptions<CodecOptions extends object = {}> {
@@ -8,7 +8,7 @@ export interface GlobalEncodeOptions<CodecOptions extends object = {}> {
   isStandalone?: boolean
   isBundle?: boolean
   shouldZip?: 'yes' | 'no' | 'maybe'
-  theme: ThemeNames
+  theme: string
 
   codecOptions?: CodecOptions
 }

--- a/src/util/html.test.ts
+++ b/src/util/html.test.ts
@@ -1,0 +1,86 @@
+import { themePath, themes } from '@stencila/thema'
+import { getThemeAssets, isTheme } from './html'
+
+const themaThemes = Object.entries(themes)
+const themeUrl = 'http://unpkg.com/@stencila/thema@1.5.3/dist/themes/stencila'
+
+describe('Check if `theme` is a Thema theme', () => {
+  test.each(themaThemes)('Thema themes - %s', (themeKey, themeValue) => {
+    expect(isTheme(themeKey)).toBe(true)
+    expect(isTheme(themeValue)).toBe(true)
+  })
+
+  test('File paths', () => {
+    expect(isTheme('/my/path/to/directory')).toBe(false)
+  })
+
+  test('URLs', () => {
+    expect(isTheme(themeUrl)).toBe(false)
+  })
+})
+
+describe('Resolve theme arguments', () => {
+  test.each(themaThemes)('Thema themes - %s', async (themeKey, themeValue) => {
+    const theme = await getThemeAssets(themeKey)
+
+    expect(theme.scripts[0]).toMatch(`${themePath}/${themeValue}/index.js`)
+    expect(theme.styles[0]).toMatch(`${themePath}/${themeValue}/styles.css`)
+  })
+
+  test('Full URL', async () => {
+    const theme = await getThemeAssets(themeUrl)
+
+    expect(theme.scripts[0]).toMatch(`${themeUrl}/index.js`)
+    expect(theme.styles[0]).toMatch(`${themeUrl}/styles.css`)
+  })
+
+  test('Full URL - top level domain', async () => {
+    const themeUrl = 'http://example.com'
+    const theme = await getThemeAssets(themeUrl)
+
+    expect(theme.scripts[0]).toMatch(`${themeUrl}/index.js`)
+    expect(theme.styles[0]).toMatch(`${themeUrl}/styles.css`)
+  })
+
+  test('Full URL - ending with a filename', async () => {
+    const theme = await getThemeAssets(themeUrl + '/styles.css')
+
+    expect(theme.scripts[0]).toMatch(`${themeUrl}/index.js`)
+    expect(theme.styles[0]).toMatch(`${themeUrl}/styles.css`)
+  })
+
+  test('Full URL - ending with a trailing slash', async () => {
+    const theme = await getThemeAssets(themeUrl + '/')
+
+    expect(theme.scripts[0]).toMatch(`${themeUrl}/index.js`)
+    expect(theme.styles[0]).toMatch(`${themeUrl}/styles.css`)
+  })
+
+  test('Fetching UNPKG asset by Thema name', async () => {
+    const theme = await getThemeAssets(themes.elife)
+
+    expect(theme.scripts[0]).toMatch(
+      `https://unpkg.com/@stencila/thema@1/dist/themes/${themes.elife}/index.js`
+    )
+    expect(theme.styles[0]).toMatch(
+      `https://unpkg.com/@stencila/thema@1/dist/themes/${themes.elife}/styles.css`
+    )
+  })
+
+  test.each(themaThemes)(
+    'Bundle theme contents by Thema name - %s',
+    async themeKey => {
+      const theme = await getThemeAssets(themeKey, true)
+
+      expect(theme.scripts[0]).toMatch('parcelRequire=')
+      expect(theme.styles[0]).toMatch(/\[itemprop=.*\]{/)
+    }
+  )
+
+  test('Bundle theme contents from URL', async () => {
+    const theme = await getThemeAssets(themeUrl, true)
+
+    expect(theme.scripts[0]).toMatch('parcelRequire=')
+    expect(theme.styles[0]).toMatch(/\[itemprop=.*\]{/)
+  })
+})

--- a/src/util/html.ts
+++ b/src/util/html.ts
@@ -8,7 +8,12 @@
  * @module util/html
  */
 
+import { getTheme, themePath, themes } from '@stencila/thema'
+import fs from 'fs'
 import jsdom from 'jsdom'
+import path from 'path'
+import { toFile } from './uri'
+import { isPath } from './vfile'
 
 const JSDOM = new jsdom.JSDOM()
 
@@ -84,4 +89,134 @@ export const allName = (elem: HTMLElement | null, name: string): Node[] => {
         : [])
     ]
   }, [])
+}
+
+interface Theme {
+  styles: string[]
+  scripts: string[]
+}
+
+/**
+ * Tests whether a given string is a valid Thema theme or not.
+ */
+export const isTheme = (theme: string): boolean =>
+  !isPath(theme) && Object.keys(themes).includes(theme.toLowerCase().trim())
+
+export const resolveTheme = (theme: string): Theme => {
+  const styles = 'styles.css'
+  const js = 'index.js'
+
+  /**
+   * If the given `theme` string does not end with a file extensions,
+   * use the last part of the path as the directory name
+   */
+  const themeDir = (dir: string): string =>
+    path.extname(dir) === '' ? path.basename(dir) : ''
+
+  const getThemePath = (dir: string, file: string): string =>
+    path.join(path.dirname(dir), themeDir(dir), file)
+
+  // If theme is a URL, use it as a directory to look for theme assets based on naming conventions
+  if (theme.includes('://')) {
+    // Process the theme URL to clean trailing slashes or file names
+    const cleanUrl = theme.endsWith('/')
+      ? theme.slice(0, theme.length - 1)
+      : theme
+    const parts = cleanUrl.split('/')
+    const endsInFile = new RegExp('\\.\\w+$').test(parts[parts.length - 1])
+    // Account for receiving top level URL such as 'http://example.com', and not consider '.com' as a file extension
+    const urlParts =
+      parts.length > 3 && endsInFile ? parts.slice(0, parts.length - 1) : parts
+    const url = urlParts.join('/')
+
+    return {
+      styles: [`${url}/${styles}`],
+      scripts: [`${url}/${js}`]
+    }
+  }
+
+  // Otherwise check if theme is a filepath
+  if (isPath(theme)) {
+    return {
+      styles: [getThemePath(theme, styles)],
+      scripts: [getThemePath(theme, js)]
+    }
+  }
+
+  // Finally, fall back to looking for theme in Thema package
+  return {
+    styles: [getThemePath(themePath, `${getTheme(theme)}/${styles}`)],
+    scripts: [getThemePath(themePath, `${getTheme(theme)}/${js}`)]
+  }
+}
+
+const themaVersion = require(path.join(
+  require.resolve('@stencila/thema'),
+  '..',
+  '..',
+  'package.json'
+)).version
+
+const themaMajor = themaVersion.split('.')[0]
+
+/**
+ * Return a CDN link to an asset, cleaning up any Windows specific path separators.
+ */
+export const generateCDNUrl = (asset: string): string => {
+  return `https://unpkg.com/@stencila/thema@${themaMajor}/${asset}`.replace(
+    /\\/g,
+    '/'
+  )
+}
+
+/**
+ * Fetches theme file contents either from a local filepath or a URL, returning the contents as a string
+ */
+export const getThemeAssets = async (
+  theme: string,
+  isBundle = false
+): Promise<Theme> => {
+  const resolvedTheme = resolveTheme(theme)
+
+  // If we are bundling the theme, return the contents of the file, otherwise a link the to CDN hosted Thema file
+  const contentsFromThema = (asset: string): string => {
+    return !isBundle
+      ? generateCDNUrl(asset)
+      : fs
+          .readFileSync(
+            path.join(require.resolve('@stencila/thema'), '..', '..', asset)
+          )
+          .toString()
+  }
+
+  // Update Thema assets with either file contents, or as a link to CDN hosted version
+  if (isTheme(theme)) {
+    return Object.entries(resolvedTheme).reduce(
+      (_theme: Theme, [key, assets]) => ({
+        ..._theme,
+        [key]: assets.map(contentsFromThema)
+      }),
+      { styles: [], scripts: [] }
+    )
+  }
+
+  const fetchAssets = async (assets: string[]): Promise<string[]> =>
+    Promise.all(
+      assets.map(asset =>
+        toFile(asset).then(file => fs.readFileSync(file.filePath).toString())
+      )
+    )
+
+  // Fetch file contents for inlining when bundling assets
+  if (isBundle) {
+    const styles = await fetchAssets(resolvedTheme.styles)
+    const scripts = await fetchAssets(resolvedTheme.scripts)
+
+    return {
+      styles,
+      scripts
+    }
+  }
+
+  return resolvedTheme
 }


### PR DESCRIPTION
Closes #397

I tried to keep changes as concise and isolated to the `util/html.ts` file as possible in order to avoid merge conflicts.
This change starts representing `themeAssets` as a list of `styles` and `scripts` under the hood, leaving room for passing multiple values for styes and scripts as [outlined in this comment](https://github.com/stencila/encoda/issues/397#issuecomment-579017540) if we ever allow doing so.

Once the large refactoring PRs are in, some cleanup should be done in a followup PR to make the `theme` argument optional.