### PR TITLE
feat(JATS): Decode <collab> Article authors as an Org

### DIFF
--- a/src/codecs/jats/__file_snapshots__/elife-30274-v1.jats.xml
+++ b/src/codecs/jats/__file_snapshots__/elife-30274-v1.jats.xml
@@ -51,12 +51,7 @@
                     <xref ref-type="aff" rid="00000000000000000000000000000000"/>
                 </contrib>
                 <contrib contrib-type="author">
-                    <string-name/>
-                    <xref ref-type="aff" rid="00000000000000000000000000000000"/>
-                    <xref ref-type="aff" rid="00000000000000000000000000000000"/>
-                    <xref ref-type="aff" rid="00000000000000000000000000000000"/>
-                    <xref ref-type="aff" rid="00000000000000000000000000000000"/>
-                    <xref ref-type="aff" rid="00000000000000000000000000000000"/>
+                    <string-name>Reproducibility Project: Cancer Biology</string-name>
                 </contrib>
                 <contrib contrib-type="author">
                     <name>
@@ -110,21 +105,6 @@
                 </aff>
                 <aff id="00000000000000000000000000000000">
                     <institution>University of Georgia, Bioexpression and Fermentation Facility</institution>
-                </aff>
-                <aff id="00000000000000000000000000000000">
-                    <institution>Science Exchange</institution>
-                </aff>
-                <aff id="00000000000000000000000000000000">
-                    <institution>Science Exchange</institution>
-                </aff>
-                <aff id="00000000000000000000000000000000">
-                    <institution>Center for Open Science</institution>
-                </aff>
-                <aff id="00000000000000000000000000000000">
-                    <institution>Science Exchange</institution>
-                </aff>
-                <aff id="00000000000000000000000000000000">
-                    <institution>Center for Open Science</institution>
                 </aff>
                 <aff id="00000000000000000000000000000000">
                     <institution>Science Exchange</institution>

--- a/src/codecs/jats/__file_snapshots__/elife-30274-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-30274-v1.yaml
@@ -83,41 +83,13 @@ authors:
       - Blum
     givenNames:
       - David
-  - type: Person
-    affiliations:
-      - type: Organization
-        address:
-          type: PostalAddress
-          addressCountry: United States
-          addressLocality: Palo Alto
-        name: Science Exchange
-      - type: Organization
-        address:
-          type: PostalAddress
-          addressCountry: United States
-          addressLocality: Palo Alto
-        name: Science Exchange
-      - type: Organization
-        address:
-          type: PostalAddress
-          addressCountry: United States
-          addressLocality: Charlottesville
-        name: Center for Open Science
-      - type: Organization
-        address:
-          type: PostalAddress
-          addressCountry: United States
-          addressLocality: Palo Alto
-        name: Science Exchange
-      - type: Organization
-        address:
-          type: PostalAddress
-          addressCountry: United States
-          addressLocality: Charlottesville
-        name: Center for Open Science
-    emails:
-      - tim@cos.io
-      - nicole@scienceexchange.com
+  - type: Organization
+    contactPoints:
+      - type: ContactPoint
+        emails:
+          - tim@cos.io
+          - nicole@scienceexchange.com
+    name: 'Reproducibility Project: Cancer Biology'
   - type: Person
     affiliations:
       - type: Organization

--- a/src/codecs/jats/jats.test.ts
+++ b/src/codecs/jats/jats.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../../__fixtures__/math/kitchen-sink'
 import { YamlCodec } from '../yaml'
 import { unlinkFiles } from '../../util/media/unlinkFiles'
+import { Article, organization, contactPoint } from '@stencila/schema'
 
 const jats = new JatsCodec()
 const yaml = new YamlCodec()
@@ -82,7 +83,7 @@ test.each([
   'plosone-0093988',
   'plosone-0178565',
 ])('decode + encode : %s', async (article) => {
-  const node = await unlinkFiles(await jats.read(fixture(article)))
+  const node = unlinkFiles(await jats.read(fixture(article)))
 
   expect(await yaml.dump(node)).toMatchFile(snapshot(`${article}.yaml`))
 
@@ -91,4 +92,27 @@ test.each([
       isStandalone: true,
     })
   ).toMatchFile(snapshot(`${article}.jats.xml`))
+})
+
+describe('authors', () => {
+  test('decode collaborators', async () => {
+    const { authors } = unlinkFiles(
+      await jats.read(fixture('elife-30274-v1'))
+    ) as Article
+
+    expect(authors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining(
+          organization({
+            name: 'Reproducibility Project: Cancer Biology',
+            contactPoints: [
+              contactPoint({
+                emails: ['tim@cos.io', 'nicole@scienceexchange.com'],
+              }),
+            ],
+          })
+        ),
+      ])
+    )
+  })
 })

--- a/src/util/xml.test.ts
+++ b/src/util/xml.test.ts
@@ -1,4 +1,4 @@
-import { elem, dump, Element } from './xml'
+import { elem, dump, Element, firstByType, load } from './xml'
 
 test('elem', () => {
   expect(elem('tag')).toEqual({
@@ -54,4 +54,32 @@ test('dump', () => {
   expect(frag(elem('parent', { foo: 'bar' }, elem('child')))).toEqual(
     `<parent foo="bar"><child/></parent>`
   )
+})
+
+describe('firstByType', () => {
+  const xml = load(`
+  <contrib contrib-type="author" corresp="yes">
+    <email>some@email.io</email>
+    <email>another@email.com</email>
+    <collab>This is an Org name
+      <contrib-group>
+        <contrib>
+          <name>
+            <surname>Test</surname>
+            <given-names>Name</given-names>
+          </name>
+        </contrib>
+      </contrib-group>
+    </collab>
+  </contrib>`)
+
+  it('gets an element', () => {
+    expect(firstByType(xml, 'element')).toEqual(xml.elements![0])
+  })
+
+  it('gets a text element', () => {
+    const match = firstByType(xml, 'text')
+    expect(match).toHaveProperty('type', 'text')
+    expect(match).toHaveProperty('text', 'some@email.io')
+  })
 })

--- a/src/util/xml.ts
+++ b/src/util/xml.ts
@@ -190,6 +190,28 @@ export function first(
 }
 
 /**
+ * Get the first descendent element of a specific type
+ */
+export function firstByType(
+  elem: Element | null,
+  type: string | null
+): Element | null {
+  if (!elem || !type || !elem.elements) return null
+  if (elem.type === type) return elem
+
+  for (const child of elem.elements) {
+    if (child.type === type) return child
+  }
+
+  for (const child of elem.elements) {
+    const result = firstByType(child, type)
+    if (result) return result
+  }
+
+  return null
+}
+
+/**
  * Get all descendent elements that match name/s and attributes
  */
 export function all(


### PR DESCRIPTION
Closes #550 

Currently this only captures the `<collab>` contributors as an `Organization` node, with the `emails` as `ContactPoints`.
Note that only a single `ContactPoint` node is created for the org containing all the emails, as opposed to one contact point per email. Can go either way on this, but the root of the issue is that we don't really have an idea whether the email addresses belong to the same entity or not.

I tried capturing the members by setting their affiliation to the "collab Org", but wasn't quite sure how to best represent this in the generated HTML and across codecs. Nesting a list of `Person`s inside the `Organization` element doesn't fit with the Schema, right now it's the same as previous behaviour where they're just listed after the Org, but I'm not sure how we'd go about targeting just those authors from Thema… 
Can think through this with a fresh perspective tomorrow, but if you have suggests please weigh in @nokome.

<img width="1588" alt="Screenshot 2020-05-27 at 22 57 51@2x" src="https://user-images.githubusercontent.com/1646307/83094531-e0b51800-a06f-11ea-90cd-c705c346409a.png">

---

Second, I've got `ContactPoint` encoding locally but it needs a companion decoder and tests added. But can put this off till a follow up PR if we'd like.

**With ContactPoints**

<img width="1584" alt="Screenshot 2020-05-27 at 23 13 24@2x" src="https://user-images.githubusercontent.com/1646307/83094546-e874bc80-a06f-11ea-87c1-ca2ccf47d17a.png">
