### PR TITLE
fix(HTML): Use innerHTML to avoid escaping in JSON

### DIFF
--- a/src/__tests__/issues/749-plotly-html-tags.ts
+++ b/src/__tests__/issues/749-plotly-html-tags.ts
@@ -1,0 +1,37 @@
+import schema from '@stencila/schema'
+import { JSDOM } from 'jsdom'
+
+import { HTMLCodec } from '../../codecs/html'
+import { plotlyMediaType } from '../../codecs/plotly'
+
+/**
+ * See https://github.com/stencila/encoda/issues/749
+ */
+test('issue 749: encoding of JSON data', async () => {
+  const html = await new HTMLCodec().dump(
+    schema.imageObject({
+      contentUrl: '',
+      content: [
+        {
+          mediaType: plotlyMediaType,
+          data: [
+            {
+              x: [1, 2, 3],
+              y: [0, 1, 0],
+              labels: {
+                x: 'R <sup>2</sup>',
+              },
+              title:
+                'Figure 3: R <sup>2</sup> between MRI and histology across measures',
+            },
+          ],
+        },
+      ],
+    })
+  )
+  const dom = new JSDOM(html).window.document.documentElement
+  const script = dom.querySelector(`script[type="${plotlyMediaType}"`)
+  expect(script).toHaveTextContent(
+    '[{"x":[1,2,3],"y":[0,1,0],"labels":{"x":"R <sup>2</sup>"},"title":"Figure 3: R <sup>2</sup> between MRI and histology across measures"}]'
+  )
+})

--- a/src/codecs/html/index.ts
+++ b/src/codecs/html/index.ts
@@ -2423,13 +2423,10 @@ function encodeImageObjectPlotly(
     'stencila-image-plotly',
     h(
       'picture',
-      h(
-        'script',
-        {
-          type: plotlyMediaType,
-        },
-        JSON.stringify(data)
-      ),
+      h('script', {
+        type: plotlyMediaType,
+        innerHTML: JSON.stringify(data),
+      }),
       encodeImageObject(image, false)
     )
   )


### PR DESCRIPTION
Closes #749
