### PR TITLE
feat(JATS): Read permissions element from figures

### DIFF
--- a/src/codecs/jats/__file_snapshots__/fig.jats.xml
+++ b/src/codecs/jats/__file_snapshots__/fig.jats.xml
@@ -77,6 +77,22 @@ http://dx.doi.org/10.1063/1.4762852.1</ext-link>
                 </caption>
                 <graphic xlink:href="" specific-use="print"/>
             </fig>
+            <p>Example 6</p>
+            <fig>
+                <label>Fig. 6</label>
+                <caption>
+                    <p>...</p>
+                </caption>
+                <graphic xlink:href=""/>
+            </fig>
+            <p>Example 7</p>
+            <fig>
+                <label>Figure 7.</label>
+                <caption>
+                    <p> . . . </p>
+                </caption>
+                <graphic xlink:href=""/>
+            </fig>
         </sec>
     </body>
     <back/>

--- a/src/codecs/jats/__file_snapshots__/fig.yaml
+++ b/src/codecs/jats/__file_snapshots__/fig.yaml
@@ -136,3 +136,40 @@ content:
         meta:
           inline: false
           usage: print
+  - type: Paragraph
+    content:
+      - Example 6
+  - type: Figure
+    id: fig6
+    caption:
+      - type: Paragraph
+        content:
+          - ...
+    label: Fig. 6
+    content:
+      - type: ImageObject
+        contentUrl: ''
+        meta:
+          inline: false
+  - type: Paragraph
+    content:
+      - Example 7
+  - type: Figure
+    id: fig7
+    caption:
+      - type: Paragraph
+        content:
+          - ' . . . '
+    label: Figure 7.
+    licenses:
+      - type: CreativeWork
+        url: http://creativecommons.org/licenses/by/4.0/
+        content:
+          - type: Paragraph
+            content:
+              - Figure 7 is distributed under ...
+    content:
+      - type: ImageObject
+        contentUrl: ''
+        meta:
+          inline: false

--- a/src/codecs/jats/__fixtures__/fig.xml
+++ b/src/codecs/jats/__fixtures__/fig.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 
 <!-- Examples taken from https://jats.nlm.nih.gov/publishing/tag-library/1.2/element/fig.html -->
+<!-- Permissions example adapted from https://jats4r.org/permissions -->
 
 <article>
   <front>
@@ -80,6 +81,33 @@ http://dx.doi.org/10.1063/1.4762852.1</ext-link>
         <graphic specific-use="print" xlink:href="1.4821168.figures.highres.f3.zip" />
         <graphic specific-use="online" xlink:href="1.4821168.figures.online.f3.jpg" />
       </alternatives>
+    </fig>
+
+    <p>Example 6</p>
+    <fig id="fig6">
+      <label>Fig. 6</label>
+      <caption>...</caption>
+      <permissions>
+      <copyright-statement>The National Portrait Gallery, London. All rights reserved</copyright-statement>
+      <copyright-year>2013</copyright-year>
+      <!-- Note: no license element here: all rights reserved. -->
+      </permissions>
+      <graphic xlink:href="images/fig1"/>
+    </fig>
+
+    <p>Example 7</p>
+    <fig id="fig7" position="float">
+      <label>Figure 7.</label>
+      <caption> . . . </caption>
+      <graphic xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="elife00013f002"/>
+      <permissions>
+      <copyright-statement>© 2012, Alegado et al</copyright-statement>
+      <copyright-year>2012</copyright-year>
+      <copyright-holder>Alegado et al</copyright-holder>
+      <license xlink:href="http://creativecommons.org/licenses/by/4.0/">
+      <license-p>Figure 7 is distributed under ...</license-p>
+      </license>
+      </permissions>
     </fig>
 
   </body>

--- a/src/codecs/jats/index.ts
+++ b/src/codecs/jats/index.ts
@@ -621,7 +621,7 @@ function decodeIsPartOf(front: xml.Element): stencila.Article['isPartOf'] {
 }
 
 /**
- * Decode a JATS `<permissions>` elements into a Stencila `.licenses` property,
+ * Decode a JATS `<permissions>` elements into a Stencila `licenses` property,
  * e.g. in the Article frontmatter or for a figure or media object.
  */
 function decodeLicenses(

--- a/src/codecs/jats/index.ts
+++ b/src/codecs/jats/index.ts
@@ -621,13 +621,14 @@ function decodeIsPartOf(front: xml.Element): stencila.Article['isPartOf'] {
 }
 
 /**
- * Decode a JATS `<permissions>` elements into a Stencila `Article.licenses` property.
+ * Decode a JATS `<permissions>` elements into a Stencila `.licenses` property,
+ * e.g. in the Article frontmatter or for a figure or media object.
  */
 function decodeLicenses(
-  front: xml.Element,
+  elem: xml.Element,
   state: DecodeState
 ): stencila.Article['licenses'] {
-  const permissions = first(front, 'permissions')
+  const permissions = first(elem, 'permissions')
   const licenses = all(permissions, 'license')
   if (licenses.length === 0) return undefined
 
@@ -2049,6 +2050,7 @@ function decodeFigure(
 
   const id = decodeInternalId(attr(elem, 'id'))
   const label = textOrUndefined(child(elem, 'label'))
+  const licenses = decodeLicenses(elem, state)
 
   // Get any `caption`
   const captionEl = child(elem, 'caption')
@@ -2064,16 +2066,21 @@ function decodeFigure(
     for (const item of elem.elements) {
       if (
         typeof item.name === 'string' &&
-        !['object-id', 'label', 'caption', 'abstract', 'kwd-group'].includes(
-          item.name
-        )
+        ![
+          'object-id',
+          'label',
+          'caption',
+          'abstract',
+          'kwd-group',
+          'permissions',
+        ].includes(item.name)
       ) {
         content.push(...decodeElement(item, state))
       }
     }
   }
 
-  return [stencila.figure({ id, label, caption, content })]
+  return [stencila.figure({ id, label, caption, content, licenses })]
 }
 
 /**


### PR DESCRIPTION
Here is an attempt at reading the permissions/license of a figure in JATS analogous to the main article license.

I'm not entirely sure how a figure with multiple images and diverging licenses should be handled:

> Contents of Permissions: The sub-elements of <permissions> are repeatable. If multiple values are applicable (such as multiple copyright years), they should be tagged separately rather than as multiple values within a single element. Repeated values do not describe the source of the material, they describe the current Intellectual Property for the article or object. 

https://jats.nlm.nih.gov/publishing/tag-library/1.2/element/permissions.html

On https://jats4r.org/permissions there are examples with repeated `<permissions>` elements:

I would think however that it's better in such a case to attach the different licenses the individual `<graphic>` elements.

Handling multiple `<permissions>` could probably be added to `encoda` but handling only one license doesn't require much code changes :slightly_smiling_face: 
(I tried for a bit but not sure if it's worth adding.)