### PR TITLE
feat(JATS): Read ids of paragraphs

### DIFF
--- a/src/codecs/jats/__file_snapshots__/f1000-8-1394-v1.yaml
+++ b/src/codecs/jats/__file_snapshots__/f1000-8-1394-v1.yaml
@@ -1394,6 +1394,7 @@ content:
             conditions.
     description:
       - type: Paragraph
+        id: FN1
         content:
           - type: Superscript
             content:
@@ -2065,6 +2066,7 @@ content:
             extracts from the German market (2018–2019).
     description:
       - type: Paragraph
+        id: FN2
         content:
           - type: Superscript
             content:
@@ -2080,24 +2082,28 @@ content:
                   - '13'
           - ', table sheet 2).'
       - type: Paragraph
+        id: FN3
         content:
           - type: Superscript
             content:
               - '2'
           - ' Not analyzed or outside calibration.'
       - type: Paragraph
+        id: FN4
         content:
           - type: Superscript
             content:
               - '3'
           - ' No labelling provided by manufacturer.'
       - type: Paragraph
+        id: FN5
         content:
           - type: Superscript
             content:
               - '4'
           - ' THC (mg/day) calculated on the basis of 1 portion according to the manufacturer’s labelling. The LOAEL may be exceeded with a probable intake of 2 portions/day.'
       - type: Paragraph
+        id: FN6
         content:
           - type: Superscript
             content:

--- a/src/codecs/jats/index.ts
+++ b/src/codecs/jats/index.ts
@@ -1570,6 +1570,7 @@ function decodeParagraph(
 ): stencila.Node[] {
   const nodes = decodeElements(elem.elements ?? [], state)
   let para: stencila.Paragraph | undefined = stencila.paragraph({ content: [] })
+  para.id = attrOrUndefined(elem, 'id')
   const blocks: stencila.Node[] = []
   for (const node of nodes) {
     if (stencila.isInlineContent(node)) {


### PR DESCRIPTION
Here's a proposal to read ids from Paragraphs in JATS XML.

I've auto-updated the fixtures as well.

Turns
```xml
  <body>
    <p id="p1">Text<fn id="idm6"><p id="footnote1">Footy note.</p></fn></p>
  </body>
```

into

```json
  "content": [
    {
      "type": "Paragraph",
      "id": "p1",
      "content": [
        "Text"
      ]
    },
    {
      "type": "Paragraph",
      "id": "footnote1",
      "content": [
        "Footy note."
      ]
    }
  ]
```

(Adding support for footnotes <fn> would probably be a separate useful thing, but for me this would already help identifying footnotes and be useful in general i believe when reading JATS.)