### PR TITLE
HTML: Encode DOI & other identifiers into References section

### DIFF
--- a/src/__fixtures__/article/journal/elife/30274.json
+++ b/src/__fixtures__/article/journal/elife/30274.json
@@ -422,6 +422,20 @@
         "type": "Date",
         "value": "2006"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1136/bmj.332.7549.1080"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 16675816
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -459,6 +473,20 @@
         "type": "Date",
         "value": "1948"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1136/jcp.1.5.288"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 16810816
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -501,12 +529,24 @@
           "givenNames": [
             "M"
           ]
+        },
+        {
+          "type": "Organization",
+          "name": "Reproducibility Project: Cancer Biology"
         }
       ],
       "datePublished": {
         "type": "Date",
         "value": "2015"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.7554/eLife.04024"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -535,6 +575,14 @@
         "type": "Date",
         "value": "1983"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1177/014662168300700301"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -718,6 +766,14 @@
         "type": "Date",
         "value": "2015"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.18632/oncotarget.6568"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -793,6 +849,14 @@
         "type": "Date",
         "value": "2014"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.7554/eLife.04333"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -956,6 +1020,20 @@
         "type": "Date",
         "value": "2016"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1038/ncomms11903"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 27301576
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -993,6 +1071,14 @@
         "type": "Date",
         "value": "2006"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1198/000313006X152649"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -1059,6 +1145,14 @@
         "type": "Date",
         "value": "2014"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.18632/oncotarget.3033"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -1155,6 +1249,20 @@
         "type": "Date",
         "value": "2004"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1038/sj.bjc.6601405"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 14735196
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -1437,6 +1545,20 @@
         "type": "Date",
         "value": "2015"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1038/nature14985"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 26331541
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -1503,6 +1625,14 @@
         "type": "Date",
         "value": "2007"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.2144/000112598"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -1659,6 +1789,20 @@
         "type": "Date",
         "value": "2016"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1038/srep28994"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 27456714
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -1759,6 +1903,20 @@
         "type": "Date",
         "value": "2010"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1038/nrg2825"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 20838408
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -1879,6 +2037,14 @@
         "type": "Date",
         "value": "2017"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.17605/OSF.IO/MOKEB"
+        }
+      ],
       "isPartOf": {
         "type": "Periodical",
         "name": "Open Science Framework"
@@ -1966,6 +2132,20 @@
         "type": "Date",
         "value": "2012"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1016/j.cell.2012.08.026"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 23021215
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2078,6 +2258,20 @@
         "type": "Date",
         "value": "2016"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.7554/eLife.15161"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 27460974
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2205,6 +2399,20 @@
         "type": "Date",
         "value": "2012"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1016/j.cell.2012.08.033"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 23021216
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2253,6 +2461,14 @@
         "type": "Date",
         "value": "1991"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1021/bp00012a600"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2301,6 +2517,20 @@
         "type": "Date",
         "value": "2011"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1038/nn.2886"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 21878926
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2412,6 +2642,20 @@
         "type": "Date",
         "value": "2015"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1016/j.molcel.2015.03.005"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 25866248
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2541,6 +2785,20 @@
         "type": "Date",
         "value": "2000"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1002/1097-0215(20000915)87:6<787::AID-IJC4>3.0.CO;2-6"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 10956386
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2571,6 +2829,14 @@
         "type": "Date",
         "value": "1959"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1080/01621459.1959.10501526"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2625,6 +2891,20 @@
         "type": "Date",
         "value": "2014"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1101/cshperspect.a014191"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 24492846
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2816,6 +3096,20 @@
         "type": "Date",
         "value": "2014"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1038/nature13537"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 25043028
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2918,6 +3212,20 @@
         "type": "Date",
         "value": "2005"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1038/sj.onc.1208198"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 15516975
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2966,6 +3274,20 @@
         "type": "Date",
         "value": "2012"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1038/nmeth.2089"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 22930834
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -3059,6 +3381,20 @@
         "type": "Date",
         "value": "1999"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1016/S0960-9822(99)80507-7"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 10556095
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -3737,6 +4073,20 @@
         "type": "Date",
         "value": "2016"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1038/srep32249"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 27577089
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -3838,6 +4188,20 @@
         "type": "Date",
         "value": "2011"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1007/s11121-011-0217-6"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 21541692
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -3868,6 +4232,14 @@
         "type": "Date",
         "value": "2010"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.18637/jss.v036.i03"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -4061,6 +4433,20 @@
         "type": "Date",
         "value": "2014"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1038/nature13473"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 25043018
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {

--- a/src/__fixtures__/article/journal/elife/50356.json
+++ b/src/__fixtures__/article/journal/elife/50356.json
@@ -354,6 +354,20 @@
         "type": "Date",
         "value": "2018"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1016/j.ejim.2018.01.001"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 29329891
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -402,6 +416,14 @@
         "type": "Date",
         "value": "1983"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1152/ajpendo.1983.244.2.E177"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -457,6 +479,20 @@
         "type": "Date",
         "value": "2019"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1186/s12906-019-2431-x"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 30646891
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -575,6 +611,20 @@
         "type": "Date",
         "value": "2015"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1073/pnas.1507931112"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 26199416
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -632,6 +682,20 @@
         "type": "Date",
         "value": "2004"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1073/pnas.0403663101"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 15256593
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -770,6 +834,20 @@
         "type": "Date",
         "value": "2017"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1038/nm.4311"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 28481360
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -863,6 +941,20 @@
         "type": "Date",
         "value": "2015"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1097/01.j.pain.0000460347.77341.bd"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 25789436
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -938,6 +1030,20 @@
         "type": "Date",
         "value": "2011"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1016/j.biopsych.2011.04.022"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 21684528
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -1031,6 +1137,20 @@
         "type": "Date",
         "value": "2018"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1038/npp.2017.175"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 28816239
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -1088,6 +1208,20 @@
         "type": "Date",
         "value": "2012"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1371/journal.pone.0035538"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 22514749
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -1161,6 +1295,20 @@
         "type": "Date",
         "value": "2001"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1136/bmj.323.7303.13"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 11440935
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -1234,6 +1382,14 @@
         "type": "Date",
         "value": "2006"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1016/j.neuropharm.2005.11.017"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -1354,6 +1510,20 @@
         "type": "Date",
         "value": "2017"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1038/nm.4262"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 28092666
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -1429,6 +1599,20 @@
         "type": "Date",
         "value": "2019"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1126/science.aap8586"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 30655440
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -1504,6 +1688,20 @@
         "type": "Date",
         "value": "2016"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1038/nrn.2016.28"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 27052382
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -1597,6 +1795,20 @@
         "type": "Date",
         "value": "2013"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1172/JCI67569"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 23934130
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -1655,6 +1867,20 @@
         "type": "Date",
         "value": "2004"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1016/j.ejphar.2004.03.051"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 15140630
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -1730,6 +1956,20 @@
         "type": "Date",
         "value": "2009"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1371/journal.pone.0004579"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 19238202
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -1842,6 +2082,20 @@
         "type": "Date",
         "value": "2019"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1007/s11011-019-00397-1"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 30798429
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -1890,6 +2144,20 @@
         "type": "Date",
         "value": "2014"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1016/j.biopsych.2013.06.012"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 23896204
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -1920,6 +2188,20 @@
         "type": "Date",
         "value": "1970"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1002/jez.1401750310"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 5529519
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -1986,6 +2268,20 @@
         "type": "Date",
         "value": "2011"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1016/j.fertnstert.2011.04.095"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 21621771
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2016,6 +2312,20 @@
         "type": "Date",
         "value": "2004"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1097/01.gco.0000136496.95075.79"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 15232483
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2109,6 +2419,14 @@
         "type": "Date",
         "value": "2017"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1038/srep44169"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2175,6 +2493,20 @@
         "type": "Date",
         "value": "2018"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1007/s00213-018-5036-z"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 30238130
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2268,6 +2600,20 @@
         "type": "Date",
         "value": "2009"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1111/j.1476-5381.2009.00399.x"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 19681888
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2334,6 +2680,20 @@
         "type": "Date",
         "value": "2013"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1016/j.ejogrb.2013.03.008"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 23537616
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2391,6 +2751,20 @@
         "type": "Date",
         "value": "2016"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1055/s-0042-106303"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 27214593
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2439,6 +2813,20 @@
         "type": "Date",
         "value": "2017"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1016/j.pbb.2017.10.012"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 29107728
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2523,6 +2911,20 @@
         "type": "Date",
         "value": "2017"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1111/bph.13887"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 28548225
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2571,6 +2973,20 @@
         "type": "Date",
         "value": "2018"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1101/lm.046870.117"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 30115766
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2685,6 +3101,14 @@
         "type": "Date",
         "value": "2015"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1097/j.pain.0000000000000260"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2742,6 +3166,20 @@
         "type": "Date",
         "value": "2018"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1097/WNR.0000000000000993"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 29461336
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2853,6 +3291,20 @@
         "type": "Date",
         "value": "2010"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.2353/ajpath.2010.100375"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 21057002
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2937,6 +3389,20 @@
         "type": "Date",
         "value": "2018"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1093/biolre/ioy035"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 29425272
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -2994,6 +3460,20 @@
         "type": "Date",
         "value": "2014"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1111/bph.12519"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 24236988
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -3033,6 +3513,20 @@
         "type": "Date",
         "value": "2018"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1016/j.ejim.2018.01.004"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 29307505
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -3090,6 +3584,20 @@
         "type": "Date",
         "value": "2017"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1093/humrep/dex091"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 28482063
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -3129,6 +3637,20 @@
         "type": "Date",
         "value": "2015"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.2217/whe.15.47"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 26314611
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -3267,6 +3789,20 @@
         "type": "Date",
         "value": "2011"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1038/npp.2010.222"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 21150914
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -3333,6 +3869,20 @@
         "type": "Date",
         "value": "2004"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1530/rep.1.00095"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 15129012
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -3372,6 +3922,14 @@
         "type": "Date",
         "value": "1982"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1530/jrf.0.0640275"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -3447,6 +4005,14 @@
         "type": "Date",
         "value": "2009"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1038/nn.2369"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -3522,6 +4088,20 @@
         "type": "Date",
         "value": "2013"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1038/npp.2013.31"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 23358238
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -3561,6 +4141,14 @@
         "type": "Date",
         "value": "2017"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1038/nrendo.2016.194"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -3627,6 +4215,20 @@
         "type": "Date",
         "value": "2018"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1016/j.neurobiolaging.2017.09.025"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 29107185
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -3684,6 +4286,20 @@
         "type": "Date",
         "value": "2016"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1001/jamapsychiatry.2016.2387"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 27680324
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -3759,6 +4375,20 @@
         "type": "Date",
         "value": "1999"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1093/humrep/14.12.2944"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 10601076
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -3898,6 +4528,20 @@
         "type": "Date",
         "value": "2019"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1136/bmjopen-2017-019570"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 30782670
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -4007,6 +4651,20 @@
         "type": "Date",
         "value": "2018"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1097/j.pain.0000000000001293"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 29847469
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -4064,6 +4722,20 @@
         "type": "Date",
         "value": "2006"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1093/humrep/dei368"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 16253968
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -4112,6 +4784,14 @@
         "type": "Date",
         "value": "2019"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.2147/JPR.S192174"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -4268,6 +4948,14 @@
         "type": "Date",
         "value": "2015"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1371/journal.pbio.1002194"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -4314,6 +5002,14 @@
         "type": "Date",
         "value": "2014"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1016/j.drugalcdep.2014.07.029"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -4362,6 +5058,20 @@
         "type": "Date",
         "value": "2019"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1186/s13048-018-0478-9"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 30646937
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -4417,6 +5127,20 @@
         "type": "Date",
         "value": "2009"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1093/humrep/den464"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 19151028
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -4474,6 +5198,14 @@
         "type": "Date",
         "value": "2008"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1016/j.ejphar.2007.12.035"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -4594,6 +5326,20 @@
         "type": "Date",
         "value": "2018"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1097/j.pain.0000000000001233"
+        },
+        {
+          "type": "PropertyValue",
+          "name": "pmid",
+          "propertyID": "https://registry.identifiers.org/registry/pmid",
+          "value": 29613911
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {
@@ -4669,6 +5415,14 @@
         "type": "Date",
         "value": "2019"
       },
+      "identifiers": [
+        {
+          "type": "PropertyValue",
+          "name": "doi",
+          "propertyID": "https://registry.identifiers.org/registry/doi",
+          "value": "10.1038/s41572-018-0008-5"
+        }
+      ],
       "isPartOf": {
         "type": "PublicationVolume",
         "isPartOf": {

--- a/src/codecs/crossref/__file_snapshots__/article-elife-50356.xml
+++ b/src/codecs/crossref/__file_snapshots__/article-elife-50356.xml
@@ -56,6 +56,7 @@
           <author>Abuhasira</author>
           <volume>49</volume>
           <cYear>2018</cYear>
+          <doi>10.1016/j.ejim.2018.01.001</doi>
           <article_title>Medical use of Cannabis and cannabinoids containing products - Regulations in Europe and north america</article_title>
         </citation>
         <citation key="ref2">
@@ -63,6 +64,7 @@
           <author>Adashi</author>
           <volume>244</volume>
           <cYear>1983</cYear>
+          <doi>10.1152/ajpendo.1983.244.2.E177</doi>
           <article_title>Direct antigonadal activity of cannabinoids: suppression of rat granulosa cell functions</article_title>
         </citation>
         <citation key="ref3">
@@ -70,6 +72,7 @@
           <author>Armour</author>
           <volume>19</volume>
           <cYear>2019</cYear>
+          <doi>10.1186/s12906-019-2431-x</doi>
           <article_title>Self-management strategies amongst Australian women with endometriosis: a national online survey</article_title>
         </citation>
         <citation key="ref4">
@@ -77,6 +80,7 @@
           <author>Arosh</author>
           <volume>112</volume>
           <cYear>2015</cYear>
+          <doi>10.1073/pnas.1507931112</doi>
           <article_title>Molecular and preclinical basis to inhibit PGE2 receptors EP2 and EP4 as a novel nonsteroidal therapy for endometriosis</article_title>
         </citation>
         <citation key="ref5">
@@ -84,6 +88,7 @@
           <author>Berkley</author>
           <volume>101</volume>
           <cYear>2004</cYear>
+          <doi>10.1073/pnas.0403663101</doi>
           <article_title>Innervation of ectopic endometrium in a rat model of endometriosis</article_title>
         </citation>
         <citation key="ref6">
@@ -91,6 +96,7 @@
           <author>Bilkei-Gorzo</author>
           <volume>23</volume>
           <cYear>2017</cYear>
+          <doi>10.1038/nm.4311</doi>
           <article_title>A chronic low dose of Δ9-tetrahydrocannabinol (THC) restores cognitive function in old mice</article_title>
         </citation>
         <citation key="ref7">
@@ -98,6 +104,7 @@
           <author>Bushnell</author>
           <volume>156</volume>
           <cYear>2015</cYear>
+          <doi>10.1097/01.j.pain.0000460347.77341.bd</doi>
           <article_title>Effect of environment on the long-term consequences of chronic pain</article_title>
         </citation>
         <citation key="ref8">
@@ -105,6 +112,7 @@
           <author>Busquets-Garcia</author>
           <volume>70</volume>
           <cYear>2011</cYear>
+          <doi>10.1016/j.biopsych.2011.04.022</doi>
           <article_title>Differential role of anandamide and 2-arachidonoylglycerol in memory and anxiety-like responses</article_title>
         </citation>
         <citation key="ref9">
@@ -112,6 +120,7 @@
           <author>Busquets-Garcia</author>
           <volume>43</volume>
           <cYear>2018</cYear>
+          <doi>10.1038/npp.2017.175</doi>
           <article_title>Hippocampal protein kinase C signaling mediates the Short-Term memory impairment induced by Delta9-Tetrahydrocannabinol</article_title>
         </citation>
         <citation key="ref10">
@@ -119,6 +128,7 @@
           <author>Byers</author>
           <volume>7</volume>
           <cYear>2012</cYear>
+          <doi>10.1371/journal.pone.0035538</doi>
           <article_title>Mouse estrous cycle identification tool and images</article_title>
         </citation>
         <citation key="ref11">
@@ -126,6 +136,7 @@
           <author>Campbell</author>
           <volume>323</volume>
           <cYear>2001</cYear>
+          <doi>10.1136/bmj.323.7303.13</doi>
           <article_title>Are cannabinoids an effective and safe treatment option in the management of pain? A qualitative systematic review</article_title>
         </citation>
         <citation key="ref12">
@@ -133,6 +144,7 @@
           <author>Célérier</author>
           <volume>50</volume>
           <cYear>2006</cYear>
+          <doi>10.1016/j.neuropharm.2005.11.017</doi>
           <article_title>Influence of the anabolic-androgenic steroid nandrolone on cannabinoid dependence</article_title>
         </citation>
         <citation key="ref13">
@@ -140,6 +152,7 @@
           <author>Corder</author>
           <volume>23</volume>
           <cYear>2017</cYear>
+          <doi>10.1038/nm.4262</doi>
           <article_title>Loss of μ opioid receptor signaling in nociceptors, but not microglia, abrogates morphine tolerance without disrupting analgesia</article_title>
         </citation>
         <citation key="ref14">
@@ -147,6 +160,7 @@
           <author>Corder</author>
           <volume>363</volume>
           <cYear>2019</cYear>
+          <doi>10.1126/science.aap8586</doi>
           <article_title>An amygdalar neural ensemble that encodes the unpleasantness of pain</article_title>
         </citation>
         <citation key="ref15">
@@ -154,6 +168,7 @@
           <author>Curran</author>
           <volume>17</volume>
           <cYear>2016</cYear>
+          <doi>10.1038/nrn.2016.28</doi>
           <article_title>Keep off the grass? Cannabis, cognition and addiction</article_title>
         </citation>
         <citation key="ref16">
@@ -161,6 +176,7 @@
           <author>Cutando</author>
           <volume>123</volume>
           <cYear>2013</cYear>
+          <doi>10.1172/JCI67569</doi>
           <article_title>Microglial activation underlies cerebellar deficits produced by repeated Cannabis exposure</article_title>
         </citation>
         <citation key="ref17">
@@ -168,6 +184,7 @@
           <author>De</author>
           <volume>491</volume>
           <cYear>2004</cYear>
+          <doi>10.1016/j.ejphar.2004.03.051</doi>
           <article_title>Pharmacological characterization of the chronic constriction injury model of neuropathic pain</article_title>
         </citation>
         <citation key="ref18">
@@ -175,6 +192,7 @@
           <author>El-Talatini</author>
           <volume>4</volume>
           <cYear>2009</cYear>
+          <doi>10.1371/journal.pone.0004579</doi>
           <article_title>Localisation and function of the endocannabinoid system in the human ovary</article_title>
         </citation>
         <citation key="ref19">
@@ -182,6 +200,7 @@
           <author>Filho</author>
           <volume>34</volume>
           <cYear>2019</cYear>
+          <doi>10.1007/s11011-019-00397-1</doi>
           <article_title>Peritoneal endometriosis induces time-related depressive- and anxiety-like alterations in female rats: involvement of hippocampal pro-oxidative and BDNF alterations</article_title>
         </citation>
         <citation key="ref20">
@@ -189,6 +208,7 @@
           <author>Flores</author>
           <volume>75</volume>
           <cYear>2014</cYear>
+          <doi>10.1016/j.biopsych.2013.06.012</doi>
           <article_title>The hypocretin/orexin receptor-1 as a novel target to modulate cannabinoid reward</article_title>
         </citation>
         <citation key="ref21">
@@ -196,6 +216,7 @@
           <author>Forsberg</author>
           <volume>175</volume>
           <cYear>1970</cYear>
+          <doi>10.1002/jez.1401750310</doi>
           <article_title>An estradiol mitotic rate inhibiting effect in the müllerian epithelium in neonatal mice</article_title>
         </citation>
         <citation key="ref22">
@@ -203,6 +224,7 @@
           <author>Fourquet</author>
           <volume>96</volume>
           <cYear>2011</cYear>
+          <doi>10.1016/j.fertnstert.2011.04.095</doi>
           <article_title>Quantification of the impact of endometriosis symptoms on health-related quality of life and work productivity</article_title>
         </citation>
         <citation key="ref23">
@@ -210,6 +232,7 @@
           <author>Garry</author>
           <volume>16</volume>
           <cYear>2004</cYear>
+          <doi>10.1097/01.gco.0000136496.95075.79</doi>
           <article_title>The effectiveness of laparoscopic excision of endometriosis</article_title>
         </citation>
         <citation key="ref24">
@@ -217,6 +240,7 @@
           <author>Greaves</author>
           <volume>7</volume>
           <cYear>2017</cYear>
+          <doi>10.1038/srep44169</doi>
           <article_title>EP2 receptor antagonism reduces peripheral and central hyperalgesia in a preclinical mouse model of endometriosis</article_title>
         </citation>
         <citation key="ref25">
@@ -224,6 +248,7 @@
           <author>Greene</author>
           <volume>235</volume>
           <cYear>2018</cYear>
+          <doi>10.1007/s00213-018-5036-z</doi>
           <article_title>Cannabidiol modulation of antinociceptive tolerance to Δ9-tetrahydrocannabinol</article_title>
         </citation>
         <citation key="ref26">
@@ -231,6 +256,7 @@
           <author>Gunasekaran</author>
           <volume>158</volume>
           <cYear>2009</cYear>
+          <doi>10.1111/j.1476-5381.2009.00399.x</doi>
           <article_title>Reintoxication: the release of fat-stored Delta(9)-tetrahydrocannabinol (THC) into blood is enhanced by food deprivation or ACTH exposure</article_title>
         </citation>
         <citation key="ref27">
@@ -238,6 +264,7 @@
           <author>Hansen</author>
           <volume>169</volume>
           <cYear>2013</cYear>
+          <doi>10.1016/j.ejogrb.2013.03.008</doi>
           <article_title>The influence of endometriosis-related symptoms on work life and work ability: a study of danish endometriosis patients in employment</article_title>
         </citation>
         <citation key="ref28">
@@ -245,6 +272,7 @@
           <author>Harris</author>
           <volume>82</volume>
           <cYear>2016</cYear>
+          <doi>10.1055/s-0042-106303</doi>
           <article_title>Effects of Delta-9-Tetrahydrocannabinol and cannabidiol on Cisplatin-Induced neuropathy in mice</article_title>
         </citation>
         <citation key="ref29">
@@ -252,6 +280,7 @@
           <author>Kasten</author>
           <volume>163</volume>
           <cYear>2017</cYear>
+          <doi>10.1016/j.pbb.2017.10.012</doi>
           <article_title>Acute and long-term effects of Δ9-tetrahydrocannabinol on object recognition and anxiety-like activity are age- and strain-dependent in mice</article_title>
         </citation>
         <citation key="ref30">
@@ -259,6 +288,7 @@
           <author>King</author>
           <volume>174</volume>
           <cYear>2017</cYear>
+          <doi>10.1111/bph.13887</doi>
           <article_title>Single and combined effects of Δ9 -tetrahydrocannabinol and cannabidiol in a mouse model of chemotherapy-induced neuropathic pain</article_title>
         </citation>
         <citation key="ref31">
@@ -266,6 +296,7 @@
           <author>Kubilius</author>
           <volume>25</volume>
           <cYear>2018</cYear>
+          <doi>10.1101/lm.046870.117</doi>
           <article_title>Highway to hell or magic smoke? The dose-dependence of Δ9-THC in place conditioning paradigms</article_title>
         </citation>
         <citation key="ref32">
@@ -273,6 +304,7 @@
           <author>La</author>
           <volume>156</volume>
           <cYear>2015</cYear>
+          <doi>10.1097/j.pain.0000000000000260</doi>
           <article_title>Role of the endocannabinoid system in the emotional manifestations of osteoarthritis pain</article_title>
         </citation>
         <citation key="ref33">
@@ -280,6 +312,7 @@
           <author>LaFleur</author>
           <volume>29</volume>
           <cYear>2018</cYear>
+          <doi>10.1097/WNR.0000000000000993</doi>
           <article_title>Sex differences in antinociceptive response to Δ-9-tetrahydrocannabinol and CP 55,940 in the mouse Formalin test</article_title>
         </citation>
         <citation key="ref34">
@@ -287,6 +320,7 @@
           <author>Leconte</author>
           <volume>177</volume>
           <cYear>2010</cYear>
+          <doi>10.2353/ajpath.2010.100375</doi>
           <article_title>Antiproliferative effects of cannabinoid agonists on deep infiltrating endometriosis</article_title>
         </citation>
         <citation key="ref35">
@@ -294,6 +328,7 @@
           <author>Li</author>
           <volume>99</volume>
           <cYear>2018</cYear>
+          <doi>10.1093/biolre/ioy035</doi>
           <article_title>Endometriosis alters brain electrophysiology, gene expression and increases pain sensitization, anxiety, and depression in female mice</article_title>
         </citation>
         <citation key="ref36">
@@ -301,6 +336,7 @@
           <author>Lopez-Rodriguez</author>
           <volume>171</volume>
           <cYear>2014</cYear>
+          <doi>10.1111/bph.12519</doi>
           <article_title>Sex-dependent long-term effects of adolescent exposure to THC and/or MDMA on neuroinflammation and serotoninergic and cannabinoid systems in rats</article_title>
         </citation>
         <citation key="ref37">
@@ -308,6 +344,7 @@
           <author>MacCallum</author>
           <volume>49</volume>
           <cYear>2018</cYear>
+          <doi>10.1016/j.ejim.2018.01.004</doi>
           <article_title>Practical considerations in medical Cannabis administration and dosing</article_title>
         </citation>
         <citation key="ref38">
@@ -315,6 +352,7 @@
           <author>Márki</author>
           <volume>32</volume>
           <cYear>2017</cYear>
+          <doi>10.1093/humrep/dex091</doi>
           <article_title>Physical pain and emotion regulation as the main predictive factors of health-related quality of life in women living with endometriosis</article_title>
         </citation>
         <citation key="ref39">
@@ -322,6 +360,7 @@
           <author>Miller</author>
           <volume>11</volume>
           <cYear>2015</cYear>
+          <doi>10.2217/whe.15.47</doi>
           <article_title>The importance of pelvic nerve fibers in endometriosis</article_title>
         </citation>
         <citation key="ref40">
@@ -329,6 +368,7 @@
           <author>Morrison</author>
           <volume>36</volume>
           <cYear>2011</cYear>
+          <doi>10.1038/npp.2010.222</doi>
           <article_title>Disruption of frontal θ coherence by Δ9-tetrahydrocannabinol is associated with positive psychotic symptoms</article_title>
         </citation>
         <citation key="ref41">
@@ -336,6 +376,7 @@
           <author>Myers</author>
           <volume>127</volume>
           <cYear>2004</cYear>
+          <doi>10.1530/rep.1.00095</doi>
           <article_title>Methods for quantifying follicular numbers within the mouse ovary</article_title>
         </citation>
         <citation key="ref42">
@@ -343,6 +384,7 @@
           <author>Numazawa</author>
           <volume>64</volume>
           <cYear>1982</cYear>
+          <doi>10.1530/jrf.0.0640275</doi>
           <article_title>Morphometric studies on ovarian follicles and corpora lutea during the oestrous cycle in the mouse</article_title>
         </citation>
         <citation key="ref43">
@@ -350,6 +392,7 @@
           <author>Puighermanal</author>
           <volume>12</volume>
           <cYear>2009</cYear>
+          <doi>10.1038/nn.2369</doi>
           <article_title>Cannabinoid modulation of hippocampal long-term memory is mediated by mTOR signaling</article_title>
         </citation>
         <citation key="ref44">
@@ -357,6 +400,7 @@
           <author>Puighermanal</author>
           <volume>38</volume>
           <cYear>2013</cYear>
+          <doi>10.1038/npp.2013.31</doi>
           <article_title>Dissociation of the pharmacological effects of THC by mTOR blockade</article_title>
         </citation>
         <citation key="ref45">
@@ -364,6 +408,7 @@
           <author>Ross</author>
           <volume>13</volume>
           <cYear>2017</cYear>
+          <doi>10.1038/nrendo.2016.194</doi>
           <article_title>The emotional cost of contraception</article_title>
         </citation>
         <citation key="ref46">
@@ -371,6 +416,7 @@
           <author>Sarne</author>
           <volume>61</volume>
           <cYear>2018</cYear>
+          <doi>10.1016/j.neurobiolaging.2017.09.025</doi>
           <article_title>Reversal of age-related cognitive impairments in mice by an extremely low dose of tetrahydrocannabinol</article_title>
         </citation>
         <citation key="ref47">
@@ -378,6 +424,7 @@
           <author>Skovlund</author>
           <volume>73</volume>
           <cYear>2016</cYear>
+          <doi>10.1001/jamapsychiatry.2016.2387</doi>
           <article_title>Association of hormonal contraception with depression</article_title>
         </citation>
         <citation key="ref48">
@@ -385,6 +432,7 @@
           <author>Somigliana</author>
           <volume>14</volume>
           <cYear>1999</cYear>
+          <doi>10.1093/humrep/14.12.2944</doi>
           <article_title>Endometrial ability to implant in ectopic sites can be prevented by interleukin-12 in a murine model of endometriosis</article_title>
         </citation>
         <citation key="ref49">
@@ -392,6 +440,7 @@
           <author>Sperschneider</author>
           <volume>9</volume>
           <cYear>2019</cYear>
+          <doi>10.1136/bmjopen-2017-019570</doi>
           <article_title>Does endometriosis affect professional life? A matched case-control study in Switzerland, Germany and Austria</article_title>
         </citation>
         <citation key="ref50">
@@ -399,6 +448,7 @@
           <author>Stockings</author>
           <volume>159</volume>
           <cYear>2018</cYear>
+          <doi>10.1097/j.pain.0000000000001293</doi>
           <article_title>Cannabis and cannabinoids for the treatment of people with chronic noncancer pain conditions: a systematic review and meta-analysis of controlled and observational studies</article_title>
         </citation>
         <citation key="ref51">
@@ -406,6 +456,7 @@
           <author>Tokushige</author>
           <volume>21</volume>
           <cYear>2006</cYear>
+          <doi>10.1093/humrep/dei368</doi>
           <article_title>High density of small nerve fibres in the functional layer of the endometrium in women with endometriosis</article_title>
         </citation>
         <citation key="ref52">
@@ -413,6 +464,7 @@
           <author>Ueberall</author>
           <volume>12</volume>
           <cYear>2019</cYear>
+          <doi>10.2147/JPR.S192174</doi>
           <article_title>Effectiveness and tolerability of THC:cbd oromucosal spray as add-on measure in patients with severe chronic pain: analysis of 12-week open-label real-world data provided by the german pain e-Registry]]&gt;</article_title>
         </citation>
         <citation key="ref53">
@@ -420,6 +472,7 @@
           <author>Viñals</author>
           <volume>40</volume>
           <cYear>2015</cYear>
+          <doi>10.1371/journal.pbio.1002194</doi>
           <article_title>Cognitive impairment induced by Delta9- tetrahydrocannabinol occurs through heteromers between cannabinoid CB 1 and serotonin 5-HT 2A receptors 1</article_title>
         </citation>
         <citation key="ref54">
@@ -427,6 +480,7 @@
           <author>Wakley</author>
           <volume>143</volume>
           <cYear>2014</cYear>
+          <doi>10.1016/j.drugalcdep.2014.07.029</doi>
           <article_title>Sex differences in antinociceptive tolerance to delta-9-tetrahydrocannabinol in the rat</article_title>
         </citation>
         <citation key="ref55">
@@ -434,6 +488,7 @@
           <author>Walker</author>
           <volume>12</volume>
           <cYear>2019</cYear>
+          <doi>10.1186/s13048-018-0478-9</doi>
           <article_title>The role of the endocannabinoid system in female reproductive tissues</article_title>
         </citation>
         <citation key="ref56">
@@ -441,6 +496,7 @@
           <author>Wang</author>
           <volume>24</volume>
           <cYear>2009</cYear>
+          <doi>10.1093/humrep/den464</doi>
           <article_title>Rich innervation of deep infiltrating endometriosis</article_title>
         </citation>
         <citation key="ref57">
@@ -448,6 +504,7 @@
           <author>Williams</author>
           <volume>584</volume>
           <cYear>2008</cYear>
+          <doi>10.1016/j.ejphar.2007.12.035</doi>
           <article_title>Decreased basal endogenous opioid levels in diabetic rodents: effects on morphine and delta-9-tetrahydrocannabinoid-induced antinociception</article_title>
         </citation>
         <citation key="ref58">
@@ -455,6 +512,7 @@
           <author>You</author>
           <volume>159</volume>
           <cYear>2018</cYear>
+          <doi>10.1097/j.pain.0000000000001233</doi>
           <article_title>Cognitive impairment in a rat model of neuropathic pain: role of hippocampal microtubule stability</article_title>
         </citation>
         <citation key="ref59">
@@ -462,6 +520,7 @@
           <author>Zondervan</author>
           <volume>4</volume>
           <cYear>2019</cYear>
+          <doi>10.1038/s41572-018-0008-5</doi>
           <article_title>Endometriosis</article_title>
         </citation>
       </citation_list>

--- a/src/codecs/docx/docx.test.ts
+++ b/src/codecs/docx/docx.test.ts
@@ -55,6 +55,7 @@ describe('encode+decode', () => {
   test('logs have expected warnings only', () => {
     expect(logMessages).toEqual([
       'Unhandled block node type when encoding: Text',
+      'csl:encode Properties of `Article` not supported: `identifiers`',
       'Unhandled block node type when encoding: MediaObject',
     ])
   })

--- a/src/codecs/elife/__file_snapshots__/45123.yaml
+++ b/src/codecs/elife/__file_snapshots__/45123.yaml
@@ -235,6 +235,15 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.7554/eLife.41770
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30628890
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -320,6 +329,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/emboj.2013.245
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24240175
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -370,6 +388,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/cercor/bhs412
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23307639
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -416,6 +443,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/srep28396
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27319317
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -566,6 +602,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1101/gr.132159.111
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22955988
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -603,6 +648,15 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pgen.1000617
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19696892
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -633,6 +687,15 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.cell.2009.02.006
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19239885
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -658,6 +721,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.3389/fneur.2017.00629
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29230193
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -713,6 +785,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.3389/fnmol.2013.00053
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24415997
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -736,6 +817,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1007/s12031-012-9880-8
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22949041
     isPartOf:
       type: PublicationVolume
       isPartOf:

--- a/src/codecs/elife/__file_snapshots__/46793.yaml
+++ b/src/codecs/elife/__file_snapshots__/46793.yaml
@@ -313,6 +313,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.apsb.2015.05.008
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26579458
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -446,6 +455,15 @@ references:
     datePublished:
       type: Date
       value: '2000'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/75556
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 10802651
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -519,6 +537,15 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1186/1479-5876-7-43
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19519883
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -594,6 +621,15 @@ references:
     datePublished:
       type: Date
       value: '1999'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1002/(SICI)1097-0215(19990909)82:6<868::AID-IJC16>3.0.CO;2-W
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 10446455
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -696,6 +732,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1158/0008-5472.CAN-13-2541
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24240700
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -728,6 +773,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrd3428
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21455236
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -818,6 +872,15 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.0712384105
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 18299561
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -855,6 +918,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1101/cshperspect.a026708
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28193767
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -910,6 +982,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nsmb.2339
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22751019
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -947,6 +1028,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nchem.1548
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23422559
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -987,6 +1077,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pone.0102711
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25033211
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1052,6 +1151,15 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/bioinformatics/btp101
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19237447
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1084,6 +1192,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/bioinformatics/btt019
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23325622
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1116,6 +1233,11 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrg3296
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1153,6 +1275,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.3390/ijms151017493
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25268620
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1173,6 +1304,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrc3560
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23842644
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1238,6 +1378,15 @@ references:
     datePublished:
       type: Date
       value: '2005'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nature03443
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15829966
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1265,6 +1414,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gks068
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22351747
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1290,6 +1448,11 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkw1280
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1333,6 +1496,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrc3459
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23550303
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1358,6 +1530,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.dnarep.2011.04.013
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21561811
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1406,6 +1587,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nbt.3295
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26192317
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1433,6 +1623,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrd3374
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21532565
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1473,6 +1672,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.2174/156800911794519752
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21247388
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1540,6 +1748,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.chembiol.2011.08.014
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22118673
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1592,6 +1809,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/s41586-018-0209-9
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29899445
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1662,6 +1888,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1021/acs.jmedchem.5b01357
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26878150
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1715,6 +1950,11 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1101/208439
     isPartOf:
       type: Periodical
       name: bioRxiv
@@ -1758,6 +1998,15 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1074/jbc.M806277200
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 18842585
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1796,6 +2045,15 @@ references:
     datePublished:
       type: Date
       value: '1993'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/363640a0
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 8510758
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1866,6 +2124,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.12688/f1000research.3928.2
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24860646
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1912,6 +2179,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.4161/cc.21399
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22871734
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1981,6 +2257,15 @@ references:
     datePublished:
       type: Date
       value: '2007'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.0707365104
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 17954919
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2024,6 +2309,15 @@ references:
     datePublished:
       type: Date
       value: '2007'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1021/ja067352b
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 17260991
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2050,6 +2344,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1080/23723556.2015.1025181
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27308538
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2101,6 +2404,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/bioinformatics/btw230
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27153664
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2155,6 +2467,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pone.0179883
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28666010
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2190,6 +2511,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrc.2016.51
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27282250
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2220,6 +2550,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1017/S1462399411002031
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22088887
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2305,6 +2644,15 @@ references:
     datePublished:
       type: Date
       value: '2005'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nature03445
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15829967
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2387,6 +2735,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkv1344
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26673716
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2485,6 +2842,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gku1075
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25355519
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2515,6 +2881,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.gene.2017.06.056
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28669924
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2550,6 +2925,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1007/s12032-011-0061-3
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21909941
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2587,6 +2971,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1186/1476-4598-12-91
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23937906
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2652,6 +3045,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkr234
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21586581
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2677,6 +3079,15 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1146/annurev.pharmtox.48.113006.094649
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19922264
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2824,6 +3235,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nmeth.2689
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24122041
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2864,6 +3284,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pone.0092444
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24647355
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2935,6 +3364,15 @@ references:
     datePublished:
       type: Date
       value: '1996'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1126/science.271.5247.350
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 8553070
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2975,6 +3413,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1186/1756-0500-5-138
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22414013
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3051,6 +3498,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/ng.3662
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27618450
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3086,6 +3542,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrd.2017.152
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28959952
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3146,6 +3611,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkt957
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24163102
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3206,6 +3680,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gky861
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30256975
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3273,6 +3756,11 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/ncb1378
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3303,6 +3791,15 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nprot.2008.211
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19131956
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3335,6 +3832,15 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkn923
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19033363
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3362,6 +3868,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/cr.2016.31
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27002218
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3384,6 +3899,11 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1039/b702491f
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3409,6 +3929,11 @@ references:
     datePublished:
       type: Date
       value: '2007'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkl1057
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3459,6 +3984,11 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/ng.2628
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3516,6 +4046,15 @@ references:
     datePublished:
       type: Date
       value: '2004'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1074/jbc.M400231200
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15028736
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3593,6 +4132,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.molcel.2014.10.025
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25435137
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3653,6 +4201,15 @@ references:
     datePublished:
       type: Date
       value: '2007'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nchembio.2007.16
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 17643112
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3690,6 +4247,15 @@ references:
     datePublished:
       type: Date
       value: '2007'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nchembio864
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 17322877
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3732,6 +4298,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nmeth.3965
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27571552
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3759,6 +4334,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nmeth.1923
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22388286
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3795,6 +4379,11 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1039/c5cc02252e
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3825,6 +4414,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/annonc/mdt384
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24225019
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3885,6 +4483,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.ejca.2012.03.023
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22538187
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3935,6 +4542,11 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.bbcan.2014.11.005
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3965,6 +4577,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkv383
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25925572
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4061,6 +4682,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.chembiol.2016.08.013
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27693060
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4113,6 +4743,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/srep26585
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27215610
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4179,6 +4818,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1158/1535-7163.MCT-16-0457
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27980104
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4225,6 +4873,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.tips.2016.06.006
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27427153
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4255,6 +4912,11 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.bbamcr.2012.05.005
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4362,6 +5024,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.18632/oncotarget.2037
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24931005
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4423,6 +5094,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1021/ja404868t
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23782415
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4465,6 +5145,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkw079
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26883636
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4500,6 +5189,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/srep38144
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27905517
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4610,6 +5308,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1002/ijc.29263
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25302833
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4736,6 +5443,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.molcel.2011.02.015
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21362549
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4758,6 +5474,15 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.1742-4658.2009.07463.x
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19951354
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4780,6 +5505,11 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/s41570-017-0041
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4838,6 +5568,15 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1242/jcs.026351
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 18840648
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4885,6 +5624,11 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.3390/ijms18091886
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4934,6 +5678,15 @@ references:
     datePublished:
       type: Date
       value: '2005'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.molcel.2005.01.008
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15694335
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4954,6 +5707,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.febslet.2010.11.024
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21094158
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5006,6 +5768,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/onc.2011.456
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21986947
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5093,6 +5864,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/onc.2014.327
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25284584
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5198,6 +5978,15 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1158/1535-7163.MCT-10-0324
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 20663931
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5245,6 +6034,11 @@ references:
     datePublished:
       type: Date
       value: '2005'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.mrfmmm.2004.09.010
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5273,6 +6067,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrc3929
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25998713
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5298,6 +6101,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkv862
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26350216
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5343,6 +6155,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1158/0008-5472.CAN-16-3565
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28652249
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5375,6 +6196,15 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/bioinformatics/btp616
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19910308
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5422,6 +6252,15 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1021/ja805615w
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 18975896
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5489,6 +6328,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nchembio.780
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22306580
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5779,6 +6627,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.cell.2018.03.035
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29625050
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5824,6 +6681,15 @@ references:
     datePublished:
       type: Date
       value: '2001'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.141229498
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 11438689
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5916,6 +6782,11 @@ references:
     datePublished:
       type: Date
       value: '1996'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 8653691
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5946,6 +6817,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrc.2017.105
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29242641
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5971,6 +6851,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pone.0055119
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23355908
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6029,6 +6918,15 @@ references:
     datePublished:
       type: Date
       value: '2003'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1101/gr.1239303
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 14597658
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6141,6 +7039,15 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1101/gad.1703008
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 18832071
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6218,6 +7125,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkw1223
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27928057
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6315,6 +7231,11 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1186/gb-2011-12-10-r104
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6505,6 +7426,15 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nature07884
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19360080
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6551,6 +7481,15 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/sj.onc.1209242
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 16288211
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6627,6 +7566,11 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkw937
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6677,6 +7621,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.chembiol.2013.02.013
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23521792
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6696,6 +7649,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkw1099
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27899622
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6724,6 +7686,15 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkj403
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 16397294
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6749,6 +7720,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.tig.2016.09.004
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27663528
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6804,6 +7784,15 @@ references:
     datePublished:
       type: Date
       value: '2005'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1074/jbc.C500348200
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 16150737
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6826,6 +7815,15 @@ references:
     datePublished:
       type: Date
       value: '2002'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrm831
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 12042765
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6866,6 +7864,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.2147/DDDT.S68872
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25364233
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6938,6 +7945,15 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/s41467-019-08905-8
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30808951
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6994,6 +8010,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1172/JCI65634
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23563309
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7021,6 +8046,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.3389/fonc.2012.00187
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23227454
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7066,6 +8100,15 @@ references:
     datePublished:
       type: Date
       value: '2002'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/emboj/cdf480
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 12234937
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7196,6 +8239,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nature13485
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25079319
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7276,6 +8328,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1158/0008-5472.CAN-18-1877
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30279242
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7303,6 +8364,15 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.1742-4658.2010.07760.x
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 20670277
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7514,6 +8584,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/ncomms14432
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28211448
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7559,6 +8638,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pgen.1004839
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25473964
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7584,6 +8672,11 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1080/15257770600809913
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7634,6 +8727,15 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkj057
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 16381865
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7672,6 +8774,15 @@ references:
     datePublished:
       type: Date
       value: '2004'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/annonc/mdh073
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 14760118
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7719,6 +8830,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.bbrc.2017.11.139
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29175326
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7786,6 +8906,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/ncomms5581
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25091051
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7881,6 +9010,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.molcel.2015.12.004
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26748828
     isPartOf:
       type: PublicationVolume
       isPartOf:

--- a/src/codecs/html/__file_snapshots__/elife-30274.html
+++ b/src/codecs/html/__file_snapshots__/elife-30274.html
@@ -1425,6 +1425,8 @@
                       itemprop="givenName">M</span></span><span data-itemprop="familyNames"><span
                       itemprop="familyName">McCarthy</span></span>
                 </li>
+                <li itemscope="" itemtype="http://schema.org/Organization" itemprop="author"><span
+                    itemprop="name">Reproducibility Project: Cancer Biology</span></li>
               </ol><time itemprop="datePublished" datetime="2015">2015</time><span
                 itemprop="headline">Registered report: Transcriptional amplification in tumor cells
                 with elevated c-Myc</span><span itemscope=""

--- a/src/codecs/html/__file_snapshots__/elife-30274.html
+++ b/src/codecs/html/__file_snapshots__/elife-30274.html
@@ -1377,6 +1377,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=The%20cost%20of%20dichotomising%20continuous%20variables">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1136/bmj.332.7549.1080</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">16675816</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib2">
               <ol data-itemprop="authors">
@@ -1407,6 +1421,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=The%20error%20of%20the%20red%20cell%20count">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1136/jcp.1.5.288</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">16810816</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib3">
               <ol data-itemprop="authors">
@@ -1443,6 +1470,13 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Registered%20report:%20Transcriptional%20amplification%20in%20tumor%20cells%20with%20elevated%20c-Myc">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.7554/eLife.04024</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib4">
               <ol data-itemprop="authors">
@@ -1468,6 +1502,14 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=The%20cost%20of%20dichotomization">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1177/014662168300700301</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib5">
               <ol data-itemprop="authors">
@@ -1582,6 +1624,13 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Integrative%20omics%20reveals%20MYCN%20as%20a%20global%20suppressor%20of%20cellular%20signalling%20and%20enables%20network-based%20therap%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.18632/oncotarget.6568</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib6">
               <ol data-itemprop="authors">
@@ -1631,6 +1680,13 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=An%20open%20investigation%20of%20the%20reproducibility%20of%20cancer%20biology%20research">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.7554/eLife.04333</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib7">
               <ol data-itemprop="authors">
@@ -1731,6 +1787,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=A%20Myc-driven%20self-reinforcing%20regulatory%20network%20maintains%20mouse%20embryonic%20stem%20cell%20identity">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1038/ncomms11903</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">27301576</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib8">
               <ol data-itemprop="authors">
@@ -1762,6 +1831,13 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=The%20difference%20between%20%E2%80%9Csignificant%E2%80%9D%20and%20%E2%80%9Cnot%20significant%E2%80%9D%20is%20not%20itself%20statistically%20significant">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1198/000313006X152649</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib9">
               <ol data-itemprop="authors">
@@ -1808,6 +1884,13 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=MYC%20regulates%20the%20non-coding%20transcriptome">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.18632/oncotarget.3033</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib10">
               <ol data-itemprop="authors">
@@ -1881,6 +1964,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Variation%20in%20RNA%20expression%20and%20genomic%20DNA%20content%20acquired%20during%20cell%20culture">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1038/sj.bjc.6601405</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">14735196</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib12">
               <ol data-itemprop="authors">
@@ -2048,6 +2144,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=The%20spliceosome%20is%20a%20therapeutic%20vulnerability%20in%20MYC-driven%20cancer">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1038/nature14985</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">26331541</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib13">
               <ol data-itemprop="authors">
@@ -2094,6 +2203,13 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=The%20costs%20of%20using%20unauthenticated">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.2144/000112598</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib14">
               <ol data-itemprop="authors">
@@ -2192,6 +2308,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Genetic%20variability%20in%20a%20frozen%20batch%20of%20MCF-7%20cells%20invisible%20in%20routine%20authentication%20affecting%20cell%20funct%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1038/srep28994</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">27456714</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib15">
               <ol data-itemprop="authors">
@@ -2258,6 +2387,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Tackling%20the%20widespread%20and%20critical%20impact%20of%20batch%20effects%20in%20high-throughput%20data">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1038/nrg2825</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">20838408</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib16">
               <ol data-itemprop="authors">
@@ -2329,6 +2471,13 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Study%2048:%20Replication%20of%20Lin%20et%20al.,%202012%20(Cell)">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.17605/OSF.IO/MOKEB</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib17">
               <ol data-itemprop="authors">
@@ -2390,6 +2539,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Transcriptional%20amplification%20in%20tumor%20cells%20with%20elevated%20c-Myc">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1016/j.cell.2012.08.026</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">23021215</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib18">
               <ol data-itemprop="authors">
@@ -2459,6 +2622,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Different%20promoter%20affinities%20account%20for%20specificity%20in%20MYC-dependent%20gene%20regulation">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.7554/eLife.15161</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">27460974</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib19">
               <ol data-itemprop="authors">
@@ -2540,6 +2716,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=c-Myc%20is%20a%20universal%20amplifier%20of%20expressed%20genes%20in%20lymphocytes%20and%20embryonic%20stem%20cells">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1016/j.cell.2012.08.033</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">23021216</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib20">
               <ol data-itemprop="authors">
@@ -2576,6 +2766,13 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Hemacytometer%20Cell%20Count%20Distributions:%20Implications%20of%20Non-Poisson%20Behavior">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1021/bp00012a600</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib21">
               <ol data-itemprop="authors">
@@ -2614,6 +2811,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Erroneous%20analyses%20of%20interactions%20in%20neuroscience:%20a%20problem%20of%20significance">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1038/nn.2886</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">21878926</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib22">
               <ol data-itemprop="authors">
@@ -2688,6 +2898,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Single%20mammalian%20cells%20compensate%20for%20differences%20in%20cellular%20volume%20and%20DNA%20copy%20number%20through%20independent%20%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1016/j.molcel.2015.03.005</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">25866248</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib23">
               <ol data-itemprop="authors">
@@ -2770,6 +2994,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Cell%20cycle%20activation%20by%20c-myc%20in%20a%20burkitt%20lymphoma%20model%20cell%20line">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1002/1097-0215(20000915)87:6&lt;787::AID-IJC4&gt;3.0.CO;2-6</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">10956386</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib24">
               <ol data-itemprop="authors">
@@ -2797,6 +3035,14 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Remarks%20on%20zeros%20and%20ties%20in%20the%20wilcoxon%20signed%20rank%20procedures">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1080/01621459.1959.10501526</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib25">
               <ol data-itemprop="authors">
@@ -2843,6 +3089,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Genome%20recognition%20by%20MYC">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1101/cshperspect.a014191</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">24492846</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib27">
               <ol data-itemprop="authors">
@@ -2960,6 +3220,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Selective%20transcriptional%20regulation%20by%20Myc%20in%20cellular%20growth%20control%20and%20lymphomagenesis">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1038/nature13537</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">25043028</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib28">
               <ol data-itemprop="authors">
@@ -3027,6 +3300,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Dissection%20of%20transcriptional%20programmes%20in%20response%20to%20serum%20and%20c-Myc%20in%20a%20human%20B-cell%20line">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1038/sj.onc.1208198</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">15516975</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib29">
               <ol data-itemprop="authors">
@@ -3063,6 +3349,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=NIH%20Image%20to%20ImageJ:%2025%20years%20of%20image%20analysis">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1038/nmeth.2089</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">22930834</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib30">
               <ol data-itemprop="authors">
@@ -3125,6 +3424,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Control%20of%20cell%20growth%20by%20c-Myc%20in%20the%20absence%20of%20cell%20division">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1016/S0960-9822(99)80507-7</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">10556095</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib31">
               <ol data-itemprop="authors">
@@ -3526,6 +3839,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Cell%20types%20differ%20in%20global%20coordination%20of%20splicing%20and%20proportion%20of%20highly%20expressed%20genes">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1038/srep32249</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">27577089</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib33">
               <ol data-itemprop="authors">
@@ -3591,6 +3917,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Replication%20in%20prevention%20science">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1007/s11121-011-0217-6</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">21541692</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib34">
               <ol data-itemprop="authors">
@@ -3618,6 +3958,13 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Conducting%20Meta-Analyses%20in%20R%20with%20the%20metafor%20Package">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.18637/jss.v036.i03</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib35">
               <ol data-itemprop="authors">
@@ -3735,6 +4082,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Activation%20and%20repression%20by%20oncogenic%20MYC%20shape%20tumour-specific%20gene%20expression%20profiles">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1038/nature13473</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">25043018</span>
+                </li>
+              </ul>
             </li>
           </ol>
         </section>

--- a/src/codecs/html/__file_snapshots__/elife-50356.html
+++ b/src/codecs/html/__file_snapshots__/elife-50356.html
@@ -1233,6 +1233,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Medical%20use%20of%20Cannabis%20and%20cannabinoids%20containing%20products%20-%20Regulations%20in%20Europe%20and%20north%20america">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1016/j.ejim.2018.01.001</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">29329891</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib2">
               <ol data-itemprop="authors">
@@ -1268,6 +1282,14 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Direct%20antigonadal%20activity%20of%20cannabinoids:%20suppression%20of%20rat%20granulosa%20cell%20functions">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1152/ajpendo.1983.244.2.E177</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib3">
               <ol data-itemprop="authors">
@@ -1308,6 +1330,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Self-management%20strategies%20amongst%20Australian%20women%20with%20endometriosis:%20a%20national%20online%20survey">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1186/s12906-019-2431-x</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">30646891</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib4">
               <ol data-itemprop="authors">
@@ -1389,6 +1425,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Molecular%20and%20preclinical%20basis%20to%20inhibit%20PGE2%20receptors%20EP2%20and%20EP4%20as%20a%20novel%20nonsteroidal%20therapy%20for%20end%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1073/pnas.1507931112</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">26199416</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib5">
               <ol data-itemprop="authors">
@@ -1430,6 +1479,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Innervation%20of%20ectopic%20endometrium%20in%20a%20rat%20model%20of%20endometriosis">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1073/pnas.0403663101</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">15256593</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib6">
               <ol data-itemprop="authors">
@@ -1519,6 +1581,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=A%20chronic%20low%20dose%20of%20%CE%949-tetrahydrocannabinol%20(THC)%20restores%20cognitive%20function%20in%20old%20mice">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1038/nm.4311</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">28481360</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib7">
               <ol data-itemprop="authors">
@@ -1578,6 +1653,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Effect%20of%20environment%20on%20the%20long-term%20consequences%20of%20chronic%20pain">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1097/01.j.pain.0000460347.77341.bd</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">25789436</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib8">
               <ol data-itemprop="authors">
@@ -1632,6 +1721,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Differential%20role%20of%20anandamide%20and%202-arachidonoylglycerol%20in%20memory%20and%20anxiety-like%20responses">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1016/j.biopsych.2011.04.022</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">21684528</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib9">
               <ol data-itemprop="authors">
@@ -1701,6 +1804,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Hippocampal%20protein%20kinase%20C%20signaling%20mediates%20the%20Short-Term%20memory%20impairment%20induced%20by%20Delta9-Tetrahydro%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1038/npp.2017.175</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">28816239</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib10">
               <ol data-itemprop="authors">
@@ -1740,6 +1856,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Mouse%20estrous%20cycle%20identification%20tool%20and%20images">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1371/journal.pone.0035538</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">22514749</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib11">
               <ol data-itemprop="authors">
@@ -1791,6 +1921,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Are%20cannabinoids%20an%20effective%20and%20safe%20treatment%20option%20in%20the%20management%20of%20pain?%20A%20qualitative%20systematic%20r%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1136/bmj.323.7303.13</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">11440935</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib12">
               <ol data-itemprop="authors">
@@ -1842,6 +1985,14 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Influence%20of%20the%20anabolic-androgenic%20steroid%20nandrolone%20on%20cannabinoid%20dependence">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1016/j.neuropharm.2005.11.017</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib13">
               <ol data-itemprop="authors">
@@ -1920,6 +2071,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Loss%20of%20%CE%BC%20opioid%20receptor%20signaling%20in%20nociceptors,%20but%20not%20microglia,%20abrogates%20morphine%20tolerance%20without%20d%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1038/nm.4262</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">28092666</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib14">
               <ol data-itemprop="authors">
@@ -1971,6 +2135,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=An%20amygdalar%20neural%20ensemble%20that%20encodes%20the%20unpleasantness%20of%20pain">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1126/science.aap8586</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">30655440</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib15">
               <ol data-itemprop="authors">
@@ -2022,6 +2199,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Keep%20off%20the%20grass?%20Cannabis,%20cognition%20and%20addiction">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1038/nrn.2016.28</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">27052382</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib16">
               <ol data-itemprop="authors">
@@ -2087,6 +2277,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Microglial%20activation%20underlies%20cerebellar%20deficits%20produced%20by%20repeated%20Cannabis%20exposure">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1172/JCI67569</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">23934130</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib17">
               <ol data-itemprop="authors">
@@ -2129,6 +2332,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Pharmacological%20characterization%20of%20the%20chronic%20constriction%20injury%20model%20of%20neuropathic%20pain">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1016/j.ejphar.2004.03.051</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">15140630</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib18">
               <ol data-itemprop="authors">
@@ -2179,6 +2396,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Localisation%20and%20function%20of%20the%20endocannabinoid%20system%20in%20the%20human%20ovary">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1371/journal.pone.0004579</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">19238202</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib19">
               <ol data-itemprop="authors">
@@ -2256,6 +2487,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Peritoneal%20endometriosis%20induces%20time-related%20depressive-%20and%20anxiety-like%20alterations%20in%20female%20rats:%20involv%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1007/s11011-019-00397-1</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">30798429</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib20">
               <ol data-itemprop="authors">
@@ -2292,6 +2537,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=The%20hypocretin/orexin%20receptor-1%20as%20a%20novel%20target%20to%20modulate%20cannabinoid%20reward">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1016/j.biopsych.2013.06.012</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">23896204</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib21">
               <ol data-itemprop="authors">
@@ -2318,6 +2577,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=An%20estradiol%20mitotic%20rate%20inhibiting%20effect%20in%20the%20m%C3%BCllerian%20epithelium%20in%20neonatal%20mice">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1002/jez.1401750310</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">5529519</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib22">
               <ol data-itemprop="authors">
@@ -2364,6 +2636,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Quantification%20of%20the%20impact%20of%20endometriosis%20symptoms%20on%20health-related%20quality%20of%20life%20and%20work%20productivity">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1016/j.fertnstert.2011.04.095</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">21621771</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib23">
               <ol data-itemprop="authors">
@@ -2391,6 +2677,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=The%20effectiveness%20of%20laparoscopic%20excision%20of%20endometriosis">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1097/01.gco.0000136496.95075.79</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">15232483</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib24">
               <ol data-itemprop="authors">
@@ -2456,6 +2756,13 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=EP2%20receptor%20antagonism%20reduces%20peripheral%20and%20central%20hyperalgesia%20in%20a%20preclinical%20mouse%20model%20of%20endometri%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1038/srep44169</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib25">
               <ol data-itemprop="authors">
@@ -2502,6 +2809,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Cannabidiol%20modulation%20of%20antinociceptive%20tolerance%20to%20%CE%949-tetrahydrocannabinol">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1007/s00213-018-5036-z</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">30238130</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib26">
               <ol data-itemprop="authors">
@@ -2566,6 +2887,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Reintoxication:%20the%20release%20of%20fat-stored%20Delta(9)-tetrahydrocannabinol%20(THC)%20into%20blood%20is%20enhanced%20by%20food%20%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1111/j.1476-5381.2009.00399.x</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">19681888</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib27">
               <ol data-itemprop="authors">
@@ -2615,6 +2950,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=The%20influence%20of%20endometriosis-related%20symptoms%20on%20work%20life%20and%20work%20ability:%20a%20study%20of%20danish%20endometriosi%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1016/j.ejogrb.2013.03.008</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">23537616</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib28">
               <ol data-itemprop="authors">
@@ -2656,6 +3005,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Effects%20of%20Delta-9-Tetrahydrocannabinol%20and%20cannabidiol%20on%20Cisplatin-Induced%20neuropathy%20in%20mice">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1055/s-0042-106303</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">27214593</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib29">
               <ol data-itemprop="authors">
@@ -2694,6 +3056,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Acute%20and%20long-term%20effects%20of%20%CE%949-tetrahydrocannabinol%20on%20object%20recognition%20and%20anxiety-like%20activity%20are%20ag%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1016/j.pbb.2017.10.012</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">29107728</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib30">
               <ol data-itemprop="authors">
@@ -2753,6 +3129,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Single%20and%20combined%20effects%20of%20%CE%949%20-tetrahydrocannabinol%20and%20cannabidiol%20in%20a%20mouse%20model%20of%20chemotherapy-indu%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1111/bph.13887</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">28548225</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib31">
               <ol data-itemprop="authors">
@@ -2789,6 +3178,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Highway%20to%20hell%20or%20magic%20smoke?%20The%20dose-dependence%20of%20%CE%949-THC%20in%20place%20conditioning%20paradigms">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1101/lm.046870.117</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">30115766</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib32">
               <ol data-itemprop="authors">
@@ -2863,6 +3265,14 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Role%20of%20the%20endocannabinoid%20system%20in%20the%20emotional%20manifestations%20of%20osteoarthritis%20pain">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1097/j.pain.0000000000000260</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib33">
               <ol data-itemprop="authors">
@@ -2907,6 +3317,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Sex%20differences%20in%20antinociceptive%20response%20to%20%CE%94-9-tetrahydrocannabinol%20and%20CP%2055,940%20in%20the%20mouse%20Formalin%20t%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1097/WNR.0000000000000993</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">29461336</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib34">
               <ol data-itemprop="authors">
@@ -2979,6 +3403,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Antiproliferative%20effects%20of%20cannabinoid%20agonists%20on%20deep%20infiltrating%20endometriosis">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.2353/ajpath.2010.100375</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">21057002</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib35">
               <ol data-itemprop="authors">
@@ -3038,6 +3476,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Endometriosis%20alters%20brain%20electrophysiology,%20gene%20expression%20and%20increases%20pain%20sensitization,%20anxiety,%20and%20%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1093/biolre/ioy035</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">29425272</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib36">
               <ol data-itemprop="authors">
@@ -3084,6 +3535,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Sex-dependent%20long-term%20effects%20of%20adolescent%20exposure%20to%20THC%20and/or%20MDMA%20on%20neuroinflammation%20and%20serotonine%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1111/bph.12519</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">24236988</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib37">
               <ol data-itemprop="authors">
@@ -3115,6 +3579,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Practical%20considerations%20in%20medical%20Cannabis%20administration%20and%20dosing">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1016/j.ejim.2018.01.004</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">29307505</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib38">
               <ol data-itemprop="authors">
@@ -3158,6 +3636,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Physical%20pain%20and%20emotion%20regulation%20as%20the%20main%20predictive%20factors%20of%20health-related%20quality%20of%20life%20in%20wome%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1093/humrep/dex091</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">28482063</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib39">
               <ol data-itemprop="authors">
@@ -3189,6 +3680,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=The%20importance%20of%20pelvic%20nerve%20fibers%20in%20endometriosis">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.2217/whe.15.47</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">26314611</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib40">
               <ol data-itemprop="authors">
@@ -3276,6 +3780,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Disruption%20of%20frontal%20%CE%B8%20coherence%20by%20%CE%949-tetrahydrocannabinol%20is%20associated%20with%20positive%20psychotic%20symptoms">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1038/npp.2010.222</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">21150914</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib41">
               <ol data-itemprop="authors">
@@ -3322,6 +3839,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Methods%20for%20quantifying%20follicular%20numbers%20within%20the%20mouse%20ovary">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1530/rep.1.00095</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">15129012</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib42">
               <ol data-itemprop="authors">
@@ -3353,6 +3883,13 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Morphometric%20studies%20on%20ovarian%20follicles%20and%20corpora%20lutea%20during%20the%20oestrous%20cycle%20in%20the%20mouse">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1530/jrf.0.0640275</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib43">
               <ol data-itemprop="authors">
@@ -3406,6 +3943,13 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Cannabinoid%20modulation%20of%20hippocampal%20long-term%20memory%20is%20mediated%20by%20mTOR%20signaling">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1038/nn.2369</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib44">
               <ol data-itemprop="authors">
@@ -3460,6 +4004,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Dissociation%20of%20the%20pharmacological%20effects%20of%20THC%20by%20mTOR%20blockade">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1038/npp.2013.31</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">23358238</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib45">
               <ol data-itemprop="authors">
@@ -3490,6 +4047,13 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=The%20emotional%20cost%20of%20contraception">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1038/nrendo.2016.194</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib46">
               <ol data-itemprop="authors">
@@ -3536,6 +4100,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Reversal%20of%20age-related%20cognitive%20impairments%20in%20mice%20by%20an%20extremely%20low%20dose%20of%20tetrahydrocannabinol">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1016/j.neurobiolaging.2017.09.025</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">29107185</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib47">
               <ol data-itemprop="authors">
@@ -3577,6 +4155,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Association%20of%20hormonal%20contraception%20with%20depression">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1001/jamapsychiatry.2016.2387</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">27680324</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib48">
               <ol data-itemprop="authors">
@@ -3631,6 +4223,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Endometrial%20ability%20to%20implant%20in%20ectopic%20sites%20can%20be%20prevented%20by%20interleukin-12%20in%20a%20murine%20model%20of%20endom%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1093/humrep/14.12.2944</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">10601076</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib49">
               <ol data-itemprop="authors">
@@ -3718,6 +4324,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Does%20endometriosis%20affect%20professional%20life?%20A%20matched%20case-control%20study%20in%20Switzerland,%20Germany%20and%20Austria">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1136/bmjopen-2017-019570</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">30782670</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib50">
               <ol data-itemprop="authors">
@@ -3792,6 +4412,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Cannabis%20and%20cannabinoids%20for%20the%20treatment%20of%20people%20with%20chronic%20noncancer%20pain%20conditions:%20a%20systematic%20re%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1097/j.pain.0000000000001293</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">29847469</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib51">
               <ol data-itemprop="authors">
@@ -3833,6 +4467,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=High%20density%20of%20small%20nerve%20fibres%20in%20the%20functional%20layer%20of%20the%20endometrium%20in%20women%20with%20endometriosis">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1093/humrep/dei368</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">16253968</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib52">
               <ol data-itemprop="authors">
@@ -3873,6 +4520,13 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Effectiveness%20and%20tolerability%20of%20THC:cbd%20oromucosal%20spray%20as%20add-on%20measure%20in%20patients%20with%20severe%20chronic%20%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.2147/JPR.S192174</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib53">
               <ol data-itemprop="authors">
@@ -3969,6 +4623,14 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Cognitive%20impairment%20induced%20by%20Delta9-%20tetrahydrocannabinol%20occurs%20through%20heteromers%20between%20cannabinoid%20CB%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1371/journal.pbio.1002194</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib54">
               <ol data-itemprop="authors">
@@ -4005,6 +4667,14 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Sex%20differences%20in%20antinociceptive%20tolerance%20to%20delta-9-tetrahydrocannabinol%20in%20the%20rat">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1016/j.drugalcdep.2014.07.029</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib55">
               <ol data-itemprop="authors">
@@ -4039,6 +4709,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=The%20role%20of%20the%20endocannabinoid%20system%20in%20female%20reproductive%20tissues">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1186/s13048-018-0478-9</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">30646937</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib56">
               <ol data-itemprop="authors">
@@ -4080,6 +4764,19 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Rich%20innervation%20of%20deep%20infiltrating%20endometriosis">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span itemprop="value">10.1093/humrep/den464</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">19151028</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib57">
               <ol data-itemprop="authors">
@@ -4123,6 +4820,14 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Decreased%20basal%20endogenous%20opioid%20levels%20in%20diabetic%20rodents:%20effects%20on%20morphine%20and%20delta-9-tetrahydrocanna%E2%80%A6">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1016/j.ejphar.2007.12.035</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib58">
               <ol data-itemprop="authors">
@@ -4199,6 +4904,20 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Cognitive%20impairment%20in%20a%20rat%20model%20of%20neuropathic%20pain:%20role%20of%20hippocampal%20microtubule%20stability">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1097/j.pain.0000000000001233</span>
+                </li>
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/pmid"><span
+                    itemprop="name">pmid</span><span itemprop="value"
+                    data-itemtype="http://schema.org/Number">29613911</span>
+                </li>
+              </ul>
             </li>
             <li itemscope="" itemtype="http://schema.org/Article" itemprop="citation" id="bib59">
               <ol data-itemprop="authors">
@@ -4247,6 +4966,14 @@
               </span>
               <meta itemprop="image"
                 content="https://via.placeholder.com/1200x714/dbdbdb/4a4a4a.png?text=Endometriosis">
+              <ul data-itemprop="identifiers">
+                <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+                  <meta itemprop="propertyID"
+                    content="https://registry.identifiers.org/registry/doi"><span
+                    itemprop="name">doi</span><span
+                    itemprop="value">10.1038/s41572-018-0008-5</span>
+                </li>
+              </ul>
             </li>
           </ol>
         </section>

--- a/src/codecs/html/index.ts
+++ b/src/codecs/html/index.ts
@@ -1051,7 +1051,7 @@ function encodeIsPartOfProperty(
 /**
  * Encode the pagination related properties of an article
  */
-function endodePaginationProperties(
+function encodePaginationProperties(
   article: stencila.Article
 ): (HTMLElement | undefined)[] {
   const { pageStart, pageEnd, pagination } = article
@@ -1265,9 +1265,9 @@ function encodeReferencesProperty(
             ? h('a', { itemprop: 'url', href: url }, titleElem)
             : titleElem,
           encodeIsPartOfProperty(isPartOf),
-          stencila.isArticle(ref) ? endodePaginationProperties(ref) : undefined,
+          stencila.isArticle(ref) ? encodePaginationProperties(ref) : undefined,
           encodePublisherProperty(publisher),
-          isA('Article', ref) ? encodeImageProperty(ref) : []
+          stencila.isArticle(ref) ? encodeImageProperty(ref) : undefined
         )
       })
     )

--- a/src/codecs/html/index.ts
+++ b/src/codecs/html/index.ts
@@ -1252,6 +1252,7 @@ function encodeReferencesProperty(
           url,
           isPartOf,
           publisher,
+          identifiers,
         } = ref
         const titleElem = encodeTitleProperty(title, state, 'span')
         return h(
@@ -1267,7 +1268,8 @@ function encodeReferencesProperty(
           encodeIsPartOfProperty(isPartOf),
           stencila.isArticle(ref) ? encodePaginationProperties(ref) : undefined,
           encodePublisherProperty(publisher),
-          stencila.isArticle(ref) ? encodeImageProperty(ref) : undefined
+          stencila.isArticle(ref) ? encodeImageProperty(ref) : undefined,
+          encodeIdentifiersProperty(identifiers)
         )
       })
     )

--- a/src/codecs/ipynb/__file_snapshots__/elife-50356.ipynb
+++ b/src/codecs/ipynb/__file_snapshots__/elife-50356.ipynb
@@ -364,6 +364,20 @@
           "type": "Date",
           "value": "2018"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1016/j.ejim.2018.01.001"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 29329891
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -412,6 +426,14 @@
           "type": "Date",
           "value": "1983"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1152/ajpendo.1983.244.2.E177"
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -467,6 +489,20 @@
           "type": "Date",
           "value": "2019"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1186/s12906-019-2431-x"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 30646891
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -585,6 +621,20 @@
           "type": "Date",
           "value": "2015"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1073/pnas.1507931112"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 26199416
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -642,6 +692,20 @@
           "type": "Date",
           "value": "2004"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1073/pnas.0403663101"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 15256593
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -780,6 +844,20 @@
           "type": "Date",
           "value": "2017"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1038/nm.4311"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 28481360
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -873,6 +951,20 @@
           "type": "Date",
           "value": "2015"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1097/01.j.pain.0000460347.77341.bd"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 25789436
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -948,6 +1040,20 @@
           "type": "Date",
           "value": "2011"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1016/j.biopsych.2011.04.022"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 21684528
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -1041,6 +1147,20 @@
           "type": "Date",
           "value": "2018"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1038/npp.2017.175"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 28816239
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -1098,6 +1218,20 @@
           "type": "Date",
           "value": "2012"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1371/journal.pone.0035538"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 22514749
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -1171,6 +1305,20 @@
           "type": "Date",
           "value": "2001"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1136/bmj.323.7303.13"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 11440935
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -1244,6 +1392,14 @@
           "type": "Date",
           "value": "2006"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1016/j.neuropharm.2005.11.017"
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -1364,6 +1520,20 @@
           "type": "Date",
           "value": "2017"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1038/nm.4262"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 28092666
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -1439,6 +1609,20 @@
           "type": "Date",
           "value": "2019"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1126/science.aap8586"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 30655440
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -1514,6 +1698,20 @@
           "type": "Date",
           "value": "2016"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1038/nrn.2016.28"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 27052382
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -1607,6 +1805,20 @@
           "type": "Date",
           "value": "2013"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1172/JCI67569"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 23934130
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -1665,6 +1877,20 @@
           "type": "Date",
           "value": "2004"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1016/j.ejphar.2004.03.051"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 15140630
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -1740,6 +1966,20 @@
           "type": "Date",
           "value": "2009"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1371/journal.pone.0004579"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 19238202
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -1852,6 +2092,20 @@
           "type": "Date",
           "value": "2019"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1007/s11011-019-00397-1"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 30798429
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -1900,6 +2154,20 @@
           "type": "Date",
           "value": "2014"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1016/j.biopsych.2013.06.012"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 23896204
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -1930,6 +2198,20 @@
           "type": "Date",
           "value": "1970"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1002/jez.1401750310"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 5529519
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -1996,6 +2278,20 @@
           "type": "Date",
           "value": "2011"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1016/j.fertnstert.2011.04.095"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 21621771
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -2026,6 +2322,20 @@
           "type": "Date",
           "value": "2004"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1097/01.gco.0000136496.95075.79"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 15232483
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -2119,6 +2429,14 @@
           "type": "Date",
           "value": "2017"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1038/srep44169"
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -2185,6 +2503,20 @@
           "type": "Date",
           "value": "2018"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1007/s00213-018-5036-z"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 30238130
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -2278,6 +2610,20 @@
           "type": "Date",
           "value": "2009"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1111/j.1476-5381.2009.00399.x"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 19681888
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -2344,6 +2690,20 @@
           "type": "Date",
           "value": "2013"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1016/j.ejogrb.2013.03.008"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 23537616
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -2401,6 +2761,20 @@
           "type": "Date",
           "value": "2016"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1055/s-0042-106303"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 27214593
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -2449,6 +2823,20 @@
           "type": "Date",
           "value": "2017"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1016/j.pbb.2017.10.012"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 29107728
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -2533,6 +2921,20 @@
           "type": "Date",
           "value": "2017"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1111/bph.13887"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 28548225
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -2581,6 +2983,20 @@
           "type": "Date",
           "value": "2018"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1101/lm.046870.117"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 30115766
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -2695,6 +3111,14 @@
           "type": "Date",
           "value": "2015"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1097/j.pain.0000000000000260"
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -2752,6 +3176,20 @@
           "type": "Date",
           "value": "2018"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1097/WNR.0000000000000993"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 29461336
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -2863,6 +3301,20 @@
           "type": "Date",
           "value": "2010"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.2353/ajpath.2010.100375"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 21057002
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -2947,6 +3399,20 @@
           "type": "Date",
           "value": "2018"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1093/biolre/ioy035"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 29425272
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -3004,6 +3470,20 @@
           "type": "Date",
           "value": "2014"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1111/bph.12519"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 24236988
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -3043,6 +3523,20 @@
           "type": "Date",
           "value": "2018"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1016/j.ejim.2018.01.004"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 29307505
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -3100,6 +3594,20 @@
           "type": "Date",
           "value": "2017"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1093/humrep/dex091"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 28482063
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -3139,6 +3647,20 @@
           "type": "Date",
           "value": "2015"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.2217/whe.15.47"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 26314611
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -3277,6 +3799,20 @@
           "type": "Date",
           "value": "2011"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1038/npp.2010.222"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 21150914
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -3343,6 +3879,20 @@
           "type": "Date",
           "value": "2004"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1530/rep.1.00095"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 15129012
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -3382,6 +3932,14 @@
           "type": "Date",
           "value": "1982"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1530/jrf.0.0640275"
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -3457,6 +4015,14 @@
           "type": "Date",
           "value": "2009"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1038/nn.2369"
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -3532,6 +4098,20 @@
           "type": "Date",
           "value": "2013"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1038/npp.2013.31"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 23358238
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -3571,6 +4151,14 @@
           "type": "Date",
           "value": "2017"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1038/nrendo.2016.194"
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -3637,6 +4225,20 @@
           "type": "Date",
           "value": "2018"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1016/j.neurobiolaging.2017.09.025"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 29107185
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -3694,6 +4296,20 @@
           "type": "Date",
           "value": "2016"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1001/jamapsychiatry.2016.2387"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 27680324
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -3769,6 +4385,20 @@
           "type": "Date",
           "value": "1999"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1093/humrep/14.12.2944"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 10601076
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -3908,6 +4538,20 @@
           "type": "Date",
           "value": "2019"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1136/bmjopen-2017-019570"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 30782670
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -4017,6 +4661,20 @@
           "type": "Date",
           "value": "2018"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1097/j.pain.0000000000001293"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 29847469
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -4074,6 +4732,20 @@
           "type": "Date",
           "value": "2006"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1093/humrep/dei368"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 16253968
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -4122,6 +4794,14 @@
           "type": "Date",
           "value": "2019"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.2147/JPR.S192174"
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -4278,6 +4958,14 @@
           "type": "Date",
           "value": "2015"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1371/journal.pbio.1002194"
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -4324,6 +5012,14 @@
           "type": "Date",
           "value": "2014"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1016/j.drugalcdep.2014.07.029"
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -4372,6 +5068,20 @@
           "type": "Date",
           "value": "2019"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1186/s13048-018-0478-9"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 30646937
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -4427,6 +5137,20 @@
           "type": "Date",
           "value": "2009"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1093/humrep/den464"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 19151028
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -4484,6 +5208,14 @@
           "type": "Date",
           "value": "2008"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1016/j.ejphar.2007.12.035"
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -4604,6 +5336,20 @@
           "type": "Date",
           "value": "2018"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1097/j.pain.0000000000001233"
+          },
+          {
+            "type": "PropertyValue",
+            "name": "pmid",
+            "propertyID": "https://registry.identifiers.org/registry/pmid",
+            "value": 29613911
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {
@@ -4679,6 +5425,14 @@
           "type": "Date",
           "value": "2019"
         },
+        "identifiers": [
+          {
+            "type": "PropertyValue",
+            "name": "doi",
+            "propertyID": "https://registry.identifiers.org/registry/doi",
+            "value": "10.1038/s41572-018-0008-5"
+          }
+        ],
         "isPartOf": {
           "type": "PublicationVolume",
           "isPartOf": {

--- a/src/codecs/jats/__file_snapshots__/elife-30274-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-30274-v1.yaml
@@ -288,6 +288,15 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1136/bmj.332.7549.1080
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 16675816
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -311,6 +320,15 @@ references:
     datePublished:
       type: Date
       value: '1948'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1136/jcp.1.5.288
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 16810816
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -343,6 +361,11 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.7554/eLife.04024
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -363,6 +386,11 @@ references:
     datePublished:
       type: Date
       value: '1983'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1177/014662168300700301
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -468,6 +496,11 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.18632/oncotarget.6568
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -516,6 +549,11 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.7554/eLife.04333
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -609,6 +647,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/ncomms11903
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27301576
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -634,6 +681,11 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1198/000313006X152649
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -676,6 +728,11 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.18632/oncotarget.3033
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -738,6 +795,15 @@ references:
     datePublished:
       type: Date
       value: '2004'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/sj.bjc.6601405
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 14735196
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -900,6 +966,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nature14985
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26331541
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -940,6 +1015,11 @@ references:
     datePublished:
       type: Date
       value: '2007'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.2144/000112598
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1030,6 +1110,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/srep28994
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27456714
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1090,6 +1179,15 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrg2825
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 20838408
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1162,6 +1260,11 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.17605/OSF.IO/MOKEB
     isPartOf:
       type: Periodical
       name: Open Science Framework
@@ -1212,6 +1315,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.cell.2012.08.026
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23021215
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1278,6 +1390,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.7554/eLife.15161
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27460974
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1353,6 +1474,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.cell.2012.08.033
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23021216
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1385,6 +1515,11 @@ references:
     datePublished:
       type: Date
       value: '1991'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1021/bp00012a600
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1417,6 +1552,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nn.2886
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21878926
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1484,6 +1628,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.molcel.2015.03.005
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25866248
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1561,6 +1714,15 @@ references:
     datePublished:
       type: Date
       value: '2000'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1002/1097-0215(20000915)87:6<787::AID-IJC4>3.0.CO;2-6
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 10956386
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1581,6 +1743,11 @@ references:
     datePublished:
       type: Date
       value: '1959'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1080/01621459.1959.10501526
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1615,6 +1782,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1101/cshperspect.a014191
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24492846
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1724,6 +1900,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nature13537
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25043028
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1786,6 +1971,15 @@ references:
     datePublished:
       type: Date
       value: '2005'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/sj.onc.1208198
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15516975
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1818,6 +2012,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nmeth.2089
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22930834
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1873,6 +2076,15 @@ references:
     datePublished:
       type: Date
       value: '1999'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/S0960-9822(99)80507-7
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 10556095
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2258,6 +2470,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/srep32249
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27577089
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2319,6 +2540,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1007/s11121-011-0217-6
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21541692
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2339,6 +2569,11 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.18637/jss.v036.i03
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2450,6 +2685,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nature13473
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25043018
     isPartOf:
       type: PublicationVolume
       isPartOf:

--- a/src/codecs/jats/__file_snapshots__/elife-43154-v2.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-43154-v2.yaml
@@ -283,6 +283,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nature15390
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26416757
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -375,6 +384,15 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.0711401105
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 18192399
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -779,6 +797,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.7554/eLife.15085
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28067620
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -875,6 +902,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pmed.1001339
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23152723
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -900,6 +936,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1056/NEJMra1708111
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29298156
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -962,6 +1007,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/ng.3107
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25261933
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -987,6 +1041,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/ije/dyu025
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24585732
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1029,6 +1092,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/ije/dyu026
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24585735
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1098,6 +1170,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/S2352-3026(15)00152-0
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26686045
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1136,6 +1217,15 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.1365-2141.2008.07085.x
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 18410566
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1183,6 +1273,11 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/S0140-6736(13)60024-0
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1200,6 +1295,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/tmi.12313_2
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25214480
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1235,6 +1339,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.hoc.2015.11.005
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27040958
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1265,6 +1378,11 @@ references:
     datePublished:
       type: Date
       value: '1971'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 5316621
     isPartOf:
       type: PublicationVolume
       isPartOf:

--- a/src/codecs/jats/__file_snapshots__/elife-46472-v3.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-46472-v3.yaml
@@ -526,6 +526,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/s41592-018-0011-5
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29786090
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -556,6 +565,15 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1262/jrd.2018-128
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30518723
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -596,6 +614,15 @@ references:
     datePublished:
       type: Date
       value: '1996'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1007/BF02359892
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 8639150
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -618,6 +645,15 @@ references:
     datePublished:
       type: Date
       value: '1998'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1023/A:1021404714631
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 9573644
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -685,6 +721,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1007/s00335-013-9484-9
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24217691
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -757,6 +802,15 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.0906522106
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19892733
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -784,6 +838,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1101/gr.187450.114
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25953951
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -871,6 +934,15 @@ references:
     datePublished:
       type: Date
       value: '2001'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1124/mol.60.6.1181
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 11723224
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -909,6 +981,15 @@ references:
     datePublished:
       type: Date
       value: '2001'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1002/1098-2396(200102)39:2<161::AID-SYN7>3.0.CO;2-E
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 11180503
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -936,6 +1017,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1097/YCO.0000000000000168
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26001916
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -986,6 +1076,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.3389/fnins.2015.00039
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25762894
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1027,6 +1126,11 @@ references:
     datePublished:
       type: Date
       value: '1987'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 3827997
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1059,6 +1163,11 @@ references:
     datePublished:
       type: Date
       value: '1989'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 2724134
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1086,6 +1195,15 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.1360-0443.2009.02564.x
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19426289
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1131,6 +1249,15 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.neures.2006.03.005
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 16644048
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1198,6 +1325,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.neuroscience.2014.07.020
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25058503
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1230,6 +1366,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.bbr.2014.06.035
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24978098
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1267,6 +1412,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1007/s00335-017-9724-5
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29127441
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1294,6 +1448,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/gbb.12100
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24152140
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1321,6 +1484,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/adb.12003
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23145527
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1378,6 +1550,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.neuropharm.2015.02.010
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25721394
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1485,6 +1666,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/npp.2015.65
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25749299
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1530,6 +1720,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.3389/fphar.2018.00645
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29977204
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1585,6 +1784,15 @@ references:
     datePublished:
       type: Date
       value: '2005'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/sj.npp.1300592
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15508023
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1607,6 +1815,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.ymeth.2010.07.007
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 20643209
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1656,6 +1873,15 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.1521-0391.2010.00082.x
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 20958846
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1703,6 +1929,15 @@ references:
     datePublished:
       type: Date
       value: '1997'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1523/JNEUROSCI.17-02-00745.1997
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 8987796
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1740,6 +1975,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/npp.2015.61
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25740289
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1775,6 +2019,11 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.3390/brainsci9070155
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1890,6 +2139,15 @@ references:
     datePublished:
       type: Date
       value: '2004'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1196/annals.1316.039
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15542732
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2000,6 +2258,15 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/sj.tpj.6500355
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 16402083
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2052,6 +2319,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pgen.1007503
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29985941
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2097,6 +2373,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1126/science.1225829
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22745249
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2124,6 +2409,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.ejphar.2015.06.019
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26092759
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2196,6 +2490,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.3389/fphar.2018.00953
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30233365
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2214,6 +2517,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.tig.2011.05.007
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21684621
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2259,6 +2571,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.neuropharm.2014.02.007
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24565640
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2331,6 +2652,15 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1124/jpet.107.132647
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 18083911
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2371,6 +2701,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1523/JNEUROSCI.2006-16.2016
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28123023
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2398,6 +2737,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.3389/fphar.2018.00279
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29636691
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2481,6 +2829,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.3389/fnsys.2014.00070
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24847220
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2587,6 +2944,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/ejn.13159
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26742098
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2669,6 +3035,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1186/s13073-016-0273-4
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26876963
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2710,6 +3085,15 @@ references:
     datePublished:
       type: Date
       value: '1998'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/S0031-9384(98)00212-1
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 9877427
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2762,6 +3146,15 @@ references:
     datePublished:
       type: Date
       value: '2002'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1006/nlme.2001.4048
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 12071673
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2799,6 +3192,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1007/978-1-4939-6427-7_4
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27933521
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2824,6 +3226,15 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/s41573-018-0009-9
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30679805
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2869,6 +3280,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/srep34703
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27698470
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2905,6 +3325,11 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.17226/12910
     publisher:
       type: Organization
       address:
@@ -2938,6 +3363,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/adb.12410
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27193165
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2995,6 +3429,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.3389/fphar.2017.00993
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29403379
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3106,6 +3549,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.1103029108
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21525407
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3138,6 +3590,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.3389/fphar.2017.00987
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29375386
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3176,6 +3637,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.1601-183X.2011.00700.x
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21554535
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3223,6 +3693,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.neuropharm.2012.01.002
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22280875
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3260,6 +3739,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.neuropharm.2011.11.005
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22118879
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3317,6 +3805,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.3389/fnins.2016.00493
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27853417
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3365,6 +3862,15 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/gbb.12533
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30375183
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3430,6 +3936,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pone.0152581
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27031617
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3480,6 +3995,15 @@ references:
     datePublished:
       type: Date
       value: '2002'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1300/J069v21n01_04
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 11831498
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3501,6 +4025,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1152/physiolgenomics.00127.2013
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24326347
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3531,6 +4064,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.bmcl.2010.12.075
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21237643
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3619,6 +4161,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.biopsych.2016.10.005
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27890469
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3638,6 +4189,11 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.18356/603a2a94-en
     publisher:
       type: Organization
       name: United Nations Publication
@@ -3703,6 +4259,15 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.1601-183X.2009.00522.x
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19689456
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3745,6 +4310,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/s41592-018-0148-2
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30275594
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3800,6 +4374,15 @@ references:
     datePublished:
       type: Date
       value: '2007'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.1601-183X.2006.00292.x
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 17212650
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3827,6 +4410,15 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1124/jpet.107.134247
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 18182557
     isPartOf:
       type: PublicationVolume
       isPartOf:

--- a/src/codecs/jats/__file_snapshots__/elife-46793-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-46793-v1.yaml
@@ -313,6 +313,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.apsb.2015.05.008
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26579458
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -446,6 +455,15 @@ references:
     datePublished:
       type: Date
       value: '2000'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/75556
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 10802651
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -519,6 +537,15 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1186/1479-5876-7-43
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19519883
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -594,6 +621,15 @@ references:
     datePublished:
       type: Date
       value: '1999'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1002/(SICI)1097-0215(19990909)82:6<868::AID-IJC16>3.0.CO;2-W
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 10446455
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -696,6 +732,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1158/0008-5472.CAN-13-2541
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24240700
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -728,6 +773,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrd3428
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21455236
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -818,6 +872,15 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.0712384105
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 18299561
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -855,6 +918,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1101/cshperspect.a026708
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28193767
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -910,6 +982,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nsmb.2339
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22751019
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -947,6 +1028,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nchem.1548
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23422559
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -987,6 +1077,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pone.0102711
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25033211
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1052,6 +1151,15 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/bioinformatics/btp101
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19237447
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1084,6 +1192,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/bioinformatics/btt019
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23325622
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1116,6 +1233,11 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrg3296
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1153,6 +1275,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.3390/ijms151017493
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25268620
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1173,6 +1304,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrc3560
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23842644
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1238,6 +1378,15 @@ references:
     datePublished:
       type: Date
       value: '2005'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nature03443
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15829966
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1265,6 +1414,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gks068
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22351747
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1290,6 +1448,11 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkw1280
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1333,6 +1496,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrc3459
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23550303
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1358,6 +1530,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.dnarep.2011.04.013
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21561811
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1406,6 +1587,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nbt.3295
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26192317
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1433,6 +1623,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrd3374
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21532565
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1473,6 +1672,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.2174/156800911794519752
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21247388
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1540,6 +1748,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.chembiol.2011.08.014
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22118673
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1592,6 +1809,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/s41586-018-0209-9
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29899445
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1662,6 +1888,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1021/acs.jmedchem.5b01357
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26878150
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1715,6 +1950,11 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1101/208439
     isPartOf:
       type: Periodical
       name: bioRxiv
@@ -1758,6 +1998,15 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1074/jbc.M806277200
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 18842585
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1796,6 +2045,15 @@ references:
     datePublished:
       type: Date
       value: '1993'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/363640a0
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 8510758
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1866,6 +2124,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.12688/f1000research.3928.2
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24860646
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1912,6 +2179,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.4161/cc.21399
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22871734
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1981,6 +2257,15 @@ references:
     datePublished:
       type: Date
       value: '2007'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.0707365104
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 17954919
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2024,6 +2309,15 @@ references:
     datePublished:
       type: Date
       value: '2007'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1021/ja067352b
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 17260991
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2050,6 +2344,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1080/23723556.2015.1025181
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27308538
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2101,6 +2404,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/bioinformatics/btw230
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27153664
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2155,6 +2467,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pone.0179883
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28666010
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2190,6 +2511,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrc.2016.51
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27282250
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2220,6 +2550,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1017/S1462399411002031
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22088887
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2305,6 +2644,15 @@ references:
     datePublished:
       type: Date
       value: '2005'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nature03445
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15829967
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2387,6 +2735,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkv1344
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26673716
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2485,6 +2842,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gku1075
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25355519
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2515,6 +2881,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.gene.2017.06.056
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28669924
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2550,6 +2925,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1007/s12032-011-0061-3
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21909941
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2587,6 +2971,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1186/1476-4598-12-91
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23937906
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2652,6 +3045,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkr234
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21586581
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2677,6 +3079,15 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1146/annurev.pharmtox.48.113006.094649
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19922264
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2824,6 +3235,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nmeth.2689
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24122041
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2864,6 +3284,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pone.0092444
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24647355
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2935,6 +3364,15 @@ references:
     datePublished:
       type: Date
       value: '1996'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1126/science.271.5247.350
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 8553070
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2975,6 +3413,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1186/1756-0500-5-138
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22414013
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3051,6 +3498,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/ng.3662
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27618450
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3086,6 +3542,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrd.2017.152
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28959952
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3146,6 +3611,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkt957
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24163102
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3206,6 +3680,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gky861
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30256975
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3273,6 +3756,11 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/ncb1378
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3303,6 +3791,15 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nprot.2008.211
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19131956
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3335,6 +3832,15 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkn923
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19033363
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3362,6 +3868,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/cr.2016.31
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27002218
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3384,6 +3899,11 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1039/b702491f
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3409,6 +3929,11 @@ references:
     datePublished:
       type: Date
       value: '2007'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkl1057
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3459,6 +3984,11 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/ng.2628
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3516,6 +4046,15 @@ references:
     datePublished:
       type: Date
       value: '2004'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1074/jbc.M400231200
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15028736
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3593,6 +4132,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.molcel.2014.10.025
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25435137
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3653,6 +4201,15 @@ references:
     datePublished:
       type: Date
       value: '2007'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nchembio.2007.16
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 17643112
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3690,6 +4247,15 @@ references:
     datePublished:
       type: Date
       value: '2007'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nchembio864
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 17322877
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3732,6 +4298,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nmeth.3965
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27571552
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3759,6 +4334,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nmeth.1923
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22388286
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3795,6 +4379,11 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1039/c5cc02252e
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3825,6 +4414,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/annonc/mdt384
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24225019
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3885,6 +4483,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.ejca.2012.03.023
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22538187
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3935,6 +4542,11 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.bbcan.2014.11.005
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -3965,6 +4577,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkv383
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25925572
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4061,6 +4682,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.chembiol.2016.08.013
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27693060
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4113,6 +4743,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/srep26585
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27215610
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4179,6 +4818,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1158/1535-7163.MCT-16-0457
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27980104
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4225,6 +4873,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.tips.2016.06.006
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27427153
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4255,6 +4912,11 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.bbamcr.2012.05.005
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4362,6 +5024,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.18632/oncotarget.2037
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24931005
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4423,6 +5094,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1021/ja404868t
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23782415
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4465,6 +5145,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkw079
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26883636
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4500,6 +5189,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/srep38144
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27905517
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4610,6 +5308,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1002/ijc.29263
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25302833
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4736,6 +5443,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.molcel.2011.02.015
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21362549
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4758,6 +5474,15 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.1742-4658.2009.07463.x
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19951354
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4780,6 +5505,11 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/s41570-017-0041
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4838,6 +5568,15 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1242/jcs.026351
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 18840648
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4885,6 +5624,11 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.3390/ijms18091886
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4934,6 +5678,15 @@ references:
     datePublished:
       type: Date
       value: '2005'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.molcel.2005.01.008
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15694335
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -4954,6 +5707,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.febslet.2010.11.024
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21094158
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5006,6 +5768,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/onc.2011.456
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21986947
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5093,6 +5864,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/onc.2014.327
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25284584
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5198,6 +5978,15 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1158/1535-7163.MCT-10-0324
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 20663931
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5245,6 +6034,11 @@ references:
     datePublished:
       type: Date
       value: '2005'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.mrfmmm.2004.09.010
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5273,6 +6067,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrc3929
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25998713
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5298,6 +6101,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkv862
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26350216
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5343,6 +6155,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1158/0008-5472.CAN-16-3565
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28652249
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5375,6 +6196,15 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/bioinformatics/btp616
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19910308
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5422,6 +6252,15 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1021/ja805615w
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 18975896
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5489,6 +6328,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nchembio.780
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22306580
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5779,6 +6627,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.cell.2018.03.035
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29625050
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5824,6 +6681,15 @@ references:
     datePublished:
       type: Date
       value: '2001'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.141229498
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 11438689
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5916,6 +6782,11 @@ references:
     datePublished:
       type: Date
       value: '1996'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 8653691
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5946,6 +6817,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrc.2017.105
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29242641
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -5971,6 +6851,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pone.0055119
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23355908
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6029,6 +6918,15 @@ references:
     datePublished:
       type: Date
       value: '2003'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1101/gr.1239303
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 14597658
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6141,6 +7039,15 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1101/gad.1703008
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 18832071
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6218,6 +7125,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkw1223
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27928057
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6315,6 +7231,11 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1186/gb-2011-12-10-r104
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6505,6 +7426,15 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nature07884
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19360080
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6551,6 +7481,15 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/sj.onc.1209242
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 16288211
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6627,6 +7566,11 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkw937
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6677,6 +7621,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.chembiol.2013.02.013
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23521792
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6696,6 +7649,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkw1099
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27899622
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6724,6 +7686,15 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkj403
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 16397294
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6749,6 +7720,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.tig.2016.09.004
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27663528
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6804,6 +7784,15 @@ references:
     datePublished:
       type: Date
       value: '2005'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1074/jbc.C500348200
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 16150737
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6826,6 +7815,15 @@ references:
     datePublished:
       type: Date
       value: '2002'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrm831
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 12042765
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6866,6 +7864,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.2147/DDDT.S68872
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25364233
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6938,6 +7945,15 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/s41467-019-08905-8
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30808951
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -6994,6 +8010,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1172/JCI65634
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23563309
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7021,6 +8046,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.3389/fonc.2012.00187
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23227454
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7066,6 +8100,15 @@ references:
     datePublished:
       type: Date
       value: '2002'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/emboj/cdf480
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 12234937
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7196,6 +8239,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nature13485
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25079319
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7276,6 +8328,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1158/0008-5472.CAN-18-1877
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30279242
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7303,6 +8364,15 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.1742-4658.2010.07760.x
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 20670277
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7514,6 +8584,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/ncomms14432
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28211448
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7559,6 +8638,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pgen.1004839
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25473964
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7584,6 +8672,11 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1080/15257770600809913
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7634,6 +8727,15 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/nar/gkj057
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 16381865
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7672,6 +8774,15 @@ references:
     datePublished:
       type: Date
       value: '2004'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/annonc/mdh073
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 14760118
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7719,6 +8830,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.bbrc.2017.11.139
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29175326
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7786,6 +8906,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/ncomms5581
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25091051
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -7881,6 +9010,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.molcel.2015.12.004
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26748828
     isPartOf:
       type: PublicationVolume
       isPartOf:

--- a/src/codecs/jats/__file_snapshots__/elife-52882-v2.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-52882-v2.yaml
@@ -286,6 +286,15 @@ references:
     datePublished:
       type: Date
       value: '1974'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1126/science.184.4143.1292
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 4598187
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -328,6 +337,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nmeth.2434
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23524393
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -350,6 +368,11 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1002/wics.10
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -375,6 +398,11 @@ references:
     datePublished:
       type: Date
       value: '1972'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/239500a0
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -405,6 +433,11 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.3389/fnsys.2011.00101
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -428,6 +461,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.cub.2015.01.042
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25754638
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -453,6 +495,15 @@ references:
     datePublished:
       type: Date
       value: '2001'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1023/a:1011204814320
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 11524578
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -480,6 +531,11 @@ references:
     datePublished:
       type: Date
       value: '2000'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1242/jeb.01529
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -512,6 +568,15 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.cub.2010.01.022
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 20153194
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -539,6 +604,15 @@ references:
     datePublished:
       type: Date
       value: '2007'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1242/jeb.003939
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 17601957
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -566,6 +640,15 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.0909673107
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 20080704
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -591,6 +674,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.3389/fnsys.2014.00039
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24723859
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -656,6 +748,11 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.7554/eLife.12741
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -681,6 +778,15 @@ references:
     datePublished:
       type: Date
       value: '1996'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1006/dbio.1996.0335
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 8954734
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -726,6 +832,15 @@ references:
     datePublished:
       type: Date
       value: '2007'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.0709337104
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 18025459
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -761,6 +876,11 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.0914718107
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -821,6 +941,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.cub.2012.08.016
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23000151
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -853,6 +982,15 @@ references:
     datePublished:
       type: Date
       value: '2004'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nature02907
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15457262
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -895,6 +1033,11 @@ references:
     datePublished:
       type: Date
       value: '1995'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1017/S0140525X0004022X
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -925,6 +1068,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pone.0128668
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26132396
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -953,6 +1105,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/ncomms1455
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21863008
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -978,6 +1139,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.conb.2011.11.008
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22169055
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1015,6 +1185,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1186/s12915-016-0346-2
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28122559
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1072,6 +1251,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/s41467-018-03520-5
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29593252
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1129,6 +1317,11 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1101/672246
     isPartOf:
       type: Periodical
       name: bioRxiv
@@ -1187,6 +1380,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.1215295110
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24043822
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1271,6 +1473,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pone.0139521
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26437184
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1294,6 +1505,11 @@ references:
     datePublished:
       type: Date
       value: '1975'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/0022-5193(75)90094-6
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1319,6 +1535,15 @@ references:
     datePublished:
       type: Date
       value: '1972'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.69.9.2509
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 4560688
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1349,6 +1574,11 @@ references:
     datePublished:
       type: Date
       value: '1999'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1098/rspb.1999.0787
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1386,6 +1616,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.cub.2017.12.002
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29307558
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1418,6 +1657,11 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1007/s00359-014-0954-7
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1537,6 +1781,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pone.0032295
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22359680
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1562,6 +1815,15 @@ references:
     datePublished:
       type: Date
       value: '2007'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1529/biophysj.106.097808
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 17208965
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1604,6 +1866,15 @@ references:
     datePublished:
       type: Date
       value: '2005'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1523/JNEUROSCI.5133-04.2005
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15800192
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1634,6 +1905,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.1600760113
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27222583
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1659,6 +1939,15 @@ references:
     datePublished:
       type: Date
       value: '2005'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1017/S0952523805223039
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 16079003
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1711,6 +2000,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.3389/fncir.2013.00065
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23576959
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1753,6 +2051,11 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1523/JNEUROSCI.4332-06.2006
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1790,6 +2093,11 @@ references:
     datePublished:
       type: Date
       value: '1994'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1007/BF02025449
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1822,6 +2130,11 @@ references:
     datePublished:
       type: Date
       value: '1999'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1590/S0100-879X1999001200016
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1847,6 +2160,15 @@ references:
     datePublished:
       type: Date
       value: '1996'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.93.2.628
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 8570606
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1872,6 +2194,15 @@ references:
     datePublished:
       type: Date
       value: '2001'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1152/jn.2001.86.4.1916
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 11600651
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1909,6 +2240,15 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pcbi.1000028
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 18389066
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1962,6 +2302,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.7554/eLife.38740
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30465650
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1997,6 +2346,15 @@ references:
     datePublished:
       type: Date
       value: '1999'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1126/science.286.5446.1943
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 10583955
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2024,6 +2382,11 @@ references:
     datePublished:
       type: Date
       value: '1930'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1103/PhysRev.36.823
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2044,6 +2407,15 @@ references:
     datePublished:
       type: Date
       value: '2001'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/S0166-2236(00)01868-3
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 11476885
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2064,6 +2436,15 @@ references:
     datePublished:
       type: Date
       value: '2002'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/S0896-6273(02)01092-9
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 12467598
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2084,6 +2465,15 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.neuron.2008.09.034
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 18957215
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2104,6 +2494,15 @@ references:
     datePublished:
       type: Date
       value: '1973'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.70.3.817
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 4351805
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2141,6 +2540,15 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nn.2155
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 18604203
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2211,6 +2619,11 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/s41467-017-00310-3
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2246,6 +2659,15 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.1007333107
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 20615986
     isPartOf:
       type: PublicationVolume
       isPartOf:

--- a/src/codecs/jats/__file_snapshots__/f1000-7-1655-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/f1000-7-1655-v1.yaml
@@ -249,6 +249,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30158621
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/d41586-018-06032-w
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -272,6 +281,19 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28580134
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.12688/f1000research.11369.2
+      - type: PropertyValue
+        name: pmcid
+        propertyID: https://registry.identifiers.org/registry/pmcid
+        value: 5967747
     isPartOf:
       type: PublicationVolume
       isPartOf:

--- a/src/codecs/jats/__file_snapshots__/f1000-8-1394-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/f1000-8-1394-v1.yaml
@@ -167,6 +167,11 @@ references:
     datePublished:
       type: Date
       value: '2004'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.5281/zenodo.3266096
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -242,6 +247,11 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1159/000484886
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -264,6 +274,11 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1159/000489287
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -313,6 +328,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25845492
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.yebeh.2015.02.043
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -345,6 +369,19 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29998598
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/epi.14477
+      - type: PropertyValue
+        name: pmcid
+        propertyID: https://registry.identifiers.org/registry/pmcid
+        value: 6175436
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -381,6 +418,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26724101
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/S1474-4422(15)00379-8
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -416,6 +462,19 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28861485
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1089/can.2015.0004
+      - type: PropertyValue
+        name: pmcid
+        propertyID: https://registry.identifiers.org/registry/pmcid
+        value: 5576596
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -476,6 +535,11 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.2903/j.efsa.2015.4141
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -510,6 +574,19 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29977291
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1155/2018/8143582
+      - type: PropertyValue
+        name: pmcid
+        propertyID: https://registry.identifiers.org/registry/pmcid
+        value: 6011091
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -541,6 +618,11 @@ references:
     datePublished:
       type: Date
       value: '1940'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1021/ja01866a040
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -577,6 +659,11 @@ references:
     datePublished:
       type: Date
       value: '1941'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1021/ja01853a052
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -610,6 +697,11 @@ references:
     datePublished:
       type: Date
       value: '2007'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1007/s11419-007-0021-y
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -640,6 +732,11 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1300/J237v10n02_02
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -668,6 +765,11 @@ references:
     datePublished:
       type: Date
       value: '2005'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.5281/zenodo.438133
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -690,6 +792,15 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 31030057
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.drugpo.2019.03.006
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -720,6 +831,19 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28861507
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1089/can.2017.0009
+      - type: PropertyValue
+        name: pmcid
+        propertyID: https://registry.identifiers.org/registry/pmcid
+        value: 5510776
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -755,6 +879,19 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28861499
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1089/can.2016.0036
+      - type: PropertyValue
+        name: pmcid
+        propertyID: https://registry.identifiers.org/registry/pmcid
+        value: 5531368
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -847,6 +984,19 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25634572
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/srep08126
+      - type: PropertyValue
+        name: pmcid
+        propertyID: https://registry.identifiers.org/registry/pmcid
+        value: 4311234
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -868,6 +1018,15 @@ references:
     datePublished:
       type: Date
       value: '2003'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 12648025
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.2165/00003088-200342040-00003
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -896,6 +1055,11 @@ references:
     datePublished:
       type: Date
       value: '1997'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 9157527
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -916,6 +1080,11 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.17590/20181108-075209-0
     title: >-
       Tetrahydrocannabinolgehalte sind in vielen hanfhaltigen Lebensmitteln zu
       hoch – gesundheitliche Beeinträchtigungen sind möglich. Stellungnahme Nr.
@@ -941,6 +1110,19 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29114823
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1001/jama.2017.11909
+      - type: PropertyValue
+        name: pmcid
+        propertyID: https://registry.identifiers.org/registry/pmcid
+        value: 5818782
     isPartOf:
       type: PublicationIssue
       isPartOf:

--- a/src/codecs/jats/__file_snapshots__/f1000-8-978-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/f1000-8-978-v1.yaml
@@ -233,6 +233,19 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22257223
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.1461-0248.2011.01736.x
+      - type: PropertyValue
+        name: pmcid
+        propertyID: https://registry.identifiers.org/registry/pmcid
+        value: 3880584
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -266,6 +279,11 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.biocon.2013.05.020
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -298,6 +316,11 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.ecocom.2014.02.003
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -358,6 +381,11 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.jaridenv.2015.02.008
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -390,6 +418,11 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.4236/nr.2012.31001
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -459,6 +492,11 @@ references:
     datePublished:
       type: Date
       value: '2002'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/S0304-3800(02)00056-X
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -489,6 +527,15 @@ references:
     datePublished:
       type: Date
       value: '2007'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 17011070
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.tree.2006.09.010
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -522,6 +569,11 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.ecoleng.2016.04.010
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -555,6 +607,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28474209
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1007/s00267-017-0884-6
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -585,6 +646,11 @@ references:
     datePublished:
       type: Date
       value: '2001'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.2307/2679936
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -620,6 +686,11 @@ references:
     datePublished:
       type: Date
       value: '2003'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.1523-1739.2003.00233.x
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -655,6 +726,11 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.1365-2664.2006.01164.x
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -688,6 +764,11 @@ references:
     datePublished:
       type: Date
       value: '2007'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.1365-2699.2006.01594.x
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -723,6 +804,11 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.foreco.2015.08.004
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -755,6 +841,11 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.3832/ifor2559-011
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -790,6 +881,15 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 16972877
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.1461-0248.2006.00970.x
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -825,6 +925,19 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24134332
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/ele.12189
+      - type: PropertyValue
+        name: pmcid
+        propertyID: https://registry.identifiers.org/registry/pmcid
+        value: 4280402
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -858,6 +971,11 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.ecolmodel.2005.03.026
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -891,6 +1009,11 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.0906-7590.2006.04700.x
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -946,6 +1069,11 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.ecolmodel.2005.03.026
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -979,6 +1107,15 @@ references:
     datePublished:
       type: Date
       value: '2005'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15652855
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.ajo.2004.07.062
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -1007,6 +1144,11 @@ references:
     datePublished:
       type: Date
       value: '2005'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.foreco.2005.03.058
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -1071,6 +1213,11 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1007/s10584-011-0151-4
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -1103,6 +1250,11 @@ references:
     datePublished:
       type: Date
       value: '2005'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1002/joc.1276
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -1136,6 +1288,11 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.2006.0906-7590.04596.x
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -1171,6 +1328,19 @@ references:
     datePublished:
       type: Date
       value: '2007'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 17622339
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pone.0000563
+      - type: PropertyValue
+        name: pmcid
+        propertyID: https://registry.identifiers.org/registry/pmcid
+        value: 1905943
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -1237,6 +1407,11 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.1600-0587.2009.05800.x
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -1272,6 +1447,19 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21060831
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pone.0013724
+      - type: PropertyValue
+        name: pmcid
+        propertyID: https://registry.identifiers.org/registry/pmcid
+        value: 2966403
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -1307,6 +1495,11 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.1472-4642.2010.00725.x
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -1336,6 +1529,11 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.ecolmodel.2011.04.011
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -1371,6 +1569,11 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.1365-2664.2006.01214.x
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -1406,6 +1609,11 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.actao.2013.02.007
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1451,6 +1659,19 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24520340
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pone.0087895
+      - type: PropertyValue
+        name: pmcid
+        propertyID: https://registry.identifiers.org/registry/pmcid
+        value: 3919747
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -1485,6 +1706,11 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1007/s11738-012-1076-x
     isPartOf:
       type: PublicationIssue
       isPartOf:
@@ -1545,6 +1771,11 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.jaridenv.2008.10.004
     isPartOf:
       type: PublicationIssue
       isPartOf:

--- a/src/codecs/jats/__file_snapshots__/ijm-00202.yaml
+++ b/src/codecs/jats/__file_snapshots__/ijm-00202.yaml
@@ -130,6 +130,11 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1257/pol.3.2.1
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -160,6 +165,11 @@ references:
     datePublished:
       type: Date
       value: '2004'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.2307/3455869
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -192,6 +202,11 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.15609/annaeconstat2009.117-118.141
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -237,6 +252,11 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1007/s11150-010-9094-1
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -294,6 +314,11 @@ references:
     datePublished:
       type: Date
       value: '2007'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.18356/126c5701-en
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -447,6 +472,11 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.jempfin.2008.02.001
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -544,6 +574,11 @@ references:
     datePublished:
       type: Date
       value: '2004'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1080/0266476042000214501
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -569,6 +604,11 @@ references:
     datePublished:
       type: Date
       value: '2007'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1628/001522107X250140
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -672,6 +712,11 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/restud/rdr049
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -697,6 +742,11 @@ references:
     datePublished:
       type: Date
       value: '2003'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1191/1471082X03st053oa
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -719,6 +769,11 @@ references:
     datePublished:
       type: Date
       value: '1991'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1108/EUM0000000000158
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -744,6 +799,11 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1007/s00362-008-0125-4
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -769,6 +829,11 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.csda.2011.10.005
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -789,6 +854,11 @@ references:
     datePublished:
       type: Date
       value: '2001'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/oxfordjournals.pan.a004873
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -875,6 +945,11 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1037/1082-989X.11.1.54
     isPartOf:
       type: PublicationVolume
       isPartOf:

--- a/src/codecs/jats/index.ts
+++ b/src/codecs/jats/index.ts
@@ -1181,6 +1181,22 @@ function decodeReference(
     publisher = stencila.organization({ name: publisherName, address })
   }
 
+  let identifiers: stencila.CreativeWork['identifiers'] = all(elem, 'pub-id')
+    .map((elem) => {
+      const name = attr(elem, 'pub-id-type') ?? undefined
+      const propertyID = encodeIdentifierTypeUri(name)
+      const value = textOrUndefined(elem)
+      return value !== undefined
+        ? stencila.propertyValue({
+            name,
+            propertyID,
+            value,
+          })
+        : undefined
+    })
+    .filter(isDefined)
+  if (identifiers.length === 0) identifiers = undefined
+
   return stencila.article({
     id,
     authors,
@@ -1190,6 +1206,7 @@ function decodeReference(
     pageEnd,
     isPartOf,
     publisher,
+    identifiers,
     url,
   })
 }

--- a/src/codecs/md/__file_snapshots__/elife-50356.md
+++ b/src/codecs/md/__file_snapshots__/elife-50356.md
@@ -235,6 +235,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.ejim.2018.01.001
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29329891
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -267,6 +276,11 @@ references:
     datePublished:
       type: Date
       value: '1983'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1152/ajpendo.1983.244.2.E177
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -302,6 +316,15 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1186/s12906-019-2431-x
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30646891
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -372,6 +395,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.1507931112
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26199416
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -409,6 +441,15 @@ references:
     datePublished:
       type: Date
       value: '2004'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.0403663101
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15256593
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -489,6 +530,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nm.4311
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28481360
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -546,6 +596,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1097/01.j.pain.0000460347.77341.bd
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25789436
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -591,6 +650,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.biopsych.2011.04.022
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21684528
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -648,6 +716,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/npp.2017.175
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28816239
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -685,6 +762,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pone.0035538
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22514749
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -728,6 +814,15 @@ references:
     datePublished:
       type: Date
       value: '2001'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1136/bmj.323.7303.13
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 11440935
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -773,6 +868,11 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.neuropharm.2005.11.017
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -845,6 +945,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nm.4262
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28092666
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -892,6 +1001,15 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1126/science.aap8586
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30655440
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -937,6 +1055,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrn.2016.28
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27052382
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -992,6 +1119,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1172/JCI67569
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23934130
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1030,6 +1166,15 @@ references:
     datePublished:
       type: Date
       value: '2004'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.ejphar.2004.03.051
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15140630
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1077,6 +1222,15 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pone.0004579
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19238202
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1143,6 +1297,15 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1007/s11011-019-00397-1
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30798429
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1176,6 +1339,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.biopsych.2013.06.012
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23896204
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1198,6 +1370,15 @@ references:
     datePublished:
       type: Date
       value: '1970'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1002/jez.1401750310
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 5529519
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1240,6 +1421,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.fertnstert.2011.04.095
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21621771
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1262,6 +1452,15 @@ references:
     datePublished:
       type: Date
       value: '2004'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1097/01.gco.0000136496.95075.79
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15232483
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1317,6 +1516,11 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/srep44169
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1359,6 +1563,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1007/s00213-018-5036-z
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30238130
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1416,6 +1629,15 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.1476-5381.2009.00399.x
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19681888
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1458,6 +1680,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.ejogrb.2013.03.008
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23537616
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1495,6 +1726,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1055/s-0042-106303
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27214593
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1527,6 +1767,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.pbb.2017.10.012
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29107728
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1580,6 +1829,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/bph.13887
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28548225
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1612,6 +1870,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1101/lm.046870.117
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30115766
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1682,6 +1949,11 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1097/j.pain.0000000000000260
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1719,6 +1991,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1097/WNR.0000000000000993
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29461336
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1786,6 +2067,15 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.2353/ajpath.2010.100375
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21057002
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1838,6 +2128,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/biolre/ioy035
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29425272
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1875,6 +2174,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/bph.12519
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24236988
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1902,6 +2210,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.ejim.2018.01.004
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29307505
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1937,6 +2254,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/humrep/dex091
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28482063
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1964,6 +2290,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.2217/whe.15.47
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26314611
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2044,6 +2379,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/npp.2010.222
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21150914
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2086,6 +2430,15 @@ references:
     datePublished:
       type: Date
       value: '2004'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1530/rep.1.00095
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15129012
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2111,6 +2464,11 @@ references:
     datePublished:
       type: Date
       value: '1982'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1530/jrf.0.0640275
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2158,6 +2516,11 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nn.2369
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2205,6 +2568,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/npp.2013.31
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23358238
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2230,6 +2602,11 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrendo.2016.194
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2270,6 +2647,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.neurobiolaging.2017.09.025
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29107185
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2307,6 +2693,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1001/jamapsychiatry.2016.2387
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27680324
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2352,6 +2747,15 @@ references:
     datePublished:
       type: Date
       value: '1999'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/humrep/14.12.2944
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 10601076
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2435,6 +2839,15 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1136/bmjopen-2017-019570
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30782670
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2500,6 +2913,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1097/j.pain.0000000000001293
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29847469
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2538,6 +2960,15 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/humrep/dei368
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 16253968
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2570,6 +3001,11 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.2147/JPR.S192174
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2663,6 +3099,11 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pbio.1002194
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2694,6 +3135,11 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.drugalcdep.2014.07.029
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2726,6 +3172,15 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1186/s13048-018-0478-9
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30646937
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2759,6 +3214,15 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/humrep/den464
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19151028
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2794,6 +3258,11 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.ejphar.2007.12.035
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2866,6 +3335,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1097/j.pain.0000000000001233
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29613911
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2913,6 +3391,11 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/s41572-018-0008-5
     isPartOf:
       type: PublicationVolume
       isPartOf:

--- a/src/codecs/xmd/__file_snapshots__/elife-50356.Rmd
+++ b/src/codecs/xmd/__file_snapshots__/elife-50356.Rmd
@@ -235,6 +235,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.ejim.2018.01.001
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29329891
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -267,6 +276,11 @@ references:
     datePublished:
       type: Date
       value: '1983'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1152/ajpendo.1983.244.2.E177
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -302,6 +316,15 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1186/s12906-019-2431-x
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30646891
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -372,6 +395,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.1507931112
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26199416
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -409,6 +441,15 @@ references:
     datePublished:
       type: Date
       value: '2004'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1073/pnas.0403663101
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15256593
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -489,6 +530,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nm.4311
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28481360
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -546,6 +596,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1097/01.j.pain.0000460347.77341.bd
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 25789436
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -591,6 +650,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.biopsych.2011.04.022
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21684528
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -648,6 +716,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/npp.2017.175
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28816239
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -685,6 +762,15 @@ references:
     datePublished:
       type: Date
       value: '2012'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pone.0035538
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 22514749
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -728,6 +814,15 @@ references:
     datePublished:
       type: Date
       value: '2001'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1136/bmj.323.7303.13
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 11440935
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -773,6 +868,11 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.neuropharm.2005.11.017
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -845,6 +945,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nm.4262
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28092666
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -892,6 +1001,15 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1126/science.aap8586
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30655440
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -937,6 +1055,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrn.2016.28
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27052382
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -992,6 +1119,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1172/JCI67569
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23934130
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1030,6 +1166,15 @@ references:
     datePublished:
       type: Date
       value: '2004'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.ejphar.2004.03.051
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15140630
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1077,6 +1222,15 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pone.0004579
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19238202
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1143,6 +1297,15 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1007/s11011-019-00397-1
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30798429
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1176,6 +1339,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.biopsych.2013.06.012
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23896204
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1198,6 +1370,15 @@ references:
     datePublished:
       type: Date
       value: '1970'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1002/jez.1401750310
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 5529519
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1240,6 +1421,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.fertnstert.2011.04.095
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21621771
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1262,6 +1452,15 @@ references:
     datePublished:
       type: Date
       value: '2004'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1097/01.gco.0000136496.95075.79
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15232483
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1317,6 +1516,11 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/srep44169
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1359,6 +1563,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1007/s00213-018-5036-z
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30238130
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1416,6 +1629,15 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/j.1476-5381.2009.00399.x
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19681888
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1458,6 +1680,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.ejogrb.2013.03.008
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23537616
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1495,6 +1726,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1055/s-0042-106303
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27214593
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1527,6 +1767,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.pbb.2017.10.012
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29107728
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1580,6 +1829,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/bph.13887
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28548225
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1612,6 +1870,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1101/lm.046870.117
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30115766
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1682,6 +1949,11 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1097/j.pain.0000000000000260
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1719,6 +1991,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1097/WNR.0000000000000993
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29461336
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1786,6 +2067,15 @@ references:
     datePublished:
       type: Date
       value: '2010'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.2353/ajpath.2010.100375
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21057002
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1838,6 +2128,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/biolre/ioy035
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29425272
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1875,6 +2174,15 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1111/bph.12519
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 24236988
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1902,6 +2210,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.ejim.2018.01.004
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29307505
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1937,6 +2254,15 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/humrep/dex091
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 28482063
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -1964,6 +2290,15 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.2217/whe.15.47
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 26314611
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2044,6 +2379,15 @@ references:
     datePublished:
       type: Date
       value: '2011'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/npp.2010.222
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 21150914
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2086,6 +2430,15 @@ references:
     datePublished:
       type: Date
       value: '2004'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1530/rep.1.00095
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 15129012
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2111,6 +2464,11 @@ references:
     datePublished:
       type: Date
       value: '1982'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1530/jrf.0.0640275
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2158,6 +2516,11 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nn.2369
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2205,6 +2568,15 @@ references:
     datePublished:
       type: Date
       value: '2013'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/npp.2013.31
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 23358238
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2230,6 +2602,11 @@ references:
     datePublished:
       type: Date
       value: '2017'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/nrendo.2016.194
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2270,6 +2647,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.neurobiolaging.2017.09.025
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29107185
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2307,6 +2693,15 @@ references:
     datePublished:
       type: Date
       value: '2016'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1001/jamapsychiatry.2016.2387
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 27680324
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2352,6 +2747,15 @@ references:
     datePublished:
       type: Date
       value: '1999'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/humrep/14.12.2944
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 10601076
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2435,6 +2839,15 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1136/bmjopen-2017-019570
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30782670
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2500,6 +2913,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1097/j.pain.0000000000001293
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29847469
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2538,6 +2960,15 @@ references:
     datePublished:
       type: Date
       value: '2006'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/humrep/dei368
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 16253968
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2570,6 +3001,11 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.2147/JPR.S192174
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2663,6 +3099,11 @@ references:
     datePublished:
       type: Date
       value: '2015'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1371/journal.pbio.1002194
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2694,6 +3135,11 @@ references:
     datePublished:
       type: Date
       value: '2014'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.drugalcdep.2014.07.029
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2726,6 +3172,15 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1186/s13048-018-0478-9
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 30646937
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2759,6 +3214,15 @@ references:
     datePublished:
       type: Date
       value: '2009'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1093/humrep/den464
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 19151028
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2794,6 +3258,11 @@ references:
     datePublished:
       type: Date
       value: '2008'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1016/j.ejphar.2007.12.035
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2866,6 +3335,15 @@ references:
     datePublished:
       type: Date
       value: '2018'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1097/j.pain.0000000000001233
+      - type: PropertyValue
+        name: pmid
+        propertyID: https://registry.identifiers.org/registry/pmid
+        value: 29613911
     isPartOf:
       type: PublicationVolume
       isPartOf:
@@ -2913,6 +3391,11 @@ references:
     datePublished:
       type: Date
       value: '2019'
+    identifiers:
+      - type: PropertyValue
+        name: doi
+        propertyID: https://registry.identifiers.org/registry/doi
+        value: 10.1038/s41572-018-0008-5
     isPartOf:
       type: PublicationVolume
       isPartOf:


### PR DESCRIPTION
Closes #816 and addresses part of #413 (to have `identifiers` for `references` in fixtures).