### PR TITLE
feat(MD): Encode references in a separate file

### DIFF
--- a/src/codecs/bib/__file_snapshots__/article.bib
+++ b/src/codecs/bib/__file_snapshots__/article.bib
@@ -1,4 +1,4 @@
-@article{Smith2010title,
+@article{8f158a4ee8ad354b3a235913cd5d1008,
 	journal = {A journal},
 	title = {The title of the article},
 	volume = {10},

--- a/src/codecs/bib/__file_snapshots__/article.bib
+++ b/src/codecs/bib/__file_snapshots__/article.bib
@@ -1,4 +1,4 @@
-@article{8f158a4ee8ad354b3a235913cd5d1008,
+@article{bibTestId,
 	journal = {A journal},
 	title = {The title of the article},
 	volume = {10},

--- a/src/codecs/bib/__file_snapshots__/small.yaml
+++ b/src/codecs/bib/__file_snapshots__/small.yaml
@@ -1,19 +1,19 @@
-type: Article
-id: articleid
-authors:
-  - type: Person
-    familyNames:
-      - Einstein
-    givenNames:
-      - Albert
-datePublished: '1924'
-isPartOf:
-  type: PublicationIssue
+- type: Article
+  id: articleid
+  authors:
+    - type: Person
+      familyNames:
+        - Einstein
+      givenNames:
+        - Albert
+  datePublished: '1924'
   isPartOf:
-    type: PublicationVolume
+    type: PublicationIssue
     isPartOf:
-      type: Periodical
-      title: The journal of small papers
-    volumeNumber: '10'
-  issueNumber: '9'
-title: A small paper
+      type: PublicationVolume
+      isPartOf:
+        type: Periodical
+        title: The journal of small papers
+      volumeNumber: '10'
+    issueNumber: '9'
+  title: A small paper

--- a/src/codecs/bib/__fixtures__/article.yaml
+++ b/src/codecs/bib/__fixtures__/article.yaml
@@ -1,5 +1,6 @@
 type: Article
 title: The title of the article
+id: bibTestId
 authors:
   - type: Person
     familyNames:

--- a/src/codecs/csl/__file_snapshots__/10.5334-jors-182.yaml
+++ b/src/codecs/csl/__file_snapshots__/10.5334-jors-182.yaml
@@ -1,20 +1,20 @@
-type: Article
-authors:
-  - type: Person
-    familyNames:
-      - Carlsson
-    givenNames:
-      - Kristoffer
-  - type: Person
-    familyNames:
-      - Ekre
-    givenNames:
-      - Fredrik
-datePublished: '2019'
-isPartOf:
-  type: PublicationVolume
+- type: Article
+  authors:
+    - type: Person
+      familyNames:
+        - Carlsson
+      givenNames:
+        - Kristoffer
+    - type: Person
+      familyNames:
+        - Ekre
+      givenNames:
+        - Fredrik
+  datePublished: '2019'
   isPartOf:
-    type: Periodical
-    title: Journal of Open Research Software
-  volumeNumber: '7'
-title: Tensors.jl — Tensor Computations in Julia
+    type: PublicationVolume
+    isPartOf:
+      type: Periodical
+      title: Journal of Open Research Software
+    volumeNumber: '7'
+  title: Tensors.jl — Tensor Computations in Julia

--- a/src/codecs/csl/__file_snapshots__/article.csl.json
+++ b/src/codecs/csl/__file_snapshots__/article.csl.json
@@ -1,6 +1,7 @@
 {
   "type": "article-journal",
   "id": "articleId",
+  "citation-label": "articleId",
   "title": "The title of the article",
   "author": [
     {

--- a/src/codecs/doi/__file_snapshots__/10.5334-jors-182.yaml
+++ b/src/codecs/doi/__file_snapshots__/10.5334-jors-182.yaml
@@ -1,20 +1,20 @@
-type: Article
-authors:
-  - type: Person
-    familyNames:
-      - Carlsson
-    givenNames:
-      - Kristoffer
-  - type: Person
-    familyNames:
-      - Ekre
-    givenNames:
-      - Fredrik
-datePublished: '2019'
-isPartOf:
-  type: PublicationVolume
+- type: Article
+  authors:
+    - type: Person
+      familyNames:
+        - Carlsson
+      givenNames:
+        - Kristoffer
+    - type: Person
+      familyNames:
+        - Ekre
+      givenNames:
+        - Fredrik
+  datePublished: '2019'
   isPartOf:
-    type: Periodical
-    title: Journal of Open Research Software
-  volumeNumber: '7'
-title: Tensors.jl — Tensor Computations in Julia
+    type: PublicationVolume
+    isPartOf:
+      type: Periodical
+      title: Journal of Open Research Software
+    volumeNumber: '7'
+  title: Tensors.jl — Tensor Computations in Julia

--- a/src/codecs/md/__file_snapshots__/mdReferences.md
+++ b/src/codecs/md/__file_snapshots__/mdReferences.md
@@ -1,0 +1,6 @@
+---
+title: MD Reference Test
+references: src/codecs/md/__file_snapshots__/mdReferences.references.bib
+---
+
+This is only a test

--- a/src/codecs/md/__file_snapshots__/mdReferences.references.bib
+++ b/src/codecs/md/__file_snapshots__/mdReferences.references.bib
@@ -1,0 +1,24 @@
+@article{1,
+	title = {Test article 1},
+}
+
+@article{2,
+	title = {Test article 2},
+}
+
+@article{3,
+	title = {Test article 3},
+}
+
+@article{4,
+	title = {Test article 4},
+}
+
+@article{5,
+	title = {Test article 5},
+}
+
+@article{6,
+	title = {Test article 6},
+}
+

--- a/src/codecs/md/__fixtures__/mdReferences.references.bib
+++ b/src/codecs/md/__fixtures__/mdReferences.references.bib
@@ -1,0 +1,24 @@
+@article{1,
+	title = {Test article 1},
+}
+
+@article{2,
+	title = {Test article 2},
+}
+
+@article{3,
+	title = {Test article 3},
+}
+
+@article{4,
+	title = {Test article 4},
+}
+
+@article{5,
+	title = {Test article 5},
+}
+
+@article{6,
+	title = {Test article 6},
+}
+

--- a/src/codecs/md/index.ts
+++ b/src/codecs/md/index.ts
@@ -55,6 +55,7 @@ import { TxtCodec } from '../txt'
 import { Codec, CommonDecodeOptions, CommonEncodeOptions } from '../types'
 import { citePlugin } from './plugins/cite'
 import { stringifyHTML } from './stringifyHtml'
+import { STDIO_PATH } from '../..'
 
 const texCodec = new TexCodec()
 const bibCodec = new BibCodec()
@@ -321,7 +322,7 @@ async function extractReferences(
   if (article.references.length <= referenceExtractionThreshold) return article
 
   // If the encoding target is being written to disk, extract references to a separate file
-  if (options.filePath) {
+  if (options.filePath && options.filePath !== STDIO_PATH) {
     const targetPath = path.parse(options.filePath)
     targetPath.ext = '.references.bib'
     delete targetPath.base

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,12 @@ const log = getLogger('encoda')
 type VFile = vfile.VFile
 
 /**
+ * To read or write from the STDIO a special `filePath` value of `-` can
+ * be used with several of the encode/decode functions.
+ */
+export const STDIO_PATH = '-'
+
+/**
  * A list of all codecs.
  *
  * Note that order is of importance for matching. More "generic"
@@ -347,7 +353,7 @@ export async function convert(
 
   const node = await read(input, from, decodeOptions)
 
-  if (outputPaths === undefined) outputPaths = ['-']
+  if (outputPaths === undefined) outputPaths = [STDIO_PATH]
   else if (typeof outputPaths === 'string') outputPaths = [outputPaths]
 
   let index = 0
@@ -359,7 +365,7 @@ export async function convert(
     // This avoids calling `preWrite` which may create files
     // which we don't if outputting to stdout. Instead `preDump`
     // will get called which bundles media files etc.
-    if (outputPath === '-') {
+    if (outputPath === STDIO_PATH) {
       const content = await dump(node, to ?? 'txt', encodeOptions)
       console.log(content)
       if (outputPaths.length > 0) return content


### PR DESCRIPTION
Close #589

This PR implements a feature to extract references into a `<filename>.references.bib` file next to the Markdown file.
This is only done when the article contains more than 5 references.
Converting back from MD attempts to read in this references file again.