### PR TITLE
Fix rpng generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,17 +226,14 @@ encoda convert paragraph.md - --to yaml
 
 Use the `--zip` option to create a Zip archive with the outputs of conversion. With `--zip=yes` a zip archive will always be created. With `--zip=maybe`, a zip archive will be created if there are more than two output files. This can be useful for formats such as HTML and Markdown, for which images and other media are stored in a sibling folder.
 
-| Option    | Description                                                                                         |
-| --------- | --------------------------------------------------------------------------------------------------- |
-| `--from`  | The format of the input content e.g. `--from md`                                                    |
-| `--to`    | The format for the output content e.g. `--to html`                                                  |
-| `--theme` | The theme for the output (only applies to HTML, PDF and RPNG output) e.g. `--theme eLife`. Either a |
-
-[Thema theme name](https://github.com/stencila/thema#available-themes) or a path/URL to a directory containing a
-`styles.css` and a `index.js` file. |
-| `--standalone` | Generate a standalone document, not a fragment (default `true`) |
-| `--bundle` | Bundle all assets (e.g images, CSS and JS) into the document (default `false`) |
-| `--debug` | Print debugging information |
+| Option         | Description                                                                                                                                                                                                                                              |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--from`       | The format of the input content e.g. `--from md`                                                                                                                                                                                                         |
+| `--to`         | The format for the output content e.g. `--to html`                                                                                                                                                                                                       |
+| `--theme`      | The theme for the output (only applies to HTML, PDF and RPNG output) e.g. `--theme eLife`. Either a [Thema theme name](https://github.com/stencila/thema#available-themes) or a path/URL to a directory containing a `styles.css` and a `index.js` file. |
+| `--standalone` | Generate a standalone document, not a fragment (default `true`)                                                                                                                                                                                          |
+| `--bundle`     | Bundle all assets (e.g images, CSS and JS) into the document (default `false`)                                                                                                                                                                           |
+| `--debug`      | Print debugging information                                                                                                                                                                                                                              |
 
 ### Using with Executa
 

--- a/src/codecs/png/index.ts
+++ b/src/codecs/png/index.ts
@@ -127,7 +127,7 @@ export class PngCodec extends Codec implements Codec {
       if (elem === null)
         throw new Error(`No element found matching selector: ${cssSelector}`)
       const boundingBox = await elem.boundingBox()
-      const viewPort = page.viewport()
+
       buffer = await elem.screenshot({
         encoding: 'binary',
         ...(size !== undefined && boundingBox !== null
@@ -135,12 +135,8 @@ export class PngCodec extends Codec implements Codec {
               clip: {
                 x: boundingBox.x,
                 y: boundingBox.y,
-                width: viewPort
-                  ? Math.min(boundingBox.width, viewPort.width)
-                  : boundingBox.width,
-                height: viewPort
-                  ? Math.min(boundingBox.height, viewPort.height)
-                  : boundingBox.height,
+                width: Math.round(boundingBox.width),
+                height: Math.round(boundingBox.height),
               },
             }
           : {}),

--- a/src/codecs/rpng/index.ts
+++ b/src/codecs/rpng/index.ts
@@ -121,6 +121,7 @@ export class RpngCodec extends Codec implements Codec {
     const png = await pngCodec.encode(node, {
       ...options,
       theme: 'rpng',
+      isStandalone: false,
       selector,
     })
     const buffer = await vfile.dump(png, 'buffer')


### PR DESCRIPTION
This PR relates to https://github.com/stencila/thema/pull/294.
Screenshot dimensions are now determined by the node size, rather than the browser viewport.