### PR TITLE
package.json, bumps remark-parse to 9.0+ to fix CVE-2020-7753 

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "remark-frontmatter": "^2.0.0",
     "remark-generic-extensions": "^1.4.0",
     "remark-math": "^3.0.1",
-    "remark-parse": "^8.0.3",
+    "remark-parse": "^9.0.0",
     "remark-stringify": "^8.1.1",
     "remark-sub-super": "^1.0.20",
     "sentence-case": "^3.0.4",


### PR DESCRIPTION
package.json, bumps remark-parse to 9.0+ to fix CVE-2020-7753 in `trim` transitive dependency.
