### PR TITLE
Decode Bookdown style figure references to Block Extensions

### DIFF
--- a/src/codecs/xmd/__file_snapshots__/basic.json
+++ b/src/codecs/xmd/__file_snapshots__/basic.json
@@ -94,6 +94,72 @@
         },
         " parameter was added to the code chunk to prevent printing of the R code that generated the plot."
       ]
+    },
+    {
+      "type": "Heading",
+      "depth": 2,
+      "content": [
+        "With a figure"
+      ]
+    },
+    {
+      "type": "CodeChunk",
+      "programmingLanguage": "r",
+      "text": "# R code here",
+      "meta": {
+        "figure3,": "",
+        "fig.cap": "(ref:figure-3)"
+      }
+    },
+    {
+      "type": "Paragraph",
+      "content": [
+        "Some intermediary content"
+      ]
+    },
+    {
+      "type": "CodeChunk",
+      "programmingLanguage": "r",
+      "text": "# R code here but non-existent figure reference",
+      "meta": {
+        "figure4,": "",
+        "fig.cap": "(ref:figure-4)"
+      }
+    },
+    {
+      "type": "Paragraph",
+      "content": [
+        "And follow up with a duplicate figure reference"
+      ]
+    },
+    {
+      "type": "CodeChunk",
+      "programmingLanguage": "r",
+      "text": "# R code here",
+      "meta": {
+        "figure3,": "",
+        "fig.cap": "(ref:figure-3)"
+      }
+    },
+    {
+      "type": "Paragraph",
+      "content": [
+        "(ref:figure-3) Figure 3. ",
+        {
+          "type": "Strong",
+          "content": [
+            "Distinct and dorsoventrally organized properties of layer 2 stellate cells."
+          ]
+        },
+        "(",
+        {
+          "type": "Strong",
+          "content": [
+            "A"
+          ]
+        },
+        ") Representative action potential after hyperpolarization waveforms from a SC (left), a pyramidal cell (middle) and an unidentified cell (right). The pyramidal and unidentified cells were..."
+      ]
     }
   ]
 }

--- a/src/codecs/xmd/__fixtures__/basic.Rmd
+++ b/src/codecs/xmd/__fixtures__/basic.Rmd
@@ -26,3 +26,23 @@ plot(pressure)
 ```
 
 Note that the `echo = FALSE` parameter was added to the code chunk to prevent printing of the R code that generated the plot.
+
+## With a figure
+
+```{r figure3, fig.cap='(ref:figure-3)'}
+# R code here
+```
+
+Some intermediary content
+
+```{r figure4, fig.cap='(ref:figure-4)'}
+# R code here but non-existent figure reference
+```
+
+And follow up with a duplicate figure reference
+
+```{r figure3, fig.cap='(ref:figure-3)'}
+# R code here
+```
+
+(ref:figure-3) Figure 3. **Distinct and dorsoventrally organized properties of layer 2 stellate cells.**(**A**) Representative action potential after hyperpolarization waveforms from a SC (left), a pyramidal cell (middle) and an unidentified cell (right). The pyramidal and unidentified cells were...

--- a/src/codecs/xmd/xmd.test.ts
+++ b/src/codecs/xmd/xmd.test.ts
@@ -1,7 +1,7 @@
 import notebook from '../../__fixtures__/article/r-notebook-simple'
 import { fixture, snapshot } from '../../__tests__/helpers'
 import { JsonCodec } from '../json'
-import { XmdCodec } from './'
+import { XmdCodec, decodeFigure } from './'
 import { unlinkFiles } from '../../util/media/unlinkFiles'
 
 const jsonCodec = new JsonCodec()
@@ -21,6 +21,86 @@ describe('decode', () => {
     expect(await xmdToJson(fixture('kitchensink.Rmd'))).toMatchFile(
       snapshot('kitchensink.json')
     )
+  })
+})
+
+describe('decode - Figure references', () => {
+  const rmdFigure = `
+\`\`\`{r figure3, fig.cap='(ref:figure-3)'}
+# R code here
+
+multi
+line
+content
+\`\`\`
+(ref:figure-3) Figure 3. **Distinct and dorsoventrally organized properties of layer 2 stellate cells.** (**A**) Representative action potential after hyperpolarization waveforms from a SC (left), a pyramidal cell (middle) and an unidentified cell (right). The pyramidal and unidentified cells were both positively labelled in _Wfs1^C^_^re^ mice. (**B**) Plot of the first versus the second principal component from PCA of the properties of labelled neurons in _Wfs1_^Cre^ mice reveals two populations of neurons. (**C**) Histogram showing the distribution of rheobase values of cells positively labelled in _Wfs1_^Cre^ mice. The two groups identified in panel (B) can be distinguished by their rheobase. (**D**) Plot of the first two principal components from PCA of the properties of the L2PC (n = 44, green) and SC populations (n = 836, black). Putative pyramidal cells (x) and SCs (+) are colored according to their dorsoventral location (inset shows the scale). (**E**) Proportion of total variance explained by the first five principal components for the analysis in panel (**D**). (**F**) Histograms of the locations of recorded SCs (upper) and L2PCs (lower). (**G**) All values of measured features from all mice are plotted as a function of the dorsoventral location of the recorded cells. Lines indicate fits of a linear model to the complete datasets for SCs (black) and L2PCs (green). Putative pyramidal cells (x, green) and SCs (+, black). Adjusted R^2^ values use the same color scheme.
+`
+
+  const mdFigure = `
+figure: Figure 3.
+:::
+\`\`\`r
+# R code here
+
+multi
+line
+content
+\`\`\`
+
+**Distinct and dorsoventrally organized properties of layer 2 stellate cells.**
+
+(**A**) Representative action potential after hyperpolarization waveforms from a SC (left), a pyramidal cell (middle) and an unidentified cell (right). The pyramidal and unidentified cells were both positively labelled in _Wfs1^C^_^re^ mice. (**B**) Plot of the first versus the second principal component from PCA of the properties of labelled neurons in _Wfs1_^Cre^ mice reveals two populations of neurons. (**C**) Histogram showing the distribution of rheobase values of cells positively labelled in _Wfs1_^Cre^ mice. The two groups identified in panel (B) can be distinguished by their rheobase. (**D**) Plot of the first two principal components from PCA of the properties of the L2PC (n = 44, green) and SC populations (n = 836, black). Putative pyramidal cells (x) and SCs (+) are colored according to their dorsoventral location (inset shows the scale). (**E**) Proportion of total variance explained by the first five principal components for the analysis in panel (**D**). (**F**) Histograms of the locations of recorded SCs (upper) and L2PCs (lower). (**G**) All values of measured features from all mice are plotted as a function of the dorsoventral location of the recorded cells. Lines indicate fits of a linear model to the complete datasets for SCs (black) and L2PCs (green). Putative pyramidal cells (x, green) and SCs (+, black). Adjusted R^2^ values use the same color scheme.
+
+:::
+(ref:figure-3) Figure 3. **Distinct and dorsoventrally organized properties of layer 2 stellate cells.** (**A**) Representative action potential after hyperpolarization waveforms from a SC (left), a pyramidal cell (middle) and an unidentified cell (right). The pyramidal and unidentified cells were both positively labelled in _Wfs1^C^_^re^ mice. (**B**) Plot of the first versus the second principal component from PCA of the properties of labelled neurons in _Wfs1_^Cre^ mice reveals two populations of neurons. (**C**) Histogram showing the distribution of rheobase values of cells positively labelled in _Wfs1_^Cre^ mice. The two groups identified in panel (B) can be distinguished by their rheobase. (**D**) Plot of the first two principal components from PCA of the properties of the L2PC (n = 44, green) and SC populations (n = 836, black). Putative pyramidal cells (x) and SCs (+) are colored according to their dorsoventral location (inset shows the scale). (**E**) Proportion of total variance explained by the first five principal components for the analysis in panel (**D**). (**F**) Histograms of the locations of recorded SCs (upper) and L2PCs (lower). (**G**) All values of measured features from all mice are plotted as a function of the dorsoventral location of the recorded cells. Lines indicate fits of a linear model to the complete datasets for SCs (black) and L2PCs (green). Putative pyramidal cells (x, green) and SCs (+, black). Adjusted R^2^ values use the same color scheme.
+
+`
+
+  it('decodes a simple Figure reference', () => {
+    expect(decodeFigure(rmdFigure)).toEqualStringContent(mdFigure)
+  })
+
+  it('selects the correct Figure reference', () => {
+    const rmdWithMultiReferences = `
+\`\`\`{r figure3, fig.cap='(ref:figure-3)'}
+# R code here
+
+multi
+line
+content
+\`\`\`
+(ref:figure-3) Figure 3. **Distinct and dorsoventrally organized properties of layer 2 stellate cells.** (**A**) Representative action potential after hyperpolarization waveforms from a SC (left), a pyramidal cell (middle) and an unidentified cell (right). The pyramidal and unidentified cells were both positively labelled in _Wfs1^C^_^re^ mice. (**B**) Plot of the first versus the second principal component from PCA of the properties of labelled neurons in _Wfs1_^Cre^ mice reveals two populations of neurons. (**C**) Histogram showing the distribution of rheobase values of cells positively labelled in _Wfs1_^Cre^ mice. The two groups identified in panel (B) can be distinguished by their rheobase. (**D**) Plot of the first two principal components from PCA of the properties of the L2PC (n = 44, green) and SC populations (n = 836, black). Putative pyramidal cells (x) and SCs (+) are colored according to their dorsoventral location (inset shows the scale). (**E**) Proportion of total variance explained by the first five principal components for the analysis in panel (**D**). (**F**) Histograms of the locations of recorded SCs (upper) and L2PCs (lower). (**G**) All values of measured features from all mice are plotted as a function of the dorsoventral location of the recorded cells. Lines indicate fits of a linear model to the complete datasets for SCs (black) and L2PCs (green). Putative pyramidal cells (x, green) and SCs (+, black). Adjusted R^2^ values use the same color scheme.
+(ref:figure-4) Figure 4. **Distinct and dorsoventrally organized properties of layer 2 stellate cells.** (**A**) Representative action potential after hyperpolarization waveforms from a SC (left), a pyramidal cell (middle) and an unidentified cell (right). The pyramidal and unidentified cells were both positively labelled in _Wfs1^C^_^re^ mice. (**B**) Plot of the first versus the second principal component from PCA of the properties of labelled neurons in _Wfs1_^Cre^ mice reveals two populations of neurons. (**C**) Histogram showing the distribution of rheobase values of cells positively labelled in _Wfs1_^Cre^ mice. The two groups identified in panel (B) can be distinguished by their rheobase. (**D**) Plot of the first two principal components from PCA of the properties of the L2PC (n = 44, green) and SC populations (n = 836, black). Putative pyramidal cells (x) and SCs (+) are colored according to their dorsoventral location (inset shows the scale). (**E**) Proportion of total variance explained by the first five principal components for the analysis in panel (**D**). (**F**) Histograms of the locations of recorded SCs (upper) and L2PCs (lower). (**G**) All values of measured features from all mice are plotted as a function of the dorsoventral location of the recorded cells. Lines indicate fits of a linear model to the complete datasets for SCs (black) and L2PCs (green). Putative pyramidal cells (x, green) and SCs (+, black). Adjusted R^2^ values use the same color scheme.
+`
+    expect(decodeFigure(rmdWithMultiReferences)).toMatch('figure: Figure 3.')
+  })
+
+  it('encodes even when a reference cannot be resolved', () => {
+    const rmdWithNoReferences = `
+\`\`\`{r figure3, fig.cap='(ref:figure-3)'}
+# R code here
+
+multi
+line
+content
+\`\`\`
+`
+
+    const emptyMd = `
+figure: figure-3
+:::
+\`\`\`r
+# R code here
+
+multi
+line
+content
+\`\`\`
+
+:::
+`
+
+    expect(decodeFigure(rmdWithNoReferences)).toEqualStringContent(emptyMd)
   })
 })
 


### PR DESCRIPTION
Close #591

Note that the references elements are not removed, so there is potential to end up with duplicate reference nodes. This was done to ensure that any references from other (non code-figures) are still able to be resolved.