### PR TITLE
fix(Markdown): Handle embedded inline HTML properly

### DIFF
--- a/src/__tests__/issues/747-md-inline-html.ts
+++ b/src/__tests__/issues/747-md-inline-html.ts
@@ -1,0 +1,78 @@
+import schema from '@stencila/schema'
+
+import { HTMLCodec } from '../../codecs/html'
+import { MdCodec } from '../../codecs/md'
+
+/**
+ * See https://github.com/stencila/encoda/issues/747
+ *
+ * Turns out that this was not a problem with the `html` codec but rather
+ * with the `md` codec that was converting embedded inline HTML into an array of
+ * nodes (which were then not getting translated to HTML properly).
+ */
+describe('issue 747: rendering of Superscript nodes in HTML', () => {
+  const htmlCodec = new HTMLCodec()
+  const mdCodec = new MdCodec()
+
+  test('HTML codec dumps a superscript as expected', async () => {
+    // The HTML codec actually works fine when dumping superscripts
+    expect(
+      await htmlCodec.dump(
+        schema.paragraph({
+          content: ['R', schema.superscript({ content: ['2'] }), '.']
+        })
+      )
+    ).toBe(
+      `<p itemscope="" itemtype="http://schema.stenci.la/Paragraph" data-itemscope="root">R<sup
+    itemscope="" itemtype="http://schema.stenci.la/Superscript">2</sup>.</p>`
+    )
+  })
+
+  test('Markdown codec loads a HTML superscript as expected', async () => {
+    // The Markdown codec works fine when loading a simple superscript
+    const article = (await mdCodec.load('R<sup>2</sup>.')) as schema.Article
+    expect(article?.content?.[0] || '').toEqual(
+      schema.paragraph({
+        content: ['R', schema.superscript({ content: ['2'] }), '.']
+      })
+    )
+  })
+
+  test('Markdown codec loads two HTML superscripts in a paragraph', async () => {
+    // But when there are two superscripts in an array, the second one and
+    // any following content gets wrapped into an array and the following content
+    // is also repeated.
+    const article = (await mdCodec.load(
+      `First <sup>1</sup> second <sup>2</sup> after.`
+    )) as schema.Article
+    expect(article.content?.[0] || '').toEqual(
+      schema.paragraph({
+        content: [
+          'First ',
+          schema.superscript({ content: ['1'] }),
+          ' second ',
+          schema.superscript({ content: ['2'] }),
+          '.'
+        ]
+      })
+    )
+  })
+
+  test('Markdown codec loads two HTML links in a paragraph', async () => {
+    // The same happens with other tags e.g. <a>.
+    const article = (await mdCodec.load(
+      `First <a href="a1">1</a> second <a href="a2">2</a> after.`
+    )) as schema.Article
+    expect(article.content?.[0] || '').toEqual(
+      schema.paragraph({
+        content: [
+          'First ',
+          schema.link({ content: ['1'], target: 'a1' }),
+          ' second ',
+          schema.link({ content: ['2'], target: 'a2' }),
+          '.'
+        ]
+      })
+    )
+  })
+})

--- a/src/__tests__/issues/747-md-inline-html.ts
+++ b/src/__tests__/issues/747-md-inline-html.ts
@@ -19,7 +19,7 @@ describe('issue 747: rendering of Superscript nodes in HTML', () => {
     expect(
       await htmlCodec.dump(
         schema.paragraph({
-          content: ['R', schema.superscript({ content: ['2'] }), '.']
+          content: ['R', schema.superscript({ content: ['2'] }), '.'],
         })
       )
     ).toBe(
@@ -33,7 +33,7 @@ describe('issue 747: rendering of Superscript nodes in HTML', () => {
     const article = (await mdCodec.load('R<sup>2</sup>.')) as schema.Article
     expect(article?.content?.[0] || '').toEqual(
       schema.paragraph({
-        content: ['R', schema.superscript({ content: ['2'] }), '.']
+        content: ['R', schema.superscript({ content: ['2'] }), '.'],
       })
     )
   })
@@ -52,8 +52,8 @@ describe('issue 747: rendering of Superscript nodes in HTML', () => {
           schema.superscript({ content: ['1'] }),
           ' second ',
           schema.superscript({ content: ['2'] }),
-          '.'
-        ]
+          ' after.',
+        ],
       })
     )
   })
@@ -70,8 +70,8 @@ describe('issue 747: rendering of Superscript nodes in HTML', () => {
           schema.link({ content: ['1'], target: 'a1' }),
           ' second ',
           schema.link({ content: ['2'], target: 'a2' }),
-          '.'
-        ]
+          ' after.',
+        ],
       })
     )
   })

--- a/src/__tests__/matchers.ts
+++ b/src/__tests__/matchers.ts
@@ -1,5 +1,5 @@
 import stencila from '@stencila/schema'
-import '@testing-library/jest-dom/extend-expect'
+import '@testing-library/jest-dom'
 import fs from 'fs-extra'
 import diff from 'jest-diff'
 import { toMatchFile } from 'jest-file-snapshot'

--- a/src/codecs/ipynb/__file_snapshots__/meta-analysis.json
+++ b/src/codecs/ipynb/__file_snapshots__/meta-analysis.json
@@ -6021,29 +6021,19 @@
           ]
         },
         " to fit a mixed-effect (ME) model to the data reported for each measure. In this way, we can estimate an overall interval of R",
-        [
-          {
-            "type": "Superscript",
-            "content": [
-              "2"
-            ]
-          },
-          " values based on the effect sizes and the sample sizes. We can also estimate the interval of R",
-          {
-            "type": "Superscript",
-            "content": []
-          }
-        ],
+        {
+          "type": "Superscript",
+          "content": [
+            "2"
+          ]
+        },
         " values based on the effect sizes and the sample sizes. We can also estimate the interval of R",
-        [
-          {
-            "type": "Superscript",
-            "content": [
-              "2"
-            ]
-          },
-          " that we can expect in future studies (this is called prediction interval). A compact way to represent these results is given by forest plots: for each study, we represent the effect size and the related sample size using a square and a horizontal error bar; then for each measure, we represent the results from the ME model using a diamond and an additional error bar; finally to represent the prediction interval we use two hourglasses and a dotted line."
-        ],
+        {
+          "type": "Superscript",
+          "content": [
+            "2"
+          ]
+        },
         " that we can expect in future studies (this is called prediction interval). A compact way to represent these results is given by forest plots: for each study, we represent the effect size and the related sample size using a square and a horizontal error bar; then for each measure, we represent the results from the ME model using a diamond and an additional error bar; finally to represent the prediction interval we use two hourglasses and a dotted line."
       ]
     },
@@ -15119,7 +15109,7 @@
         "execution_count": 12
       }
     },
-    null,
+    0,
     {
       "type": "Paragraph",
       "content": [

--- a/src/codecs/ipynb/__file_snapshots__/running-code.json
+++ b/src/codecs/ipynb/__file_snapshots__/running-code.json
@@ -49,7 +49,7 @@
           "text": "Shift-Enter"
         },
         " or pressing the ",
-        "button in the toolbar above:",
+        "",
         " button in the toolbar above:"
       ]
     },

--- a/src/codecs/md/stringifyHtml.ts
+++ b/src/codecs/md/stringifyHtml.ts
@@ -106,13 +106,16 @@ export const stringifyHTML = (tree: Node | Parent): Node => {
       if (node.type === 'html' && typeof node.value === 'string') {
         // Find the node index containing corresponding closing HTML tag.
         const subsequentNodes = A.dropLeft(idx)(tree.children)
-        const closingTagIdx = getClosingTagIdx(subsequentNodes)
+        const closingTagIdx = O.getOrElse(() => 0)(
+          getClosingTagIdx(subsequentNodes)
+        )
 
         // If we couldn't find the final closing tag in this Node, don't skip any Nodes
-        skipUntil = O.getOrElse(() => 0)(closingTagIdx) + idx
+        skipUntil = closingTagIdx + idx
 
         // Now that we know where in the list of the children the HTML start and end, we can merge their values
-        const subSet = A.takeLeft(skipUntil)(subsequentNodes)
+        // `closingTagIdx` is zero based, so add 1 to translate to the number of elements we want to take
+        const subSet = A.takeLeft(closingTagIdx + 1)(subsequentNodes)
         return [...innerTree, fullHtmlNode(joinHTML(subSet))]
       }
 


### PR DESCRIPTION
This is a PR to fix #747. @alex-ketch I have set up some tests that narrow down the issue. I am pretty sure it has something to do with the [`stringifyHtml`](https://github.com/stencila/encoda/blob/47f39014a26afaf9a2e8145806c0f90565dd5d79/src/codecs/md/stringifyHtml.ts#L89) function (or related functions). Could you take this over please.

