### PR TITLE
fix(HTML): Fix encoding of missing nomodule attribute

### DIFF
--- a/src/codecs/html/__file_snapshots__/elife-50356.html
+++ b/src/codecs/html/__file_snapshots__/elife-50356.html
@@ -15,7 +15,7 @@
       type="module"></script>
     <script
       src="https://unpkg.com/@stencila/components@&lt;=1/dist/stencila-components/stencila-components.js"
-      type="text/javascript"></script>
+      type="text/javascript" nomodule=""></script>
   </head>
 
   <body>

--- a/src/codecs/html/__file_snapshots__/jupyter-notebook-simple.html
+++ b/src/codecs/html/__file_snapshots__/jupyter-notebook-simple.html
@@ -14,7 +14,7 @@
       type="module"></script>
     <script
       src="https://unpkg.com/@stencila/components@&lt;=1/dist/stencila-components/stencila-components.js"
-      type="text/javascript"></script>
+      type="text/javascript" nomodule=""></script>
   </head>
 
   <body>

--- a/src/codecs/html/__file_snapshots__/kitchen-sink-article.html
+++ b/src/codecs/html/__file_snapshots__/kitchen-sink-article.html
@@ -14,7 +14,7 @@
       type="module"></script>
     <script
       src="https://unpkg.com/@stencila/components@&lt;=1/dist/stencila-components/stencila-components.js"
-      type="text/javascript"></script>
+      type="text/javascript" nomodule=""></script>
   </head>
 
   <body>

--- a/src/codecs/html/__file_snapshots__/math-article.html
+++ b/src/codecs/html/__file_snapshots__/math-article.html
@@ -14,7 +14,7 @@
       type="module"></script>
     <script
       src="https://unpkg.com/@stencila/components@&lt;=1/dist/stencila-components/stencila-components.js"
-      type="text/javascript"></script>
+      type="text/javascript" nomodule=""></script>
   </head>
 
   <body>

--- a/src/codecs/html/__file_snapshots__/plosone-0229075.html
+++ b/src/codecs/html/__file_snapshots__/plosone-0229075.html
@@ -15,7 +15,7 @@
       type="module"></script>
     <script
       src="https://unpkg.com/@stencila/components@&lt;=1/dist/stencila-components/stencila-components.js"
-      type="text/javascript"></script>
+      type="text/javascript" nomodule=""></script>
   </head>
 
   <body>

--- a/src/codecs/html/__file_snapshots__/python-code-chunk.html
+++ b/src/codecs/html/__file_snapshots__/python-code-chunk.html
@@ -14,7 +14,7 @@
       type="module"></script>
     <script
       src="https://unpkg.com/@stencila/components@&lt;=1/dist/stencila-components/stencila-components.js"
-      type="text/javascript"></script>
+      type="text/javascript" nomodule=""></script>
   </head>
 
   <body>

--- a/src/codecs/html/__file_snapshots__/r-code-chunk-image-output.html
+++ b/src/codecs/html/__file_snapshots__/r-code-chunk-image-output.html
@@ -14,7 +14,7 @@
       type="module"></script>
     <script
       src="https://unpkg.com/@stencila/components@&lt;=1/dist/stencila-components/stencila-components.js"
-      type="text/javascript"></script>
+      type="text/javascript" nomodule=""></script>
   </head>
 
   <body>

--- a/src/codecs/html/__file_snapshots__/r-code-expression.html
+++ b/src/codecs/html/__file_snapshots__/r-code-expression.html
@@ -14,7 +14,7 @@
       type="module"></script>
     <script
       src="https://unpkg.com/@stencila/components@&lt;=1/dist/stencila-components/stencila-components.js"
-      type="text/javascript"></script>
+      type="text/javascript" nomodule=""></script>
   </head>
 
   <body>

--- a/src/codecs/html/__file_snapshots__/r-notebook-simple.html
+++ b/src/codecs/html/__file_snapshots__/r-notebook-simple.html
@@ -14,7 +14,7 @@
       type="module"></script>
     <script
       src="https://unpkg.com/@stencila/components@&lt;=1/dist/stencila-components/stencila-components.js"
-      type="text/javascript"></script>
+      type="text/javascript" nomodule=""></script>
   </head>
 
   <body>

--- a/src/codecs/html/index.ts
+++ b/src/codecs/html/index.ts
@@ -666,7 +666,9 @@ async function generateHtmlElement(
         type: 'module',
       }),
       h('script', {
-        nomodule: '',
+        attrs: {
+          nomodule: '',
+        },
         src:
           'https://unpkg.com/@stencila/components@<=1/dist/stencila-components/stencila-components.js',
         type: 'text/javascript',


### PR DESCRIPTION
Ensure that the ES5 script tag of Stencila Components is not loaded for modern browsers.