### PR TITLE
fix(MD): Don't treat email addresses as citations

### DIFF
--- a/src/codecs/md/md.test.ts
+++ b/src/codecs/md/md.test.ts
@@ -1175,7 +1175,7 @@ And lastly a simple, non-linked, email hello@stenci.la.
     )
   })
 
-  it('decodes a citation at the end a a sentence', async () => {
+  it('decodes a citation at the end of a sentence', async () => {
     const article = `# Cite test
 
 A sentence ending with a citation (${reference}).

--- a/src/codecs/md/md.test.ts
+++ b/src/codecs/md/md.test.ts
@@ -1135,6 +1135,58 @@ Followed by more text
 
     expect(await d(citeGroup)).toEqual(citeGroupNode)
   })
+
+  it('does not treat email addresses as citations', async () => {
+    const article = `# Cite test
+
+Some paragraph with a citation (${reference}) inside a paragraph.
+
+Followed by more text and an email [hello@stenci.la](mailto:hello@stenci.la).
+
+And lastly a simple, non-linked, email hello@stenci.la.
+`
+
+    const ast = await d(article)
+    expect(ast).toHaveProperty(
+      ['content', 0, 'content'],
+      expect.arrayContaining([expect.objectContaining(referenceNode)])
+    )
+
+    expect(ast).toHaveProperty(
+      ['content', 1, 'content'],
+      expect.arrayContaining([
+        expect.objectContaining({
+          content: ['hello@stenci.la'],
+          target: 'mailto:hello@stenci.la',
+          type: 'Link',
+        }),
+      ])
+    )
+
+    expect(ast).toHaveProperty(
+      ['content', 2, 'content'],
+      expect.arrayContaining([
+        expect.objectContaining({
+          content: ['hello@stenci.la'],
+          target: 'mailto:hello@stenci.la',
+          type: 'Link',
+        }),
+      ])
+    )
+  })
+
+  it('decodes a citation at the end a a sentence', async () => {
+    const article = `# Cite test
+
+A sentence ending with a citation (${reference}).
+`
+
+    const ast = await d(article)
+    expect(ast).toHaveProperty(
+      ['content', 0, 'content'],
+      expect.arrayContaining([expect.objectContaining(referenceNode)])
+    )
+  })
 })
 
 describe('References', () => {

--- a/src/codecs/md/plugins/cite.ts
+++ b/src/codecs/md/plugins/cite.ts
@@ -8,7 +8,11 @@ import { Eat, Locator, Parser, Tokenizer } from 'remark-parse'
 import { Plugin } from 'unified'
 
 const marker = '@'
-const CITE_REGEX = /[ [(]@([\w|-]+)[\w.]*[\])]?|^@([\w|-]+)[\w.]*/
+/* Regex to find Pandoc style citations, but care needs to be taken to filter out email addresses.
+ * Group 1: Possibly a citation target id
+ * Group 2: Possibly the top level domain of an email address. If not empty, then the match is an email.
+ */
+const CITE_REGEX = /\B@([\w|-]+)(\.\w+)?/
 
 const locator: Locator = (value, fromIndex) => {
   let index = -1
@@ -48,10 +52,16 @@ export const citePlugin: Plugin<[]> = function () {
       !value.startsWith(marker + ' ') &&
       !value.startsWith(marker + marker)
     ) {
+      const matches = CITE_REGEX.exec(value) ?? []
+
+      const isEmail = matches[2] !== undefined
+
+      // Early termination if we’re dealing with an email and not a citation format
+      if (isEmail) return
+
       const citeLength = pipe(
-        CITE_REGEX.exec(value) ?? [],
+        matches,
         A.head,
-        O.filter((match) => !(match.includes('.') && !match.endsWith('.'))), // Filter out email addresses, but not end of sentences
         O.getOrElse(() => ''),
         (match) => match.length
       )

--- a/src/codecs/md/plugins/cite.ts
+++ b/src/codecs/md/plugins/cite.ts
@@ -8,7 +8,7 @@ import { Eat, Locator, Parser, Tokenizer } from 'remark-parse'
 import { Plugin } from 'unified'
 
 const marker = '@'
-const CITE_REGEX = /@([\w|-]+)/
+const CITE_REGEX = /[ [(]@([\w|-]+)[\w.]*[\])]?|^@([\w|-]+)[\w.]*/
 
 const locator: Locator = (value, fromIndex) => {
   let index = -1
@@ -51,9 +51,13 @@ export const citePlugin: Plugin<[]> = function () {
       const citeLength = pipe(
         CITE_REGEX.exec(value) ?? [],
         A.head,
+        O.filter((match) => !(match.includes('.') && !match.endsWith('.'))), // Filter out email addresses, but not end of sentences
         O.getOrElse(() => ''),
         (match) => match.length
       )
+
+      // Early termination if we don’t have a match
+      if (citeLength === 0) return
 
       eat(value.substring(0, citeLength))({
         type: 'cite',


### PR DESCRIPTION
When transforming MD, Encoda would treat links containing email addresses (`[hello@stenci.la](mailto:hello@stenci.la)`) as Citations. This PR fixes the issue.

![Screenshot 2021-03-08 at 13 08 58@2x](https://user-images.githubusercontent.com/1646307/110362706-98b81e00-800f-11eb-82d7-45739deed88b.png)
