### PR TITLE
feat(MD): Decode Pandoc style text citations

### DIFF
--- a/src/codecs/md/index.ts
+++ b/src/codecs/md/index.ts
@@ -28,30 +28,25 @@ import * as MDAST from 'mdast'
 import compact from 'mdast-util-compact'
 // @ts-ignore
 import attrs from 'remark-attr'
-// @ts-ignore
 import frontmatter from 'remark-frontmatter'
 // @ts-ignore
 import genericExtensions from 'remark-generic-extensions'
 // @ts-ignore
 import math from 'remark-math'
-// @ts-ignore
 import parser from 'remark-parse'
-// @ts-ignore
 import stringifier from 'remark-stringify'
 // @ts-ignore
 import subSuper from 'remark-sub-super'
 import unified from 'unified'
 import * as UNIST from 'unist'
-// @ts-ignore
 import filter from 'unist-util-filter'
-// @ts-ignore
 import map from 'unist-util-map'
-// @ts-ignore
 import { selectAll } from 'unist-util-select'
 import * as vfile from '../../util/vfile'
 import { HTMLCodec } from '../html'
 import { TxtCodec } from '../txt'
 import { Codec, CommonDecodeOptions } from '../types'
+import { citePlugin } from './plugins/cite'
 import { stringifyHTML } from './stringifyHtml'
 import { TexCodec } from '../tex'
 import transform from '../../util/transform'
@@ -184,6 +179,7 @@ export function decodeMarkdown(
     .use(attrs, ATTR_OPTIONS)
     .use(subSuper)
     .use(math)
+    .use(citePlugin)
     .use(genericExtensions, { elements: extensionHandlers })
     .parse(md)
   compact(mdast, true)
@@ -265,6 +261,8 @@ function decodeNode(node: UNIST.Node): stencila.Node {
       return decodeStrong(node as MDAST.Strong)
     case 'delete':
       return decodeDelete(node as MDAST.Delete)
+    case 'cite':
+      return decodeCite(node as MDAST.Literal)
     case 'sub':
       return decodeSubscript(node as MDAST.Parent)
     case 'sup':
@@ -956,6 +954,15 @@ function encodeCite(cite: stencila.Cite): MDAST.Text {
     type: 'text',
     value: `@${cite.target}`,
   }
+}
+
+/**
+ * Encode a MDAST `Cite` node with Pandoc style `@`-prefixed citations e.g. `@smith04` to a Stencila `Cite` node.
+ */
+function decodeCite(cite: MDAST.Literal): stencila.Cite {
+  return stencila.cite({
+    target: cite.value,
+  })
 }
 
 /**

--- a/src/codecs/md/md.test.ts
+++ b/src/codecs/md/md.test.ts
@@ -15,9 +15,9 @@ const mdCodec = new MdCodec()
 const { decode, encode } = mdCodec
 const jsonCodec = new JsonCodec()
 
-describe('decode', () => {
-  const d = async (md: string) => await decode(await load(md))
+const d = async (md: string) => await decode(await load(md))
 
+describe('decode', () => {
   test('Kitchen Sink', async () => {
     expect(await d(kitchenSink.md)).toEqual(kitchenSink.node)
   })
@@ -240,9 +240,9 @@ describe('decode: fixtures', () => {
   })
 })
 
-describe('encode', () => {
-  const e = async (node: stencila.Node) => await dump(await encode(node))
+const e = async (node: stencila.Node) => await dump(await encode(node))
 
+describe('encode', () => {
   test('Kitchen Sink', async () => {
     expect(await e(kitchenSink.node)).toEqual(kitchenSink.md)
   })
@@ -1049,3 +1049,92 @@ const references = {
     ],
   },
 }
+
+describe('Citations', () => {
+  const reference = '@simple'
+  const referenceNode = cite({ target: reference.replace('@', '') })
+
+  const complexReference = '@like-this'
+  const complexReferenceNode = cite({
+    target: complexReference.replace('@', ''),
+  })
+
+  const complexReference2 = '@like-this_underscore'
+  const complexReferenceNode2 = cite({
+    target: complexReference2.replace('@', ''),
+  })
+
+  const alphaNumReference = '@alpha1234num'
+  const alphaNumReferenceNode = cite({
+    target: alphaNumReference.replace('@', ''),
+  })
+
+  it('encodes a cite node to markdown', async () => {
+    expect(await e(referenceNode)).toEqual(reference)
+  })
+
+  it('decodes a simple citation', async () => {
+    const ast = await d(reference)
+    expect(ast).toHaveProperty(
+      ['content', 0, 'content'],
+      expect.arrayContaining([expect.objectContaining(referenceNode)])
+    )
+  })
+
+  it('decodes a simple citation', async () => {
+    const ast = await d(reference)
+    expect(ast).toHaveProperty(
+      ['content', 0, 'content'],
+      expect.arrayContaining([expect.objectContaining(referenceNode)])
+    )
+  })
+
+  it('decodes a complex citation', async () => {
+    const ast = await d(complexReference)
+    expect(ast).toHaveProperty(
+      ['content', 0, 'content'],
+      expect.arrayContaining([expect.objectContaining(complexReferenceNode)])
+    )
+  })
+
+  it('decodes a citation with underscores', async () => {
+    const ast = await d(complexReference2)
+    expect(ast).toHaveProperty(
+      ['content', 0, 'content'],
+      expect.arrayContaining([expect.objectContaining(complexReferenceNode2)])
+    )
+  })
+
+  it('decodes an alphanumeric citation', async () => {
+    const ast = await d(alphaNumReference)
+    expect(ast).toHaveProperty(
+      ['content', 0, 'content'],
+      expect.arrayContaining([expect.objectContaining(alphaNumReferenceNode)])
+    )
+  })
+
+  it('decodes a complex paragraph', async () => {
+    const article = `# Cite test
+
+Some paragraph with a citation (${reference}) inside a paragraph.
+
+Followed by more text
+`
+
+    const ast = await d(article)
+    expect(ast).toHaveProperty(
+      ['content', 0, 'content'],
+      expect.arrayContaining([expect.objectContaining(referenceNode)])
+    )
+  })
+
+  // TODO: Encode a chain of citations into a `CiteGroup`
+  it.skip('encodes a citeGroup node to markdown', async () => {
+    const citeGroup = `some text with (@cite-group-cite1, @cite-group-cite-another) a cite`
+    const citeGroupNode = cite({
+      target: complexReference.replace('@', ''),
+    })
+
+    expect(await d(citeGroup)).toEqual(citeGroupNode)
+  })
+})

--- a/src/codecs/md/plugins/cite.ts
+++ b/src/codecs/md/plugins/cite.ts
@@ -1,0 +1,77 @@
+// Remark plugin for Citation nodes
+// Based on https://github.com/zestedesavoir/zmarkdown/blob/master/packages/remark-sub-super/src/index.js
+// Encode Pandoc style `@`-prefixed citation e.g. `@smith04` strings into a custom `Cite` MDAST node type.
+
+import { array as A, option as O } from 'fp-ts'
+import { pipe } from 'fp-ts/lib/pipeable'
+import { Eat, Locator, Parser, Tokenizer } from 'remark-parse'
+import { Plugin } from 'unified'
+
+const marker = '@'
+const CITE_REGEX = /@([\w|-]+)/
+
+const locator: Locator = (value, fromIndex) => {
+  let index = -1
+  const found = []
+  index = value.indexOf(marker, fromIndex)
+  if (index !== -1) {
+    found.push(index)
+  }
+
+  if (!A.isEmpty(found)) {
+    found.sort((a, b) => a - b)
+    return found[0]
+  }
+
+  return -1
+}
+
+export const citePlugin: Plugin<[]> = function () {
+  const inlineTokenizer: Tokenizer = function (
+    this: Parser,
+    eat: Eat,
+    value: string
+  ) {
+    // allow escaping of all markers
+    // @ts-expect-error
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+    if (!this.escape.includes(marker)) this.escape.push(marker)
+
+    const startChar = value[0]
+    // @ts-expect-error
+    const now = eat.now()
+    now.column += 1
+    now.offset += 1
+
+    if (
+      startChar === marker &&
+      !value.startsWith(marker + ' ') &&
+      !value.startsWith(marker + marker)
+    ) {
+      const citeLength = pipe(
+        CITE_REGEX.exec(value) ?? [],
+        A.head,
+        O.getOrElse(() => ''),
+        (match) => match.length
+      )
+
+      eat(value.substring(0, citeLength))({
+        type: 'cite',
+        value: value.substring(1, citeLength),
+        data: {
+          hName: 'cite',
+        },
+      })
+    }
+  }
+
+  inlineTokenizer.locator = locator
+
+  const Parser = this.Parser
+
+  // Inject inlineTokenizer
+  const inlineTokenizers = Parser.prototype.inlineTokenizers
+  const inlineMethods = Parser.prototype.inlineMethods
+  inlineTokenizers.citeRefs = inlineTokenizer
+  inlineMethods.splice(inlineMethods.indexOf('text'), 0, 'citeRefs')
+}


### PR DESCRIPTION
close #543

The underlying assumption here is that a citation reference is an alphanumeric, with optional hyphen or underscored, string, being matched by the following RegEx `/@([\w|-]+)/`. This means that the following citations are matched:

- `@simple`
- `@alpha1234num`
- `@like-this`
- "some text (*`@with-a-ref`*) like this" [the part in italics]