### PR TITLE
fix(JATS): Don't duplicate footnote content in abstract

### DIFF
--- a/src/codecs/jats/__fixtures__/footnote.xml
+++ b/src/codecs/jats/__fixtures__/footnote.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0"?>
 <article>
+<front>
+<abstract>
+<p>The abstract can contain a footnote.<fn id="note-1"><p id="footnote1">A footnote from the abstract.</p></fn></p>
+</abstract>
+</front>
 <body>
-<p>Further<fn id="note-1"><p id="Ch0.note-1">An <bold>important</bold> footnote.</p></fn> thoughts below.</p>
+<p>Further<fn id="note-2"><p id="footnote2">An <bold>important</bold> footnote.</p></fn> thoughts below.</p>
 </body>
 </article>

--- a/src/codecs/jats/index.ts
+++ b/src/codecs/jats/index.ts
@@ -509,7 +509,7 @@ function decodeAbstract(
   state: DecodeState
 ): stencila.Article['description'] {
   if (elem === null) return undefined
-  const ps = all(elem, 'p')
+  const ps = children(elem, 'p')
   if (ps.length === 0) return undefined
   if (ps.length === 1) {
     const content = decodeInlineContent(ps, state)


### PR DESCRIPTION
Previously all `<p>`s in an abstract would be rendered. With footnotes
a paragraph can appear nested "inside" of a paragraph.

Before:
```json
{
  "type": "Article",
  "description": [
    {
      "type": "Paragraph",
      "content": [
        "The abstract can contain a footnote.",
        {
          "type": "Note",
          "id": "note-1",
          "noteType": "Footnote",
          "content": [
            {
              "type": "Paragraph",
              "id": "footnote1",
              "content": [
                "A footnote from the abstract."
              ]
            }
          ]
        }
      ]
    },
    {
      "type": "Paragraph",
      "id": "footnote1",
      "content": [
        "A footnote from the abstract."
      ]
    }
  ],
```

With using `children` instead of `all`:
```json
  "type": "Article",
  "description": [
    "The abstract can contain a footnote.",
    {
      "type": "Note",
      "id": "note-1",
      "noteType": "Footnote",
      "content": [
        {
          "type": "Paragraph",
          "id": "footnote1",
          "content": [
            "A footnote from the abstract."
          ]
        }
      ]
    }
  ],
```

I tried updating the fixtures, but couldn't get it to work, even with `--clearCache`.