### PR TITLE
fix: Allow MathML elements with `m:math` namespace in JATS

### DIFF
--- a/src/codecs/jats/index.ts
+++ b/src/codecs/jats/index.ts
@@ -2117,7 +2117,7 @@ function decodeMath(
   formula: xml.Element
 ): (stencila.Math | stencila.ImageObject | stencila.Paragraph)[] {
   const inline = formula.name === 'inline-formula'
-  const mathml = first(formula, 'mml:math') || first(formula, 'm:math')
+  const mathml = first(formula, 'mml:math') ?? first(formula, 'm:math')
 
   if (mathml === null) {
     const graphic = first(formula, ['graphic', 'inline-graphic'])

--- a/src/codecs/jats/index.ts
+++ b/src/codecs/jats/index.ts
@@ -2109,15 +2109,15 @@ function decodeSupplementaryMaterial(
  * Decode a JATS `<inline-formula>` or `<disp-formula>` element to a
  * Stencila `MathFragment`, `MathBlock` or `ImageObject` node.
  *
- * This function preferentially uses `<mml:math>` but, if that is
- * not available, uses an image as an alternative (which is wrapped in
- * a paragraph for display formulas).
+ * This function preferentially uses `<mml:math>` or `<m:math>` but, if
+ * that is not available, uses an image as an alternative (which is wrapped
+ * in a paragraph for display formulas).
  */
 function decodeMath(
   formula: xml.Element
 ): (stencila.Math | stencila.ImageObject | stencila.Paragraph)[] {
   const inline = formula.name === 'inline-formula'
-  const mathml = first(formula, 'mml:math')
+  const mathml = first(formula, 'mml:math') || first(formula, 'm:math')
 
   if (mathml === null) {
     const graphic = first(formula, ['graphic', 'inline-graphic'])


### PR DESCRIPTION
As can be seen in #876 tools like Pandoc or LaTeXML produce MathML nodes with different namespaces.

LaTeXML's `m:math` is currently not read by `encoda`.

A simple fix is to also look for this namespace in the JATS decoder. I looked into doing the right thing and trying to read the namespace but this is probably a good enough solution if you want to include this.

According to the JATS tag browser `m` is common even though `mml` seems to be the official standard.

> MathML Namespacing: The vast majority of users of this Tag Set use the DTDs as their primary (or only) model, so this Tag Set is maintained to ensure that users of DTDs and DTD-based tools will work well. Because DTDs do not “play well” with namespaces, and most DTD-based tools are not namespace aware, the MathML namespace has been hardcoded to the prefix “mml” in the DTDs. This means that the element name, in the DTDs, really is <mml:math>. While this was the usual prefix when this Tag Set was originally established, the more frequently seen prefix is now “m”. Since XSD and RNG use “real” namespaces, this makes no difference to them, as to a namespace-aware processor a namespace prefix is only a placeholder. For DTD users, the element names in the MathML will need to be “mml” (for example, <mml:mfrac>), but tools can be set to provide that prefix and the essence of namespaces is that prefixes do not matter, so no harm is done.

https://jats.nlm.nih.gov/publishing/tag-library/1.2/element/mml-math.html

Happy to look into providing test cases or consider alternatives!