### PR TITLE
Refactor decode and encode options

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -5,7 +5,7 @@ import tempy from 'tempy'
 import { codecList, convert, dump, handled, load, match, read, write } from '..'
 import { JsonCodec } from '../codecs/json'
 import { TxtCodec } from '../codecs/txt'
-import { defaultEncodeOptions } from '../codecs/types'
+import { commonEncodeDefaults } from '../codecs/types'
 import { YamlCodec } from '../codecs/yaml'
 import * as ssf from '../codecs/__mocks__/ssf'
 import { fixture } from './helpers'
@@ -114,7 +114,7 @@ describe('write', () => {
 
   it('works with stdout', async () => {
     const consoleLog = jest.spyOn(console, 'log')
-    await write(simpleThing, '-', { ...defaultEncodeOptions, format: 'json' })
+    await write(simpleThing, '-', { ...commonEncodeDefaults, format: 'json' })
     expect(consoleLog).toHaveBeenCalledWith(simpleThingJson)
   })
 })

--- a/src/__tests__/matchers.ts
+++ b/src/__tests__/matchers.ts
@@ -7,7 +7,6 @@ import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils'
 import mime from 'mime'
 import path from 'path'
 import { Codec } from '../codecs/types'
-import { getTheme } from '@stencila/thema'
 
 /**
  * A Jest matcher for testing that a codec is able
@@ -31,8 +30,7 @@ async function toInvert(codec: Codec, node: stencila.Node, fileName?: string) {
   const outPath = path.join(__dirname, '__outputs__', fileName)
   await fs.ensureDir(path.dirname(outPath))
   const file = await codec.encode(node, {
-    filePath: outPath,
-    theme: getTheme()
+    filePath: outPath
   })
   const nodeDecoded = await codec.decode(file)
   try {

--- a/src/codecs/__mocks__/ssf.ts
+++ b/src/codecs/__mocks__/ssf.ts
@@ -4,14 +4,14 @@
 
 import { Node } from '@stencila/schema'
 import { create, VFile } from '../../util/vfile'
-import { Codec, defaultEncodeOptions } from '../types'
+import { Codec, commonEncodeDefaults } from '../types'
 
 export const fileNames = ['super-special-file']
 export const extNames = ['ssf']
 export const mediaTypes = ['application/vnd.super-corp.super-special-file']
 export const sniff = async (content: string) => /^SSF:/.test(content)
 export const decode = async (file: VFile) => null
-export const encode = async (node: Node, options: {} = defaultEncodeOptions) =>
+export const encode = async (node: Node, options: {} = commonEncodeDefaults) =>
   create()
 
 export class SsfCodec extends Codec implements Codec {

--- a/src/codecs/bib/index.ts
+++ b/src/codecs/bib/index.ts
@@ -21,6 +21,6 @@ export class BibCodec extends Codec implements Codec {
   public readonly encode = async (
     node: stencila.Node
   ): Promise<vfile.VFile> => {
-    return csl.encode(node, { ...this.defaultEncodeOptions, format: 'bibtex' })
+    return csl.encode(node, { format: 'bibtex' })
   }
 }

--- a/src/codecs/csl/index.ts
+++ b/src/codecs/csl/index.ts
@@ -12,7 +12,7 @@ import { load } from '../..'
 import { logErrorNodeType, logWarnLoss, logWarnLossIfAny } from '../../log'
 import { stringifyContent } from '../../util/content/stringifyContent'
 import * as vfile from '../../util/vfile'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, CommonEncodeOptions } from '../types'
 
 /**
  * The directory where styles are stored
@@ -61,7 +61,7 @@ export class CSLCodec extends Codec<{}, DecodeOptions>
    */
   public readonly encode = (
     node: stencila.Node,
-    options: GlobalEncodeOptions = this.defaultEncodeOptions
+    options: CommonEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const { format = 'json' } = options
 

--- a/src/codecs/dar/dar.test.ts
+++ b/src/codecs/dar/dar.test.ts
@@ -4,7 +4,6 @@ import path from 'path'
 import { DarCodec } from '.'
 import flat from '../../__fixtures__/collection/flat'
 import mixed from '../../__fixtures__/collection/mixed'
-import { defaultEncodeOptions } from '../types'
 
 const { decode, encode, sniff } = new DarCodec()
 
@@ -46,7 +45,7 @@ describe('encode', () => {
   it('works on flat collection', async () => {
     const dir = await outdir('flat.dar')
 
-    await encode(flat, { ...defaultEncodeOptions, filePath: dir })
+    await encode(flat, { filePath: dir })
 
     expect(await files(dir)).toEqual([
       'manifest.xml',
@@ -60,7 +59,7 @@ describe('encode', () => {
   it('works on mixed collection', async () => {
     const dir = await outdir('mixed.dar')
 
-    await encode(mixed, { ...defaultEncodeOptions, filePath: dir })
+    await encode(mixed, { filePath: dir })
 
     expect(await files(dir)).toEqual([
       'manifest.xml',
@@ -89,7 +88,7 @@ describe('encode', () => {
           }
         ]
       },
-      { ...defaultEncodeOptions, filePath: dir }
+      { filePath: dir }
     )
 
     expect(await manifest(dir)).toMatchSnapshot()

--- a/src/codecs/dar/index.ts
+++ b/src/codecs/dar/index.ts
@@ -55,7 +55,7 @@ export class DarCodec extends Codec implements Codec {
    */
   public encode = async (
     node: stencila.Node,
-    options: CommonEncodeOptions = this.defaultEncodeOptions
+    options: CommonEncodeOptions = this.commonEncodeDefaults
   ): Promise<vfile.VFile> => {
     const { filePath } = options
 

--- a/src/codecs/dar/index.ts
+++ b/src/codecs/dar/index.ts
@@ -13,7 +13,7 @@ import tempy from 'tempy'
 import { write } from '../..'
 import * as uri from '../../util/uri'
 import * as vfile from '../../util/vfile'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, CommonEncodeOptions } from '../types'
 
 export class DarCodec extends Codec implements Codec {
   public readonly extNames = ['dar']
@@ -55,7 +55,7 @@ export class DarCodec extends Codec implements Codec {
    */
   public encode = async (
     node: stencila.Node,
-    options: GlobalEncodeOptions = this.defaultEncodeOptions
+    options: CommonEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const { filePath } = options
 
@@ -129,7 +129,7 @@ async function encodeDocument(
   node: stencila.Node,
   id: string,
   darPath: string,
-  options: GlobalEncodeOptions
+  options: CommonEncodeOptions
 ): Promise<Element> {
   const documentFile = `${id}.jats.xml`
   const documentPath = path.join(darPath, documentFile)

--- a/src/codecs/dar/index.ts
+++ b/src/codecs/dar/index.ts
@@ -55,7 +55,7 @@ export class DarCodec extends Codec implements Codec {
    */
   public encode = async (
     node: stencila.Node,
-    options = this.defaultEncodeOptions
+    options: GlobalEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const { filePath } = options
 

--- a/src/codecs/dir/dir.test.ts
+++ b/src/codecs/dir/dir.test.ts
@@ -4,7 +4,7 @@ import globby from 'globby'
 import path from 'path'
 import { DirCodec } from '.'
 import * as vfile from '../../util/vfile'
-import { defaultEncodeOptions, GlobalEncodeOptions } from '../types'
+import { defaultEncodeOptions, CommonEncodeOptions } from '../types'
 
 const { decode, encode, sniff } = new DirCodec()
 
@@ -84,7 +84,7 @@ describe('decode', () => {
 })
 
 describe('encode', () => {
-  const e = (n: stencila.Node, options: Omit<GlobalEncodeOptions, 'theme'>) =>
+  const e = (n: stencila.Node, options: Omit<CommonEncodeOptions, 'theme'>) =>
     encode(n, { ...defaultEncodeOptions, ...options })
 
   it('creates a directory', async () => {

--- a/src/codecs/dir/dir.test.ts
+++ b/src/codecs/dir/dir.test.ts
@@ -4,7 +4,7 @@ import globby from 'globby'
 import path from 'path'
 import { DirCodec } from '.'
 import * as vfile from '../../util/vfile'
-import { defaultEncodeOptions, CommonEncodeOptions } from '../types'
+import { commonEncodeDefaults, CommonEncodeOptions } from '../types'
 
 const { decode, encode, sniff } = new DirCodec()
 
@@ -85,7 +85,7 @@ describe('decode', () => {
 
 describe('encode', () => {
   const e = (n: stencila.Node, options: Omit<CommonEncodeOptions, 'theme'>) =>
-    encode(n, { ...defaultEncodeOptions, ...options })
+    encode(n, { ...commonEncodeDefaults, ...options })
 
   it('creates a directory', async () => {
     const dir = path.join(__dirname, '__outputs__', 'flat')

--- a/src/codecs/dir/index.ts
+++ b/src/codecs/dir/index.ts
@@ -24,11 +24,11 @@ import trash from 'trash'
 import unixify from 'unixify'
 import { read, write } from '../..'
 import * as vfile from '../../util/vfile'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, CommonEncodeOptions } from '../types'
 
 const log = getLogger('encoda:dir')
 
-interface EncodeOptions extends GlobalEncodeOptions {
+interface EncodeOptions extends CommonEncodeOptions {
   /**
    * The format to decode parts of the `Collection` as.
    * Defaults to `html`.

--- a/src/codecs/dir/index.ts
+++ b/src/codecs/dir/index.ts
@@ -24,19 +24,20 @@ import trash from 'trash'
 import unixify from 'unixify'
 import { read, write } from '../..'
 import * as vfile from '../../util/vfile'
-import { Codec, CommonEncodeOptions } from '../types'
+import { Codec, CommonEncodeOptions, CommonDecodeOptions } from '../types'
 
 const log = getLogger('encoda:dir')
 
 interface EncodeOptions extends CommonEncodeOptions {
   /**
    * The format to decode parts of the `Collection` as.
-   * Defaults to `html`.
+   * Defaults to `html`. Different from the common option
+   * `format`, which in this case is `dir`.
    */
-  format?: string
+  fileFormat?: string
 }
 
-interface DecodeOptions {
+interface DecodeOptions extends CommonDecodeOptions {
   /**
    * Minimatch patterns to use to select only some of the included
    * files. Defaults to '**\/\*' (i.e. everything, including in
@@ -196,11 +197,11 @@ export class DirCodec extends Codec<EncodeOptions, DecodeOptions>
 
   public readonly encode = async (
     node: stencila.Node,
-    options: EncodeOptions = this.defaultEncodeOptions
+    options: EncodeOptions = this.commonEncodeDefaults
     // eslint-disable-next-line @typescript-eslint/require-await
   ): Promise<vfile.VFile> => {
     const dirPath = options.filePath ?? tempy.directory()
-    const format = options.format ?? 'html'
+    const format = options.fileFormat ?? 'html'
 
     // Wrap to a collection as necessary
     const cw: stencila.CreativeWork = isCreativeWork(node)

--- a/src/codecs/dmagic/demo-magic.test.ts
+++ b/src/codecs/dmagic/demo-magic.test.ts
@@ -1,6 +1,6 @@
 import stencila from '@stencila/schema'
 import { dump } from '../../util/vfile'
-import { defaultEncodeOptions } from '../types'
+import { commonEncodeDefaults } from '../types'
 import { DMagicCodec } from './'
 
 const { decode, encode } = new DMagicCodec()
@@ -13,7 +13,7 @@ test('decode', async () => {
 
 test('encode', async () => {
   expect(
-    await dump(await encode(node, { ...defaultEncodeOptions, isBundle: false }))
+    await dump(await encode(node, { ...commonEncodeDefaults, isBundle: false }))
   ).toEqual(bash)
   expect(await encode(node)).toBeTruthy()
 })

--- a/src/codecs/dmagic/index.ts
+++ b/src/codecs/dmagic/index.ts
@@ -49,7 +49,7 @@ export class DMagicCodec extends Codec implements Codec {
    */
   public readonly encode = async (
     node: stencila.Node,
-    options: CommonEncodeOptions = this.defaultEncodeOptions
+    options: CommonEncodeOptions = this.commonEncodeDefaults
   ): Promise<vfile.VFile> => {
     const { isBundle = true } = options
     let bash = await encodeNode(node)

--- a/src/codecs/dmagic/index.ts
+++ b/src/codecs/dmagic/index.ts
@@ -17,7 +17,7 @@ import fs from 'fs-extra'
 import path from 'path'
 import { dump } from '../..'
 import * as vfile from '../../util/vfile'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, CommonEncodeOptions } from '../types'
 
 export class DMagicCodec extends Codec implements Codec {
   /**
@@ -49,7 +49,7 @@ export class DMagicCodec extends Codec implements Codec {
    */
   public readonly encode = async (
     node: stencila.Node,
-    options: GlobalEncodeOptions = this.defaultEncodeOptions
+    options: CommonEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const { isBundle = true } = options
     let bash = await encodeNode(node)

--- a/src/codecs/docx/index.ts
+++ b/src/codecs/docx/index.ts
@@ -10,7 +10,7 @@ import * as vfile from '../../util/vfile'
 import { stylesDir } from '../csl'
 import * as Pandoc from '../pandoc'
 import { dataDir } from '../pandoc/binary'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, CommonEncodeOptions } from '../types'
 
 const pandoc = new Pandoc.PandocCodec()
 
@@ -48,7 +48,7 @@ export class DocxCodec extends Codec<EncodeOptions>
    */
   public readonly encode = async (
     node: stencila.Node,
-    { filePath, codecOptions = {} }: GlobalEncodeOptions<EncodeOptions> = this
+    { filePath, codecOptions = {} }: CommonEncodeOptions<EncodeOptions> = this
       .defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const article = ensureArticle(node)

--- a/src/codecs/docx/index.ts
+++ b/src/codecs/docx/index.ts
@@ -3,43 +3,31 @@
  */
 
 import stencila from '@stencila/schema'
-import { getTheme } from '@stencila/thema'
 import path from 'path'
 import { ensureArticle } from '../../util/content/ensureArticle'
 import * as vfile from '../../util/vfile'
 import { stylesDir } from '../csl'
-import * as Pandoc from '../pandoc'
+import { InputFormat, OutputFormat, PandocCodec } from '../pandoc'
 import { dataDir } from '../pandoc/binary'
-import { Codec, CommonEncodeOptions } from '../types'
+import { Codec, CommonDecodeOptions, CommonEncodeOptions } from '../types'
 
-const pandoc = new Pandoc.PandocCodec()
+const pandoc = new PandocCodec()
 
-interface EncodeOptions {
-  templatePath?: string
-}
-
-export class DocxCodec extends Codec<EncodeOptions>
-  implements Codec<EncodeOptions> {
+export class DocxCodec extends Codec implements Codec {
   public readonly mediaTypes = [
     'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
   ]
 
   public readonly decode = async (
-    file: vfile.VFile
+    file: vfile.VFile,
+    options: CommonDecodeOptions = this.commonDecodeDefaults
   ): Promise<stencila.Node> => {
-    return pandoc.decode(file, {
-      ensureFile: true,
-      flags: [`--extract-media=${file.path}.media`],
-      from: Pandoc.InputFormat.docx
+    return pandoc.decode(file, options, {
+      pandocFormat: InputFormat.docx,
+      pandocArgs: [`--extract-media=${file.path}.media`],
+      ensureFile: true
     })
   }
-
-  /** Used to style conversion outputs targeting Microsoft Word */
-  private static defaultTemplatePath = path.join(
-    dataDir,
-    'templates',
-    'stencila-template.docx'
-  )
 
   /**
    * Encode a Stencila `Node` to a Microsoft Word `docx` format.
@@ -48,35 +36,27 @@ export class DocxCodec extends Codec<EncodeOptions>
    */
   public readonly encode = async (
     node: stencila.Node,
-    { filePath, codecOptions = {} }: CommonEncodeOptions<EncodeOptions> = this
-      .defaultEncodeOptions
+    options: CommonEncodeOptions = this.commonEncodeDefaults
   ): Promise<vfile.VFile> => {
     const article = ensureArticle(node)
-    const { references } = article
 
-    const referenceDoc =
-      codecOptions.templatePath ?? DocxCodec.defaultTemplatePath
-
-    let flags: string[] = [`--reference-doc=${referenceDoc}`]
-
-    if (references !== undefined) {
+    const refDoc = path.join(dataDir, 'templates', 'stencila-template.docx')
+    const pandocArgs = [`--reference-doc=${refDoc}`]
+    const useCiteproc = article.references !== undefined
+    if (useCiteproc) {
       // Currently the style is fixed, but in the future will be an encoding option.
       const cslStyle = path.join(stylesDir, 'apa.csl')
-      flags = [
+      pandocArgs.push(
         `--metadata=csl:${cslStyle}`,
         '--metadata=reference-section-title:References'
-      ]
+      )
     }
 
-    return pandoc.encode(article, {
-      filePath,
-      format: Pandoc.OutputFormat.docx,
-      theme: getTheme(),
-      codecOptions: {
-        flags,
-        ensureFile: true,
-        useCiteproc: references !== undefined
-      }
+    return pandoc.encode(article, options, {
+      pandocFormat: OutputFormat.docx,
+      pandocArgs,
+      ensureFile: true,
+      useCiteproc
     })
   }
 }

--- a/src/codecs/gdoc/index.ts
+++ b/src/codecs/gdoc/index.ts
@@ -19,11 +19,11 @@ import { docs_v1 as GDocT } from 'googleapis'
 import { stringifyContent } from '../../util/content/stringifyContent'
 import * as http from '../../util/http'
 import * as vfile from '../../util/vfile'
-import { Codec } from '../types'
+import { Codec, CommonDecodeOptions } from '../types'
 
 const log = getLogger('encoda:gdoc')
 
-interface DecodeOptions {
+interface DecodeOptions extends CommonDecodeOptions {
   fetch: boolean
 }
 

--- a/src/codecs/html/html.test.ts
+++ b/src/codecs/html/html.test.ts
@@ -64,6 +64,7 @@ const doc = (innerHTML: string) =>
 const json = new JsonCodec()
 const html = new HTMLCodec()
 const { encode, decode } = html
+const dump = html.dump.bind(html)
 
 const e = async (
   node: stencila.Node,
@@ -572,10 +573,10 @@ describe('Encode & Decode Collections', () => {
 })
 
 test('encode with different themes', async () => {
-  const e = async (options = defaultEncodeOptions) =>
-    vfile.dump(await encode(kitchenSink, options))
-
-  let html = await e({ theme: 'stencila' })
+  let html = await dump(stencila.article(), {
+    theme: 'stencila',
+    isStandalone: true
+  })
   expect(html).toMatch(
     /<script src="https:\/\/unpkg\.com\/@stencila\/thema@\d\/dist\/themes\/stencila\/index\.js/
   )
@@ -583,7 +584,7 @@ test('encode with different themes', async () => {
     /<link href="https:\/\/unpkg\.com\/@stencila\/thema@\d\/dist\/themes\/stencila\/styles\.css/
   )
 
-  html = await e({ theme: 'eLife' })
+  html = await dump(stencila.article(), { theme: 'eLife', isStandalone: true })
   expect(html).toMatch(
     /<script src="https:\/\/unpkg\.com\/@stencila\/thema@\d\/dist\/themes\/eLife\/index\.js/
   )
@@ -593,9 +594,6 @@ test('encode with different themes', async () => {
 })
 
 test('encode with bundling', async () => {
-  const e = async (options = defaultEncodeOptions) =>
-    vfile.dump(await encode(kitchenSink, options))
-
   const stylesheet = fs.readFileSync(
     require.resolve('@stencila/thema/dist/themes/eLife/styles.css'),
     'utf8'
@@ -610,7 +608,11 @@ test('encode with bundling', async () => {
   // affects indentation.
   // Previously we used a snapshot for this but that is avoided
   // here since it will fail when Thema is upgraded.
-  let html = await e({ theme: 'eLife', isBundle: true })
+  let html = await dump(stencila.article(), {
+    theme: 'eLife',
+    isStandalone: true,
+    isBundle: true
+  })
   expect(html).toMatch(stylesheet.trim().split('\n')[1])
   expect(html).toMatch(js.trim().split('\n')[1])
 })

--- a/src/codecs/html/html.test.ts
+++ b/src/codecs/html/html.test.ts
@@ -54,7 +54,7 @@ import kitchenSink from '../../__fixtures__/article/kitchen-sink'
 import mathArticle from '../../__fixtures__/article/math'
 import { readFixture, snapshot } from '../../__tests__/helpers'
 import { JsonCodec } from '../json'
-import { defaultEncodeOptions } from '../types'
+import { commonEncodeDefaults } from '../types'
 import { decodeHref, HTMLCodec } from './'
 import { encodeMicrodataItemtype, stencilaItemProp, Types } from './microdata'
 
@@ -68,7 +68,7 @@ const dump = html.dump.bind(html)
 
 const e = async (
   node: stencila.Node,
-  options = { ...defaultEncodeOptions, isStandalone: false }
+  options = { ...commonEncodeDefaults, isStandalone: false }
 ) => vfile.dump(await encode(node, options))
 
 const d = async (htmlString: string): Promise<stencila.Node> =>

--- a/src/codecs/html/index.ts
+++ b/src/codecs/html/index.ts
@@ -241,10 +241,10 @@ export class HTMLCodec extends Codec implements Codec {
    */
   public readonly encode = async (
     node: stencila.Node,
-    options: CommonEncodeOptions = this.defaultEncodeOptions
+    options: CommonEncodeOptions = this.commonEncodeDefaults
   ): Promise<vfile.VFile> => {
     const { filePath, isStandalone, isBundle, theme } = {
-      ...this.defaultEncodeOptions,
+      ...this.commonEncodeDefaults,
       ...options
     }
 

--- a/src/codecs/html/index.ts
+++ b/src/codecs/html/index.ts
@@ -37,7 +37,7 @@ import { getThemeAssets } from '../../util/html'
 import { toFiles } from '../../util/toFiles'
 import { truncate } from '../../util/truncate'
 import * as vfile from '../../util/vfile'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, CommonEncodeOptions } from '../types'
 import {
   decodeMicrodataItemtype,
   encodeMicrodataItemtype,
@@ -241,7 +241,7 @@ export class HTMLCodec extends Codec implements Codec {
    */
   public readonly encode = async (
     node: stencila.Node,
-    options: GlobalEncodeOptions = this.defaultEncodeOptions
+    options: CommonEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const { filePath, isStandalone, isBundle, theme } = {
       ...this.defaultEncodeOptions,

--- a/src/codecs/html/index.ts
+++ b/src/codecs/html/index.ts
@@ -37,7 +37,7 @@ import { getThemeAssets } from '../../util/html'
 import { toFiles } from '../../util/toFiles'
 import { truncate } from '../../util/truncate'
 import * as vfile from '../../util/vfile'
-import { Codec, defaultEncodeOptions, GlobalEncodeOptions } from '../types'
+import { Codec, GlobalEncodeOptions } from '../types'
 import {
   decodeMicrodataItemtype,
   encodeMicrodataItemtype,
@@ -243,12 +243,10 @@ export class HTMLCodec extends Codec implements Codec {
     node: stencila.Node,
     options: GlobalEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
-    const {
-      filePath,
-      isStandalone = true,
-      isBundle = false,
-      theme = themes.stencila
-    } = options
+    const { filePath, isStandalone, isBundle, theme } = {
+      ...this.defaultEncodeOptions,
+      ...options
+    }
 
     // Reset the slugger to avoid unnecessarily adding numbers to ids
     // in order to make them unique
@@ -269,8 +267,9 @@ export class HTMLCodec extends Codec implements Codec {
       dom = await generateHtmlElement(
         stringifyContent(title),
         [dom],
-        mathjaxCss,
-        options
+        isBundle,
+        theme,
+        mathjaxCss
       )
     }
 
@@ -604,17 +603,17 @@ function decodeDocument(doc: HTMLDocument): stencila.Node {
 /**
  * Generate a `<html>` element with supplied title, metadata, body content, and
  * optionally custom CSS to style the document with.
+ *
+ * TODO: This function needs refactoring. It only called from one location
+ * and it may be better to move some of all of it there.
  */
 async function generateHtmlElement(
-  title = 'Untitled',
-  body: Node[] = [],
-  css?: string,
-  options: GlobalEncodeOptions = defaultEncodeOptions
+  title: string,
+  body: Node[],
+  isBundle: boolean,
+  theme: string,
+  css?: string
 ): Promise<HTMLHtmlElement> {
-  const { isBundle = false, theme } = options
-
-  log.debug(`Generating <html> elem with options ${JSON.stringify(options)}`)
-
   const { styles, scripts } = await getThemeAssets(theme, isBundle)
 
   let themeCss
@@ -808,7 +807,7 @@ function encodeTitleProperty(
 
   return h(
     tag,
-    {[headline === title ?  'itemprop' : stencilaItemProp]: 'headline'},
+    { [headline === title ? 'itemprop' : stencilaItemProp]: 'headline' },
     headline === title
       ? undefined
       : h('meta', { itemprop: 'headline', content: headline }),
@@ -967,10 +966,7 @@ function encodeReferencesProperty(
       { [stencilaItemType]: encodeMicrodataItemtype('Heading') },
       'References'
     ),
-    h(
-      'ol',
-      references.map(encodeReference)
-    )
+    h('ol', references.map(encodeReference))
   )
 }
 

--- a/src/codecs/jats-pandoc/index.ts
+++ b/src/codecs/jats-pandoc/index.ts
@@ -5,7 +5,7 @@
 import stencila from '@stencila/schema'
 import * as vfile from '../../util/vfile'
 import * as Pandoc from '../pandoc'
-import { Codec } from '../types'
+import { Codec, GlobalEncodeOptions } from '../types'
 
 const pandoc = new Pandoc.PandocCodec()
 
@@ -21,7 +21,7 @@ export class JatsPandocCodec extends Codec implements Codec {
 
   public readonly encode = async (
     node: stencila.Node,
-    options = this.defaultEncodeOptions
+    options: GlobalEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     return pandoc.encode(node, {
       ...options,

--- a/src/codecs/jats-pandoc/index.ts
+++ b/src/codecs/jats-pandoc/index.ts
@@ -4,10 +4,10 @@
 
 import stencila from '@stencila/schema'
 import * as vfile from '../../util/vfile'
-import * as Pandoc from '../pandoc'
-import { Codec, CommonEncodeOptions } from '../types'
+import { InputFormat, OutputFormat, PandocCodec } from '../pandoc'
+import { Codec, CommonDecodeOptions, CommonEncodeOptions } from '../types'
 
-const pandoc = new Pandoc.PandocCodec()
+const pandoc = new PandocCodec()
 
 export class JatsPandocCodec extends Codec implements Codec {
   /**
@@ -15,18 +15,22 @@ export class JatsPandocCodec extends Codec implements Codec {
    */
   public readonly mediaTypes = ['application/jats+xml']
 
-  public readonly decode = (file: vfile.VFile): Promise<stencila.Node> => {
-    return pandoc.decode(file, { from: Pandoc.InputFormat.jats })
+  public readonly decode = (
+    file: vfile.VFile,
+    options: CommonDecodeOptions = this.commonDecodeDefaults
+  ): Promise<stencila.Node> => {
+    return pandoc.decode(file, options, {
+      pandocFormat: InputFormat.jats
+    })
   }
 
   public readonly encode = async (
     node: stencila.Node,
-    options: CommonEncodeOptions = this.defaultEncodeOptions
+    options: CommonEncodeOptions = this.commonEncodeDefaults
   ): Promise<vfile.VFile> => {
-    return pandoc.encode(node, {
-      ...options,
-      format: Pandoc.OutputFormat.jats,
-      codecOptions: { flags: [`--template=jats-template.xml`] }
+    return pandoc.encode(node, options, {
+      pandocFormat: OutputFormat.jats,
+      pandocArgs: [`--template=jats-template.xml`]
     })
   }
 }

--- a/src/codecs/jats-pandoc/index.ts
+++ b/src/codecs/jats-pandoc/index.ts
@@ -5,7 +5,7 @@
 import stencila from '@stencila/schema'
 import * as vfile from '../../util/vfile'
 import * as Pandoc from '../pandoc'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, CommonEncodeOptions } from '../types'
 
 const pandoc = new Pandoc.PandocCodec()
 
@@ -21,7 +21,7 @@ export class JatsPandocCodec extends Codec implements Codec {
 
   public readonly encode = async (
     node: stencila.Node,
-    options: GlobalEncodeOptions = this.defaultEncodeOptions
+    options: CommonEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     return pandoc.encode(node, {
       ...options,

--- a/src/codecs/latex/index.ts
+++ b/src/codecs/latex/index.ts
@@ -5,7 +5,7 @@
 import stencila from '@stencila/schema'
 import * as vfile from '../../util/vfile'
 import * as P from '../pandoc'
-import { Codec } from '../types'
+import { Codec, GlobalEncodeOptions } from '../types'
 
 const pandoc = new P.PandocCodec()
 
@@ -22,7 +22,7 @@ export class LatexCodec extends Codec implements Codec {
 
   public readonly encode = async (
     node: stencila.Node,
-    options = this.defaultEncodeOptions
+    options: GlobalEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     return pandoc.encode(node, {
       ...options,

--- a/src/codecs/latex/index.ts
+++ b/src/codecs/latex/index.ts
@@ -5,7 +5,7 @@
 import stencila from '@stencila/schema'
 import * as vfile from '../../util/vfile'
 import * as P from '../pandoc'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, CommonEncodeOptions } from '../types'
 
 const pandoc = new P.PandocCodec()
 
@@ -22,7 +22,7 @@ export class LatexCodec extends Codec implements Codec {
 
   public readonly encode = async (
     node: stencila.Node,
-    options: GlobalEncodeOptions = this.defaultEncodeOptions
+    options: CommonEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     return pandoc.encode(node, {
       ...options,

--- a/src/codecs/latex/index.ts
+++ b/src/codecs/latex/index.ts
@@ -4,10 +4,10 @@
 
 import stencila from '@stencila/schema'
 import * as vfile from '../../util/vfile'
-import * as P from '../pandoc'
-import { Codec, CommonEncodeOptions } from '../types'
+import { InputFormat, OutputFormat, PandocCodec } from '../pandoc'
+import { Codec, CommonDecodeOptions, CommonEncodeOptions } from '../types'
 
-const pandoc = new P.PandocCodec()
+const pandoc = new PandocCodec()
 
 export class LatexCodec extends Codec implements Codec {
   public readonly mediaTypes = ['application/x-latex']
@@ -15,18 +15,20 @@ export class LatexCodec extends Codec implements Codec {
   public readonly extNames = ['latex', 'tex']
 
   public readonly decode = async (
-    file: vfile.VFile
+    file: vfile.VFile,
+    options: CommonDecodeOptions = this.commonDecodeDefaults
   ): Promise<stencila.Node> => {
-    return pandoc.decode(file, { from: P.InputFormat.latex })
+    return pandoc.decode(file, options, {
+      pandocFormat: InputFormat.latex
+    })
   }
 
   public readonly encode = async (
     node: stencila.Node,
-    options: CommonEncodeOptions = this.defaultEncodeOptions
+    options: CommonEncodeOptions = this.commonEncodeDefaults
   ): Promise<vfile.VFile> => {
-    return pandoc.encode(node, {
-      ...options,
-      format: P.OutputFormat.latex
+    return pandoc.encode(node, options, {
+      pandocFormat: OutputFormat.latex
     })
   }
 }

--- a/src/codecs/ods/index.ts
+++ b/src/codecs/ods/index.ts
@@ -23,6 +23,6 @@ export class ODSCodec extends Codec implements Codec {
   public readonly encode = async (
     node: stencila.Node
   ): Promise<vfile.VFile> => {
-    return xlsx.encode(node, { ...this.defaultEncodeOptions, format: 'ods' })
+    return xlsx.encode(node, { format: 'ods' })
   }
 }

--- a/src/codecs/odt/index.ts
+++ b/src/codecs/odt/index.ts
@@ -5,7 +5,7 @@
 import stencila from '@stencila/schema'
 import * as vfile from '../../util/vfile'
 import * as P from '../pandoc'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, CommonEncodeOptions } from '../types'
 
 const pandoc = new P.PandocCodec()
 
@@ -23,7 +23,7 @@ export class ODTCodec extends Codec implements Codec {
 
   public readonly encode = async (
     node: stencila.Node,
-    options: GlobalEncodeOptions = this.defaultEncodeOptions
+    options: CommonEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     return pandoc.encode(node, {
       ...options,

--- a/src/codecs/odt/index.ts
+++ b/src/codecs/odt/index.ts
@@ -4,33 +4,31 @@
 
 import stencila from '@stencila/schema'
 import * as vfile from '../../util/vfile'
-import * as P from '../pandoc'
-import { Codec, CommonEncodeOptions } from '../types'
+import { InputFormat, OutputFormat, PandocCodec } from '../pandoc'
+import { Codec, CommonDecodeOptions, CommonEncodeOptions } from '../types'
 
-const pandoc = new P.PandocCodec()
+const pandoc = new PandocCodec()
 
 export class ODTCodec extends Codec implements Codec {
   public readonly mediaTypes = ['application/vnd.oasis.opendocument.text']
 
   public readonly decode = async (
-    file: vfile.VFile
+    file: vfile.VFile,
+    options: CommonDecodeOptions = this.commonDecodeDefaults
   ): Promise<stencila.Node> => {
-    return pandoc.decode(file, {
-      from: P.InputFormat.odt,
-      flags: [`--extract-media=${file.path}.media`]
+    return pandoc.decode(file, options, {
+      pandocFormat: InputFormat.odt,
+      pandocArgs: [`--extract-media=${file.path}.media`]
     })
   }
 
   public readonly encode = async (
     node: stencila.Node,
-    options: CommonEncodeOptions = this.defaultEncodeOptions
+    options: CommonEncodeOptions = this.commonEncodeDefaults
   ): Promise<vfile.VFile> => {
-    return pandoc.encode(node, {
-      ...options,
-      format: P.OutputFormat.odt,
-      codecOptions: {
-        ensureFile: true
-      }
+    return pandoc.encode(node, options, {
+      pandocFormat: OutputFormat.odt,
+      ensureFile: true
     })
   }
 }

--- a/src/codecs/odt/index.ts
+++ b/src/codecs/odt/index.ts
@@ -5,7 +5,7 @@
 import stencila from '@stencila/schema'
 import * as vfile from '../../util/vfile'
 import * as P from '../pandoc'
-import { Codec } from '../types'
+import { Codec, GlobalEncodeOptions } from '../types'
 
 const pandoc = new P.PandocCodec()
 
@@ -23,7 +23,7 @@ export class ODTCodec extends Codec implements Codec {
 
   public readonly encode = async (
     node: stencila.Node,
-    options = this.defaultEncodeOptions
+    options: GlobalEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     return pandoc.encode(node, {
       ...options,

--- a/src/codecs/pandoc/index.ts
+++ b/src/codecs/pandoc/index.ts
@@ -25,7 +25,7 @@ import { write } from '../..'
 import { ensureBlockContent } from '../../util/content/ensureBlockContent'
 import * as vfile from '../../util/vfile'
 import { RPNGCodec } from '../rpng'
-import { Codec, defaultEncodeOptions, GlobalEncodeOptions } from '../types'
+import { Codec, defaultEncodeOptions, CommonEncodeOptions } from '../types'
 import { binary, dataDir, citeprocBinaryPath } from './binary'
 import * as Pandoc from './types'
 import { stringifyContent } from '../../util/content/stringifyContent'
@@ -106,7 +106,7 @@ export class PandocCodec extends Codec
       filePath,
       format = Pandoc.OutputFormat.json,
       codecOptions = { flags: [], ensureFile: false }
-    }: GlobalEncodeOptions<EncodeOptions> = this.defaultEncodeOptions
+    }: CommonEncodeOptions<EncodeOptions> = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     encodePromises = []
     const { standalone, pdoc } = encodeNode(node)

--- a/src/codecs/pandoc/pandoc.test.ts
+++ b/src/codecs/pandoc/pandoc.test.ts
@@ -4,7 +4,7 @@ import path from 'path'
 import * as vfile from '../../util/vfile'
 import { fixture, snapshot } from '../../__tests__/helpers'
 import { RPNGCodec } from '../rpng'
-import { defaultEncodeOptions } from '../types'
+import { commonEncodeDefaults } from '../types'
 import { JsonCodec } from '../json'
 import { decodeMeta, emptyAttrs, encodeMeta, PandocCodec, run } from './'
 import * as Pandoc from './types'
@@ -620,7 +620,7 @@ describe('rPNG encoding & decoding of "special" node types', () => {
     'decode: %s',
     async (name: string, value: stencila.Node, done: jest.DoneCallback) => {
       const rPNG = await rpng.encode(value, {
-        ...defaultEncodeOptions,
+        ...commonEncodeDefaults,
         filePath: path.join(output, `${name}.png`)
       })
 

--- a/src/codecs/pdf/index.ts
+++ b/src/codecs/pdf/index.ts
@@ -70,7 +70,7 @@ export class PdfCodec extends Codec {
    */
   public readonly encode = async (
     node: stencila.Node,
-    options: CommonEncodeOptions = this.defaultEncodeOptions
+    options: CommonEncodeOptions = this.commonEncodeDefaults
   ): Promise<vfile.VFile> => {
     // Generate HTML that will be used to render the PDF
     // Bundle images into HTML, otherwise Puppeteer will not

--- a/src/codecs/pdf/index.ts
+++ b/src/codecs/pdf/index.ts
@@ -10,7 +10,7 @@ import * as puppeteer from '../../util/puppeteer'
 import * as vfile from '../../util/vfile'
 import * as xml from '../../util/xml'
 import { decodeDoc as decodeXmlDoc, encodeDoc as encodeXmlDoc } from '../xml'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, CommonEncodeOptions } from '../types'
 import { stringifyContent } from '../../util/content/stringifyContent'
 
 const log = getLogger('encoda:pdf')
@@ -70,7 +70,7 @@ export class PdfCodec extends Codec {
    */
   public readonly encode = async (
     node: stencila.Node,
-    options: GlobalEncodeOptions = this.defaultEncodeOptions
+    options: CommonEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     // Generate HTML that will be used to render the PDF
     // Bundle images into HTML, otherwise Puppeteer will not

--- a/src/codecs/rpng/index.ts
+++ b/src/codecs/rpng/index.ts
@@ -230,7 +230,7 @@ export class RPNGCodec extends Codec implements Codec {
    */
   public readonly encode = async (
     node: stencila.Node,
-    options: CommonEncodeOptions = this.defaultEncodeOptions
+    options: CommonEncodeOptions = this.commonEncodeDefaults
   ): Promise<vfile.VFile> => {
     // isStandalone defaults to false because usually we are generating
     // rPNGs to be embedded in other files e.g. rDOCX

--- a/src/codecs/rpng/index.ts
+++ b/src/codecs/rpng/index.ts
@@ -27,7 +27,7 @@ import punycode from 'punycode'
 import { dump } from '../../index'
 import * as puppeteer from '../../util/puppeteer'
 import * as vfile from '../../util/vfile'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, CommonEncodeOptions } from '../types'
 
 /**
  * Styling to be applied to a node's HTML fragment
@@ -230,7 +230,7 @@ export class RPNGCodec extends Codec implements Codec {
    */
   public readonly encode = async (
     node: stencila.Node,
-    options: GlobalEncodeOptions = this.defaultEncodeOptions
+    options: CommonEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     // isStandalone defaults to false because usually we are generating
     // rPNGs to be embedded in other files e.g. rDOCX

--- a/src/codecs/tdp/index.ts
+++ b/src/codecs/tdp/index.ts
@@ -18,7 +18,7 @@ import * as stencila from '@stencila/schema'
 import datapackage from 'datapackage'
 import { dump } from '../..'
 import * as vfile from '../../util/vfile'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, CommonEncodeOptions } from '../types'
 
 const logger = getLogger('encoda')
 
@@ -84,7 +84,7 @@ export class TDPCodec extends Codec implements Codec {
 
   public readonly encode = async (
     node: stencila.Node,
-    { filePath }: GlobalEncodeOptions = this.defaultEncodeOptions
+    { filePath }: CommonEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const cw = node as stencila.CreativeWork
 

--- a/src/codecs/tdp/index.ts
+++ b/src/codecs/tdp/index.ts
@@ -84,7 +84,7 @@ export class TDPCodec extends Codec implements Codec {
 
   public readonly encode = async (
     node: stencila.Node,
-    { filePath }: CommonEncodeOptions = this.defaultEncodeOptions
+    { filePath }: CommonEncodeOptions = this.commonEncodeDefaults
   ): Promise<vfile.VFile> => {
     const cw = node as stencila.CreativeWork
 

--- a/src/codecs/types.ts
+++ b/src/codecs/types.ts
@@ -2,18 +2,40 @@ import * as stencila from '@stencila/schema'
 import { getTheme } from '@stencila/thema'
 import * as vfile from '../util/vfile'
 
+/**
+ * Encoding options that are common to all codecs.
+ *
+ * Codecs are encouraged to respect these options but
+ * are not forced to. Indeed, some options do not make sense for
+ * some codecs. For example, for the PDF codec `isStandalone`
+ * is always `true` so if `isStandalone: false` is supplied
+ * as an option it will be ignored. Futhermore, some combinations
+ * of options are pointless e.g. a `theme` when `isStandalone: false`
+ */
 export interface GlobalEncodeOptions<CodecOptions extends object = {}> {
   format?: string
   filePath?: string
   isStandalone?: boolean
   isBundle?: boolean
   shouldZip?: 'yes' | 'no' | 'maybe'
-  theme: string
+  theme?: string
 
   codecOptions?: CodecOptions
 }
 
-export const defaultEncodeOptions: GlobalEncodeOptions = {
+/**
+ * Default values for encoding options.
+ *
+ * This set of defaults provide a way of promoting consistency amongst
+ * codecs. Instead of, for example, one codec defaulting
+ * to `isStandalone: true` and another to `false`.
+ */
+export const defaultEncodeOptions: Required<Pick<
+  GlobalEncodeOptions,
+  'isStandalone' | 'isBundle' | 'shouldZip' | 'theme'
+>> = {
+  isStandalone: false,
+  isBundle: false,
   shouldZip: 'no',
   theme: getTheme()
 }

--- a/src/codecs/types.ts
+++ b/src/codecs/types.ts
@@ -12,7 +12,7 @@ import * as vfile from '../util/vfile'
  * as an option it will be ignored. Futhermore, some combinations
  * of options are pointless e.g. a `theme` when `isStandalone: false`
  */
-export interface GlobalEncodeOptions<CodecOptions extends object = {}> {
+export interface CommonEncodeOptions<CodecOptions extends object = {}> {
   format?: string
   filePath?: string
   isStandalone?: boolean
@@ -31,7 +31,7 @@ export interface GlobalEncodeOptions<CodecOptions extends object = {}> {
  * to `isStandalone: true` and another to `false`.
  */
 export const defaultEncodeOptions: Required<Pick<
-  GlobalEncodeOptions,
+  CommonEncodeOptions,
   'isStandalone' | 'isBundle' | 'shouldZip' | 'theme'
 >> = {
   isStandalone: false,
@@ -102,7 +102,7 @@ export abstract class Codec<
    */
   public abstract readonly encode: (
     node: stencila.Node,
-    options?: EncodeOptions & GlobalEncodeOptions
+    options?: EncodeOptions & CommonEncodeOptions
   ) => Promise<vfile.VFile>
 
   /**
@@ -135,7 +135,7 @@ export abstract class Codec<
    */
   public async dump(
     node: stencila.Node,
-    options?: EncodeOptions & GlobalEncodeOptions
+    options?: EncodeOptions & CommonEncodeOptions
   ): Promise<string> {
     return vfile.dump(await this.encode(node, options))
   }

--- a/src/codecs/xlsx/index.ts
+++ b/src/codecs/xlsx/index.ts
@@ -18,7 +18,7 @@ import { range } from 'fp-ts/lib/Array'
 import { pipe } from 'fp-ts/lib/pipeable'
 import * as xlsx from 'xlsx'
 import * as vfile from '../../util/vfile'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, CommonEncodeOptions } from '../types'
 
 const cellNameRegEx = /^([A-Z]+)([1-9][0-9]*)$/
 
@@ -39,7 +39,7 @@ export class XlsxCodec extends Codec implements Codec {
 
   public readonly encode = (
     node: stencila.Node,
-    { format = 'xlsx' }: GlobalEncodeOptions = this.defaultEncodeOptions
+    { format = 'xlsx' }: CommonEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const workbook = encodeNode(node)
     const buffer = xlsx.write(workbook, {

--- a/src/codecs/xlsx/index.ts
+++ b/src/codecs/xlsx/index.ts
@@ -39,7 +39,7 @@ export class XlsxCodec extends Codec implements Codec {
 
   public readonly encode = (
     node: stencila.Node,
-    { format = 'xlsx' }: CommonEncodeOptions = this.defaultEncodeOptions
+    { format = 'xlsx' }: CommonEncodeOptions = this.commonEncodeDefaults
   ): Promise<vfile.VFile> => {
     const workbook = encodeNode(node)
     const buffer = xlsx.write(workbook, {

--- a/src/codecs/xml/index.ts
+++ b/src/codecs/xml/index.ts
@@ -7,7 +7,7 @@ import * as stencila from '@stencila/schema'
 import { getVersion as getSchemaVersion } from '../../util/schemas'
 import * as vfile from '../../util/vfile'
 import * as xml from '../../util/xml'
-import { Codec, GlobalEncodeOptions } from '../types'
+import { Codec, CommonEncodeOptions } from '../types'
 
 const log = getLogger('encoda:xml')
 
@@ -47,7 +47,7 @@ export class XmlCodec extends Codec {
    */
   public readonly encode = async (
     node: stencila.Node,
-    options: GlobalEncodeOptions = this.defaultEncodeOptions
+    options: CommonEncodeOptions = this.defaultEncodeOptions
   ): Promise<vfile.VFile> => {
     const doc = await encodeDoc(node, options.isStandalone)
     const content = xml.dump(doc, { spaces: 4 })

--- a/src/codecs/xml/index.ts
+++ b/src/codecs/xml/index.ts
@@ -47,7 +47,7 @@ export class XmlCodec extends Codec {
    */
   public readonly encode = async (
     node: stencila.Node,
-    options: CommonEncodeOptions = this.defaultEncodeOptions
+    options: CommonEncodeOptions = this.commonEncodeDefaults
   ): Promise<vfile.VFile> => {
     const doc = await encodeDoc(node, options.isStandalone)
     const content = xml.dump(doc, { spaces: 4 })

--- a/src/encoda.ts
+++ b/src/encoda.ts
@@ -8,7 +8,7 @@ import {
 import { getLogger } from '@stencila/logga'
 import * as schema from '@stencila/schema'
 import { codecList, decode, encode } from '.'
-import { defaultEncodeOptions } from './codecs/types'
+import { commonEncodeDefaults } from './codecs/types'
 import * as vfile from './util/vfile'
 
 const log = getLogger('encoda')
@@ -81,7 +81,7 @@ export class Encoda extends Listener {
     format?: string
   ): Promise<string> {
     const encoding = await encode(node, {
-      ...defaultEncodeOptions,
+      ...commonEncodeDefaults,
       format,
       filePath: dest
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import path from 'path'
 import {
   Codec,
   defaultEncodeOptions,
-  GlobalEncodeOptions
+  CommonEncodeOptions
 } from './codecs/types'
 import * as vfile from './util/vfile'
 import * as zip from './util/zip'
@@ -241,7 +241,7 @@ export async function decode(
  */
 export const encode = async (
   node: stencila.Node,
-  options: GlobalEncodeOptions = defaultEncodeOptions
+  options: CommonEncodeOptions = defaultEncodeOptions
 ): Promise<VFile> => {
   const { filePath, format } = options
   if (!(filePath || format)) {
@@ -277,7 +277,7 @@ export async function load(
 export async function dump(
   node: stencila.Node,
   format: string,
-  options: GlobalEncodeOptions = defaultEncodeOptions
+  options: CommonEncodeOptions = defaultEncodeOptions
 ): Promise<string> {
   const file = await encode(node, { ...options, format })
   return vfile.dump(file)
@@ -310,7 +310,7 @@ export async function read(
 export async function write(
   node: stencila.Node,
   filePath: string,
-  options: GlobalEncodeOptions = defaultEncodeOptions
+  options: CommonEncodeOptions = defaultEncodeOptions
 ): Promise<VFile> {
   const file = await encode(node, { ...options, filePath })
   await vfile.write(file, filePath)
@@ -320,7 +320,7 @@ export async function write(
 interface ConvertOptions {
   to?: string
   from?: string
-  encodeOptions?: GlobalEncodeOptions
+  encodeOptions?: CommonEncodeOptions
 }
 
 /**

--- a/src/process.ts
+++ b/src/process.ts
@@ -12,7 +12,7 @@ import * as stencila from '@stencila/schema'
 import assert from 'assert'
 import path from 'path'
 import { dump, load, read, write } from '.'
-import { defaultEncodeOptions } from './codecs/types'
+import { commonEncodeDefaults } from './codecs/types'
 import { coerce } from './util/coerce'
 import { validate } from './util/validate'
 
@@ -69,7 +69,7 @@ export default async function process(
             _get(meta.export),
             meta.to || code.programmingLanguage,
             {
-              ...defaultEncodeOptions,
+              ...commonEncodeDefaults,
               isStandalone: false
             }
           )
@@ -223,7 +223,7 @@ export default async function process(
   ): Promise<void> {
     try {
       const targetPath = './' + path.join(dir, target)
-      await write(node, targetPath, { ...defaultEncodeOptions, format })
+      await write(node, targetPath, { ...commonEncodeDefaults, format })
     } catch (error) {
       throw Error(`Error: writing "${target}": ${error} `)
     }

--- a/src/util/html.test.ts
+++ b/src/util/html.test.ts
@@ -2,7 +2,6 @@ import { themePath, themes } from '@stencila/thema'
 import { nockRecord } from '../__tests__/helpers'
 import { getThemeAssets, isTheme } from './html'
 
-
 const themaThemes = Object.entries(themes)
 const themeUrl = 'http://unpkg.com/@stencila/thema@1.5.3/dist/themes/stencila'
 


### PR DESCRIPTION
This PR aims to do some tidying up around common aka. global decode and encode options:

- add common options for decoding e.g. `asType`
- make all options optional
- revise how codecs define their own options (?)
- define default values for consistency
