### PR TITLE
feat(MD): Decode citation node content from MD frontmatter

### DIFF
--- a/src/codecs/jats/index.ts
+++ b/src/codecs/jats/index.ts
@@ -20,6 +20,7 @@ import fs from 'fs-extra'
 import { isDefined } from '../../util'
 import { ensureArticle } from '../../util/content/ensureArticle'
 import { ensureInlineContentArray } from '../../util/content/ensureInlineContentArray'
+import { encodeCitationText } from '../../util/references'
 import transform from '../../util/transform'
 import * as vfile from '../../util/vfile'
 /* eslint-disable import/no-duplicates */
@@ -1078,45 +1079,6 @@ function encodeReference(
 
     return elem('ref', { id: rid }, elem('element-citation', null, ...children))
   }
-}
-
-/**
- * Create text used to cite a Stencila `CreativeWork` within
- * the content of an `Article`.
- */
-function encodeCitationText(work: stencila.CreativeWork): string {
-  const { authors, datePublished } = work
-  let citeText = ''
-
-  if (authors?.length) {
-    const people = authors.filter((p) => stencila.isA('Person', p))
-
-    if (people.length) {
-      const firstPerson = people[0] as stencila.Person
-      let secondPerson
-
-      if (firstPerson.familyNames) {
-        citeText += firstPerson.familyNames.join(' ')
-
-        if (people.length === 2) {
-          secondPerson = people[1] as stencila.Person
-          if (secondPerson.familyNames)
-            citeText += 'and ' + secondPerson.familyNames.join(' ')
-        } else if (people.length > 2) {
-          citeText += ' et al.'
-        }
-      }
-    }
-  }
-
-  if (datePublished !== undefined) {
-    const date =
-      typeof datePublished === 'string' ? datePublished : datePublished.value
-    const publishedYear = date.split('-')[0]
-    citeText += `, ${publishedYear}`
-  }
-
-  return citeText
 }
 
 // Functions for decoding / encoding content in article body

--- a/src/util/references.ts
+++ b/src/util/references.ts
@@ -1,0 +1,41 @@
+import { CreativeWork, isA, Person } from '@stencila/schema'
+import { array as A } from 'fp-ts'
+
+/**
+ * Create text used to cite a Stencila `CreativeWork` within
+ * the content of an `Article`.
+ */
+export const encodeCitationText = (work: CreativeWork): string => {
+  const { authors = [], datePublished } = work
+  let citeText = ''
+
+  if (!A.isEmpty(authors)) {
+    const people = authors.filter((p) => isA('Person', p))
+
+    if (!A.isEmpty(people)) {
+      const firstPerson = people[0] as Person
+      let secondPerson
+
+      if (firstPerson.familyNames) {
+        citeText += firstPerson.familyNames.join(' ')
+
+        if (people.length === 2) {
+          secondPerson = people[1] as Person
+          if (secondPerson.familyNames)
+            citeText += 'and ' + secondPerson.familyNames.join(' ')
+        } else if (people.length > 2) {
+          citeText += ' et al.'
+        }
+      }
+    }
+  }
+
+  if (datePublished !== undefined) {
+    const date =
+      typeof datePublished === 'string' ? datePublished : datePublished.value
+    const publishedYear = date.split('-')[0]
+    citeText += `, ${publishedYear}`
+  }
+
+  return citeText
+}


### PR DESCRIPTION
This change introduces a `context` argument for node decode functions in the Markdown codec.
The `context` object is currently populated with the JSON representation of the front matter YAML, which is then used to look up citation reference `content`.