### PR TITLE
feat(JATS): Add label field to MathBlocks

### DIFF
--- a/src/codecs/jats/__file_snapshots__/elife-52882-v2.yaml
+++ b/src/codecs/jats/__file_snapshots__/elife-52882-v2.yaml
@@ -5884,6 +5884,7 @@ content:
       - ' in the form:'
   - type: MathBlock
     id: equ1
+    label: (1)
     mathLanguage: mathml
     text: >-
       <mml:math

--- a/src/codecs/jats/__fixtures__/equation.jats.xml
+++ b/src/codecs/jats/__fixtures__/equation.jats.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<article>
+    <front>
+        <article-meta>
+            <contrib-group />
+        </article-meta>
+    </front>
+    <body>
+        <p id="p1">A formula which can be referenced and has a label.</p>
+        <p>
+            <disp-formula id="S0.Ex1">
+                <label>Special-Label</label>
+                <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="a=b" display="block">
+                    <mml:mrow>
+                        <mml:mi>a</mml:mi>
+                        <mml:mo>=</mml:mo>
+                        <mml:mi>b</mml:mi>
+                    </mml:mrow>
+                </mml:math>
+            </disp-formula>
+        </p>
+        <p id="p2">
+            See equation (
+            <xref rid="S0.Ex1">Special-Label</xref>
+            ).
+        </p>
+    </body>
+    <back>
+        <app-group />
+    </back>
+</article>

--- a/src/codecs/jats/index.ts
+++ b/src/codecs/jats/index.ts
@@ -2163,7 +2163,7 @@ function decodeMath(
   }
 
   const id = attrOrUndefined(formula, 'id')
-
+  const label = textOrUndefined(child(formula, 'label'))
   const altText = attrOrUndefined(mathml, 'alttext')
   const meta = altText !== undefined ? { altText } : undefined
 
@@ -2172,6 +2172,7 @@ function decodeMath(
   return [
     (inline ? stencila.mathFragment : stencila.mathBlock)({
       id,
+      label,
       meta,
       mathLanguage: 'mathml',
       text,


### PR DESCRIPTION
This adds extracting the label field from a `disp-formula`.

https://jats.nlm.nih.gov/publishing/tag-library/1.2/element/label.html

Example:
```xml
<disp-formula id="S0.Ex1">
    <label>Special-Label</label>
    <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" alttext="a=b" display="block">
        <mml:mrow>
            <mml:mi>a</mml:mi>
            <mml:mo>=</mml:mo>
            <mml:mi>b</mml:mi>
        </mml:mrow>
    </mml:math>
</disp-formula>
```

To 
```json
{
  "type": "MathBlock",
  "id": "S0.Ex9",
  "label": "Special-Label",
  "mathLanguage": "mathml",
  "text": "<mml:math xmlns:mml=\"http://www.w3.org/1998/Math/MathML\" alttext=\"a=b\" display=\"block\"><mml:mrow><mml:mi>a</mml:mi><mml:mo>=</mml:mo><mml:mi>b</mml:mi></mml:mrow></mml:math>",
  "meta": {
    "altText": "a=b"
  }
}
```